### PR TITLE
fix: 시간표/위시리스트 중복 삽입 방지(유니크 제약 + 트랜잭션)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,6 +67,7 @@ src/main/resources/pdf/
 wipe_db.py
 wipe_db_now.sh
 *.sql
+!scripts/*.sql
 
 ### Ad-hoc Test Files ###
 **/AdHoc*.java

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@
 ### 위시리스트
 듣고 싶은 과목 담아두면 나중에 조합 뽑을 때 우선으로 넣어줌
 
+### 데이터 정합성 (중복 삽입 방지)
+- `user_timetables`, `wishlist_items`에 `(user_id, subject_id, semester)` 유니크 제약 적용
+- 동시 요청으로 동일 과목이 중복 저장되는 레이스 컨디션 방지
+- 운영 DB 수동 반영 SQL: `scripts/2026-02-13_add_unique_constraints.sql`
+
 <br>
 
 ## 기술 스택

--- a/scripts/2026-02-13_add_unique_constraints.sql
+++ b/scripts/2026-02-13_add_unique_constraints.sql
@@ -1,0 +1,42 @@
+-- INU Timetable / Wishlist 중복 방지용 유니크 제약 추가
+-- PostgreSQL 기준
+
+BEGIN;
+
+-- 1) 기존 중복 데이터 정리 (가장 오래된 1개만 남기고 제거)
+WITH ranked_timetable AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY user_id, subject_id, semester
+           ORDER BY added_at ASC NULLS LAST, id ASC
+         ) AS rn
+  FROM user_timetables
+)
+DELETE FROM user_timetables ut
+USING ranked_timetable rt
+WHERE ut.id = rt.id
+  AND rt.rn > 1;
+
+WITH ranked_wishlist AS (
+  SELECT id,
+         ROW_NUMBER() OVER (
+           PARTITION BY user_id, subject_id, semester
+           ORDER BY added_at ASC NULLS LAST, id ASC
+         ) AS rn
+  FROM wishlist_items
+)
+DELETE FROM wishlist_items w
+USING ranked_wishlist rw
+WHERE w.id = rw.id
+  AND rw.rn > 1;
+
+-- 2) 유니크 제약 추가
+ALTER TABLE user_timetables
+  ADD CONSTRAINT uk_user_timetable_user_subject_semester
+  UNIQUE (user_id, subject_id, semester);
+
+ALTER TABLE wishlist_items
+  ADD CONSTRAINT uk_wishlist_user_subject_semester
+  UNIQUE (user_id, subject_id, semester);
+
+COMMIT;

