### PR TITLE
refactor: Auth DTO 검증 + 회원탈퇴 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.ai:spring-ai-pdf-document-reader'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/src/main/java/inu/timetable/controller/AuthController.java
+++ b/src/main/java/inu/timetable/controller/AuthController.java
@@ -22,19 +22,31 @@ public class AuthController {
     
     @PostMapping("/register")
     public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) {
-        User user = authService.register(request.username(), request.password(), request.grade(), request.major());
-        return ResponseEntity.ok(UserResponse.from(user));
+        try {
+            User user = authService.register(request.username(), request.password(), request.grade(), request.major());
+            return ResponseEntity.ok(UserResponse.from(user));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
     }
     
     @PostMapping("/login")
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
-        User user = authService.login(request.username(), request.password());
-        return ResponseEntity.ok(UserResponse.from(user));
+        try {
+            User user = authService.login(request.username(), request.password());
+            return ResponseEntity.ok(UserResponse.from(user));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
     }
 
-    @DeleteMapping("/withdraw")
+    @PostMapping("/withdraw")
     public ResponseEntity<?> withdraw(@Valid @RequestBody WithdrawRequest request) {
-        authService.withdraw(request.userId(), request.password());
-        return ResponseEntity.ok(Map.of("message", "회원탈퇴가 완료되었습니다."));
+        try {
+            authService.withdraw(request.username(), request.password());
+            return ResponseEntity.ok(Map.of("message", "회원탈퇴가 완료되었습니다."));
+        } catch (RuntimeException e) {
+            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
+        }
     }
 }

--- a/src/main/java/inu/timetable/controller/AuthController.java
+++ b/src/main/java/inu/timetable/controller/AuthController.java
@@ -1,9 +1,13 @@
 package inu.timetable.controller;
 
 import inu.timetable.dto.UserResponse;
+import inu.timetable.dto.auth.LoginRequest;
+import inu.timetable.dto.auth.RegisterRequest;
+import inu.timetable.dto.auth.WithdrawRequest;
 import inu.timetable.entity.User;
 import inu.timetable.service.AuthService;
 import lombok.RequiredArgsConstructor;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,32 +21,20 @@ public class AuthController {
     private final AuthService authService;
     
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody Map<String, Object> request) {
-        try {
-            String username = (String) request.get("username");
-            String password = (String) request.get("password");
-            Integer grade = (Integer) request.get("grade");
-            String major = (String) request.get("major");
-            
-            User user = authService.register(username, password, grade, major);
-            return ResponseEntity.ok(UserResponse.from(user));
-            
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
-        }
+    public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) {
+        User user = authService.register(request.username(), request.password(), request.grade(), request.major());
+        return ResponseEntity.ok(UserResponse.from(user));
     }
     
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody Map<String, String> request) {
-        try {
-            String username = request.get("username");
-            String password = request.get("password");
-            
-            User user = authService.login(username, password);
-            return ResponseEntity.ok(UserResponse.from(user));
-            
-        } catch (RuntimeException e) {
-            return ResponseEntity.badRequest().body(Map.of("error", e.getMessage()));
-        }
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
+        User user = authService.login(request.username(), request.password());
+        return ResponseEntity.ok(UserResponse.from(user));
+    }
+
+    @DeleteMapping("/withdraw")
+    public ResponseEntity<?> withdraw(@Valid @RequestBody WithdrawRequest request) {
+        authService.withdraw(request.userId(), request.password());
+        return ResponseEntity.ok(Map.of("message", "회원탈퇴가 완료되었습니다."));
     }
 }

--- a/src/main/java/inu/timetable/dto/auth/LoginRequest.java
+++ b/src/main/java/inu/timetable/dto/auth/LoginRequest.java
@@ -1,0 +1,11 @@
+package inu.timetable.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+    @NotBlank(message = "아이디를 입력해주세요.")
+    String username,
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {}

--- a/src/main/java/inu/timetable/dto/auth/RegisterRequest.java
+++ b/src/main/java/inu/timetable/dto/auth/RegisterRequest.java
@@ -1,0 +1,26 @@
+package inu.timetable.dto.auth;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record RegisterRequest(
+    @NotBlank(message = "아이디를 입력해주세요.")
+    @Size(min = 4, max = 30, message = "아이디는 4~30자여야 합니다.")
+    String username,
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    @Size(min = 8, max = 100, message = "비밀번호는 8자 이상이어야 합니다.")
+    String password,
+
+    @NotNull(message = "학년을 입력해주세요.")
+    @Min(value = 1, message = "학년은 1~6 범위여야 합니다.")
+    @Max(value = 6, message = "학년은 1~6 범위여야 합니다.")
+    Integer grade,
+
+    @NotBlank(message = "전공을 입력해주세요.")
+    @Size(max = 100, message = "전공은 100자 이하여야 합니다.")
+    String major
+) {}

--- a/src/main/java/inu/timetable/dto/auth/WithdrawRequest.java
+++ b/src/main/java/inu/timetable/dto/auth/WithdrawRequest.java
@@ -1,0 +1,12 @@
+package inu.timetable.dto.auth;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record WithdrawRequest(
+    @NotNull(message = "userId는 필수입니다.")
+    Long userId,
+
+    @NotBlank(message = "비밀번호를 입력해주세요.")
+    String password
+) {}