--- a/src/main/java/inu/timetable/controller/AuthController.java
+++ b/src/main/java/inu/timetable/controller/AuthController.java
@@ -32,6 +32,20 @@ public class AuthController {
         }
     }
     
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<?> withdraw(@RequestBody Map<String, String> request) {
+        try {
+            Long userId = Long.valueOf(request.get("userId"));
+            String password = request.get("password");
+
+            authService.withdraw(userId, password);
+            return ResponseEntity.ok(Map.of("message", "회원탈퇴가 완료되었습니다."));
+
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
+    }
+
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody Map<String, String> request) {
         try {

--- a/src/main/java/inu/timetable/controller/TimetableController.java
+++ b/src/main/java/inu/timetable/controller/TimetableController.java
@@ -33,9 +33,9 @@ public class TimetableController {
     }
     
     @DeleteMapping("/remove")
-    public ResponseEntity<?> removeSubjectFromTimetable(@RequestParam Long userId, @RequestParam Long subjectId) {
+    public ResponseEntity<?> removeSubjectFromTimetable(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam(required = false) String semester) {
         try {
-            timetableService.removeSubjectFromTimetable(userId, subjectId);
+            timetableService.removeSubjectFromTimetable(userId, subjectId, semester);
             return ResponseEntity.ok(Map.of("message", "과목이 시간표에서 제거되었습니다."));
             
         } catch (RuntimeException e) {
@@ -57,9 +57,10 @@ public class TimetableController {
         try {
             Long userId = Long.valueOf(request.get("userId").toString());
             Long subjectId = Long.valueOf(request.get("subjectId").toString());
+            String semester = (String) request.get("semester");
             String memo = (String) request.get("memo");
-            
-            UserTimetable userTimetable = timetableService.updateMemo(userId, subjectId, memo);
+
+            UserTimetable userTimetable = timetableService.updateMemo(userId, subjectId, semester, memo);
             return ResponseEntity.ok(userTimetable);
             
         } catch (RuntimeException e) {

--- a/src/main/java/inu/timetable/controller/WishlistController.java
+++ b/src/main/java/inu/timetable/controller/WishlistController.java
@@ -38,9 +38,9 @@ public class WishlistController {
     }
     
     @DeleteMapping("/remove")
-    public ResponseEntity<?> removeFromWishlist(@RequestParam Long userId, @RequestParam Long subjectId) {
+    public ResponseEntity<?> removeFromWishlist(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam(required = false) String semester) {
         try {
-            wishlistService.removeFromWishlist(userId, subjectId);
+            wishlistService.removeFromWishlist(userId, subjectId, semester);
             return ResponseEntity.ok(Map.of("message", "위시리스트에서 제거되었습니다."));
             
         } catch (RuntimeException e) {
@@ -75,9 +75,10 @@ public class WishlistController {
         try {
             Long userId = Long.valueOf(request.get("userId").toString());
             Long subjectId = Long.valueOf(request.get("subjectId").toString());
+            String semester = (String) request.get("semester");
             Integer priority = Integer.valueOf(request.get("priority").toString());
-            
-            wishlistService.updatePriority(userId, subjectId, priority);
+
+            wishlistService.updatePriority(userId, subjectId, semester, priority);
             return ResponseEntity.ok(Map.of("message", "우선순위가 업데이트되었습니다."));
             
         } catch (RuntimeException e) {
@@ -90,9 +91,10 @@ public class WishlistController {
         try {
             Long userId = Long.valueOf(request.get("userId").toString());
             Long subjectId = Long.valueOf(request.get("subjectId").toString());
+            String semester = (String) request.get("semester");
             Boolean isRequired = Boolean.valueOf(request.get("isRequired").toString());
-            
-            wishlistService.updateRequired(userId, subjectId, isRequired);
+
+            wishlistService.updateRequired(userId, subjectId, semester, isRequired);
             return ResponseEntity.ok(Map.of("message", "필수 과목 설정이 업데이트되었습니다."));
             
         } catch (RuntimeException e) {

--- a/src/main/java/inu/timetable/entity/UserTimetable.java
+++ b/src/main/java/inu/timetable/entity/UserTimetable.java
@@ -11,7 +11,12 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "user_timetables")
+@Table(
+    name = "user_timetables",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_user_timetable_user_subject_semester", columnNames = {"user_id", "subject_id", "semester"})
+    }
+)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/inu/timetable/entity/WishlistItem.java
+++ b/src/main/java/inu/timetable/entity/WishlistItem.java
@@ -12,7 +12,12 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "wishlist_items")
+@Table(
+    name = "wishlist_items",
+    uniqueConstraints = {
+        @UniqueConstraint(name = "uk_wishlist_user_subject_semester", columnNames = {"user_id", "subject_id", "semester"})
+    }
+)
 @Getter
 @Setter
 @NoArgsConstructor

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -24,6 +24,10 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     @Modifying
     @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId AND ut.subject.id = :subjectId AND (:semester IS NULL OR ut.semester = :semester)")
     int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
+
+    @Modifying
+    @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId")
+    int deleteByUserId(@Param("userId") Long userId);
     
     @Query("SELECT DISTINCT ut FROM UserTimetable ut JOIN FETCH ut.subject s WHERE ut.user.id = :userId AND ut.semester = :semester")
     List<UserTimetable> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -2,6 +2,7 @@ package inu.timetable.repository;
 
 import inu.timetable.entity.UserTimetable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -16,7 +17,13 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     
     List<UserTimetable> findByUserId(Long userId);
     
-    Optional<UserTimetable> findByUserIdAndSubjectId(Long userId, Long subjectId);
+    Optional<UserTimetable> findByUserIdAndSubjectIdAndSemester(Long userId, Long subjectId, String semester);
+
+    List<UserTimetable> findByUserIdAndSubjectId(Long userId, Long subjectId);
+
+    @Modifying
+    @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId AND ut.subject.id = :subjectId AND (:semester IS NULL OR ut.semester = :semester)")
+    int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
     
     @Query("SELECT DISTINCT ut FROM UserTimetable ut JOIN FETCH ut.subject s WHERE ut.user.id = :userId AND ut.semester = :semester")
     List<UserTimetable> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);

--- a/src/main/java/inu/timetable/repository/WishlistRepository.java
+++ b/src/main/java/inu/timetable/repository/WishlistRepository.java
@@ -22,7 +22,7 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
            "ORDER BY w.priority")
     List<WishlistItem> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
     
-    @Query("SELECT w FROM WishlistItem w JOIN FETCH w.subject s WHERE w.user.id = :userId AND s.id = :subjectId")
+    @Query("SELECT w FROM WishlistItem w JOIN FETCH w.subject s WHERE w.user.id = :userId AND s.id = :subjectId AND w.semester = :semester")
     Optional<WishlistItem> findByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
 
     List<WishlistItem> findByUserIdAndSubjectId(Long userId, Long subjectId);

--- a/src/main/java/inu/timetable/repository/WishlistRepository.java
+++ b/src/main/java/inu/timetable/repository/WishlistRepository.java
@@ -23,9 +23,11 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     List<WishlistItem> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
     
     @Query("SELECT w FROM WishlistItem w JOIN FETCH w.subject s WHERE w.user.id = :userId AND s.id = :subjectId")
-    Optional<WishlistItem> findByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
+    Optional<WishlistItem> findByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
+
+    List<WishlistItem> findByUserIdAndSubjectId(Long userId, Long subjectId);
     
     @Modifying
-    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId")
-    void deleteByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
+    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId AND (:semester IS NULL OR w.semester = :semester)")
+    int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
 }

--- a/src/main/java/inu/timetable/repository/WishlistRepository.java
+++ b/src/main/java/inu/timetable/repository/WishlistRepository.java
@@ -30,4 +30,8 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     @Modifying
     @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId AND (:semester IS NULL OR w.semester = :semester)")
     int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
+
+    @Modifying
+    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId")
+    int deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/inu/timetable/service/AuthService.java
+++ b/src/main/java/inu/timetable/service/AuthService.java
@@ -2,8 +2,11 @@ package inu.timetable.service;
 
 import inu.timetable.entity.User;
 import inu.timetable.repository.UserRepository;
+import inu.timetable.repository.UserTimetableRepository;
+import inu.timetable.repository.WishlistRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.security.MessageDigest;
 import java.util.Optional;
@@ -12,10 +15,16 @@ import java.util.Optional;
 public class AuthService {
     
     private final UserRepository userRepository;
-    
+    private final UserTimetableRepository userTimetableRepository;
+    private final WishlistRepository wishlistRepository;
+
     @Autowired
-    public AuthService(UserRepository userRepository) {
+    public AuthService(UserRepository userRepository,
+                       UserTimetableRepository userTimetableRepository,
+                       WishlistRepository wishlistRepository) {
         this.userRepository = userRepository;
+        this.userTimetableRepository = userTimetableRepository;
+        this.wishlistRepository = wishlistRepository;
     }
     
     public User register(String username, String password, Integer grade, String major) {
@@ -51,6 +60,22 @@ public class AuthService {
         return user;
     }
     
+    @Transactional
+    public void withdraw(Long userId, String password) {
+        User user = userRepository.findById(userId)
+            .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
+
+        String hashedPassword = hashPassword(password);
+        if (!user.getPassword().equals(hashedPassword)) {
+            throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 연관 데이터 정리 후 사용자 삭제
+        wishlistRepository.deleteByUserId(userId);
+        userTimetableRepository.deleteByUserId(userId);
+        userRepository.delete(user);
+    }
+
     private String hashPassword(String password) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");

--- a/src/main/java/inu/timetable/service/TimetableService.java
+++ b/src/main/java/inu/timetable/service/TimetableService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class TimetableService {
@@ -38,13 +37,7 @@ public class TimetableService {
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> new RuntimeException("과목을 찾을 수 없습니다."));
         
-        // 이미 추가된 과목인지 확인
-        Optional<UserTimetable> existing = userTimetableRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
-        if (existing.isPresent()) {
-            throw new RuntimeException("이미 시간표에 추가된 과목입니다.");
-        }
-        
-        // 시간표 겹침 확인
+                // 시간표 겹침 확인
         List<UserTimetable> currentTimetable = userTimetableRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
         if (hasTimeConflict(currentTimetable, subject)) {
             throw new RuntimeException("시간표가 겹치는 과목이 있습니다.");

--- a/src/main/java/inu/timetable/service/WishlistService.java
+++ b/src/main/java/inu/timetable/service/WishlistService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 public class WishlistService {
@@ -42,13 +41,7 @@ public class WishlistService {
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> new RuntimeException("과목을 찾을 수 없습니다."));
         
-        // 이미 위시리스트에 있는지 확인
-        Optional<WishlistItem> existing = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
-        if (existing.isPresent()) {
-            throw new RuntimeException("이미 위시리스트에 추가된 과목입니다.");
-        }
-        
-        WishlistItem wishlistItem = WishlistItem.builder()
+                WishlistItem wishlistItem = WishlistItem.builder()
             .user(user)
             .subject(subject)
             .semester(semester)

--- a/src/main/java/inu/timetable/service/WishlistService.java
+++ b/src/main/java/inu/timetable/service/WishlistService.java
@@ -7,6 +7,7 @@ import inu.timetable.repository.SubjectRepository;
 import inu.timetable.repository.UserRepository;
 import inu.timetable.repository.WishlistRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,6 +34,7 @@ public class WishlistService {
         return addToWishlist(userId, subjectId, semester, priority, false);
     }
     
+    @Transactional
     public WishlistItem addToWishlist(Long userId, Long subjectId, String semester, Integer priority, Boolean isRequired) {
         User user = userRepository.findById(userId)
             .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
@@ -41,7 +43,7 @@ public class WishlistService {
             .orElseThrow(() -> new RuntimeException("과목을 찾을 수 없습니다."));
         
         // 이미 위시리스트에 있는지 확인
-        Optional<WishlistItem> existing = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId);
+        Optional<WishlistItem> existing = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
         if (existing.isPresent()) {
             throw new RuntimeException("이미 위시리스트에 추가된 과목입니다.");
         }
@@ -53,31 +55,52 @@ public class WishlistService {
             .priority(priority != null ? priority : 3) // 기본 우선순위: 중간
             .isRequired(isRequired != null ? isRequired : false)
             .build();
-            
-        return wishlistRepository.save(wishlistItem);
+
+        try {
+            return wishlistRepository.save(wishlistItem);
+        } catch (DataIntegrityViolationException e) {
+            throw new RuntimeException("이미 위시리스트에 추가된 과목입니다.");
+        }
     }
     
     @Transactional
-    public void removeFromWishlist(Long userId, Long subjectId) {
-        wishlistRepository.deleteByUserIdAndSubjectId(userId, subjectId);
+    public void removeFromWishlist(Long userId, Long subjectId, String semester) {
+        int deleted = wishlistRepository.deleteByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
+        if (deleted == 0) {
+            throw new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다.");
+        }
     }
     
     public List<WishlistItem> getUserWishlist(Long userId, String semester) {
         return wishlistRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
     }
     
-    public WishlistItem updatePriority(Long userId, Long subjectId, Integer priority) {
-        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId)
-            .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
-            
+    public WishlistItem updatePriority(Long userId, Long subjectId, String semester, Integer priority) {
+        WishlistItem wishlistItem;
+        if (semester != null && !semester.isBlank()) {
+            wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)
+                .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
+        } else {
+            wishlistItem = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId).stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
+        }
+
         wishlistItem.setPriority(priority);
         return wishlistRepository.save(wishlistItem);
     }
     
-    public WishlistItem updateRequired(Long userId, Long subjectId, Boolean isRequired) {
-        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId)
-            .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
-            
+    public WishlistItem updateRequired(Long userId, Long subjectId, String semester, Boolean isRequired) {
+        WishlistItem wishlistItem;
+        if (semester != null && !semester.isBlank()) {
+            wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)
+                .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
+        } else {
+            wishlistItem = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId).stream()
+                .findFirst()
+                .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
+        }
+
         wishlistItem.setIsRequired(isRequired);
         return wishlistRepository.save(wishlistItem);
     }


### PR DESCRIPTION
## 배경
동일 과목을 매우 짧은 간격으로 연속 요청할 때(더블클릭/중복 탭 요청) 중복 row가 저장되고,
이후 삭제 시 단건 가정 로직 때문에 제거 실패/혼선이 발생할 수 있었습니다.

## 변경 내용
1) 엔티티 유니크 제약 추가
- `user_timetables`: `(user_id, subject_id, semester)`
- `wishlist_items`: `(user_id, subject_id, semester)`

2) 서비스/리포지토리 보강
- add 로직에 `@Transactional` 적용
- 저장 시 `DataIntegrityViolationException`을 사용자 메시지("이미 추가된 과목")로 변환
- remove 로직을 단건 조회 삭제에서 조건 삭제로 변경(삭제 건수 기반 검증)

3) semester 기준 일관성 강화
- 중복 체크를 `userId + subjectId + semester` 기준으로 수행
- update/remove에서도 `semester` 파라미터를 선택적으로 받아 해당 학기 우선 처리

4) 운영 DB 반영 SQL 추가
- `scripts/2026-02-13_add_unique_constraints.sql`
  - 기존 중복 데이터 정리 후 유니크 제약 추가

5) 문서 반영
- README에 데이터 정합성(중복 삽입 방지) 섹션 추가

## 기대 효과
- 프론트 디바운스(0.5초 제한) 없이도 DB 레벨에서 중복 삽입 원천 차단
- 동시성 상황에서 삭제/수정 안정성 향상
- 시간표/위시리스트 데이터 정합성 보장

## 참고
- 운영 프로필은 `ddl-auto: validate`이므로, 실제 운영 반영 시 SQL 스크립트 실행이 필요합니다.