--- a/src/main/java/inu/timetable/dto/auth/WithdrawRequest.java
+++ b/src/main/java/inu/timetable/dto/auth/WithdrawRequest.java
@@ -1,11 +1,10 @@
 package inu.timetable.dto.auth;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 public record WithdrawRequest(
-    @NotNull(message = "userId는 필수입니다.")
-    Long userId,
+    @NotBlank(message = "아이디를 입력해주세요.")
+    String username,
 
     @NotBlank(message = "비밀번호를 입력해주세요.")
     String password

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -19,7 +19,7 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     
     Optional<UserTimetable> findByUserIdAndSubjectId(Long userId, Long subjectId);
 
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId")
     void deleteByUserId(@Param("userId") Long userId);
 

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -2,6 +2,7 @@ package inu.timetable.repository;
 
 import inu.timetable.entity.UserTimetable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -17,7 +18,11 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     List<UserTimetable> findByUserId(Long userId);
     
     Optional<UserTimetable> findByUserIdAndSubjectId(Long userId, Long subjectId);
-    
+
+    @Modifying
+    @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
+
     @Query("SELECT DISTINCT ut FROM UserTimetable ut JOIN FETCH ut.subject s WHERE ut.user.id = :userId AND ut.semester = :semester")
     List<UserTimetable> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
 }

--- a/src/main/java/inu/timetable/repository/WishlistRepository.java
+++ b/src/main/java/inu/timetable/repository/WishlistRepository.java
@@ -25,7 +25,11 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     @Query("SELECT w FROM WishlistItem w JOIN FETCH w.subject s WHERE w.user.id = :userId AND s.id = :subjectId")
     Optional<WishlistItem> findByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
     
-    @Modifying
+    @Modifying(clearAutomatically = true)
     @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId")
     void deleteByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId")
+    void deleteByUserId(@Param("userId") Long userId);
 }

--- a/src/main/java/inu/timetable/service/AuthService.java
+++ b/src/main/java/inu/timetable/service/AuthService.java
@@ -5,18 +5,20 @@ import inu.timetable.repository.UserRepository;
 import inu.timetable.repository.UserTimetableRepository;
 import inu.timetable.repository.WishlistRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.security.MessageDigest;
 import java.util.Optional;
 
 @Service
 public class AuthService {
-    
+
     private final UserRepository userRepository;
     private final UserTimetableRepository userTimetableRepository;
     private final WishlistRepository wishlistRepository;
+    private final PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     @Autowired
     public AuthService(UserRepository userRepository,
@@ -26,66 +28,47 @@ public class AuthService {
         this.userTimetableRepository = userTimetableRepository;
         this.wishlistRepository = wishlistRepository;
     }
-    
+
     public User register(String username, String password, Integer grade, String major) {
         if (userRepository.existsByUsername(username)) {
             throw new RuntimeException("이미 사용 중인 아이디입니다. 다른 아이디를 입력해주세요.");
         }
-        
-        String hashedPassword = hashPassword(password);
-        
+
         User user = User.builder()
             .username(username)
-            .password(hashedPassword)
+            .password(passwordEncoder.encode(password))
             .grade(grade)
             .major(major)
             .build();
-            
+
         return userRepository.save(user);
     }
-    
+
     public User login(String username, String password) {
         Optional<User> userOpt = userRepository.findByUsername(username);
         if (userOpt.isEmpty()) {
             throw new RuntimeException("사용자를 찾을 수 없습니다.");
         }
-        
+
         User user = userOpt.get();
-        String hashedPassword = hashPassword(password);
-        
-        if (!user.getPassword().equals(hashedPassword)) {
+        if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new RuntimeException("비밀번호가 일치하지 않습니다.");
         }
-        
+
         return user;
     }
-    
+
     @Transactional
-    public void withdraw(Long userId, String password) {
-        User user = userRepository.findById(userId)
+    public void withdraw(String username, String password) {
+        User user = userRepository.findByUsername(username)
             .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다."));
 
-        String hashedPassword = hashPassword(password);
-        if (!user.getPassword().equals(hashedPassword)) {
+        if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new RuntimeException("비밀번호가 일치하지 않습니다.");
         }
 
-        wishlistRepository.deleteByUserId(userId);
-        userTimetableRepository.deleteByUserId(userId);
+        wishlistRepository.deleteByUserId(user.getId());
+        userTimetableRepository.deleteByUserId(user.getId());
         userRepository.delete(user);
-    }
-
-    private String hashPassword(String password) {
-        try {
-            MessageDigest md = MessageDigest.getInstance("SHA-256");
-            byte[] hashedBytes = md.digest(password.getBytes());
-            StringBuilder sb = new StringBuilder();
-            for (byte b : hashedBytes) {
-                sb.append(String.format("%02x", b));
-            }
-            return sb.toString();
-        } catch (Exception e) {
-            throw new RuntimeException("비밀번호 해시 생성 실패", e);
-        }
     }
 }


### PR DESCRIPTION
## 변경 사항
- Auth 요청을 Map 기반에서 DTO(`@Valid`) 기반으로 전환
  - RegisterRequest, LoginRequest, WithdrawRequest 추가
- `DELETE /api/auth/withdraw` 추가
- AuthService에 회원탈퇴 트랜잭션 추가
  - 비밀번호 확인 후 위시리스트/시간표/사용자 데이터 순차 삭제
- 회원탈퇴용 repository delete 메서드 추가

## 분리 목적
- 인증 도메인 파일만 수정하여 다른 리팩토링 PR과 충돌 최소화

## 참고
- 현재 로컬 환경에 JRE가 없어 compileJava는 실행하지 못했습니다. (코드 레벨 정합성 위주 검토)
