### PR TITLE
refactor: semester 기반 시간표/위시리스트 조작 정합성 강화

### DIFF
--- a/src/main/java/inu/timetable/controller/TimetableController.java
+++ b/src/main/java/inu/timetable/controller/TimetableController.java
@@ -33,7 +33,7 @@ public class TimetableController {
     }
     
     @DeleteMapping("/remove")
-    public ResponseEntity<?> removeSubjectFromTimetable(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam(required = false) String semester) {
+    public ResponseEntity<?> removeSubjectFromTimetable(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam String semester) {
         try {
             timetableService.removeSubjectFromTimetable(userId, subjectId, semester);
             return ResponseEntity.ok(Map.of("message", "과목이 시간표에서 제거되었습니다."));
@@ -46,7 +46,7 @@ public class TimetableController {
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<UserTimetable>> getUserTimetable(
             @PathVariable Long userId,
-            @RequestParam(required = false) String semester) {
+            @RequestParam String semester) {
         
         List<UserTimetable> timetable = timetableService.getUserTimetable(userId, semester);
         return ResponseEntity.ok(timetable);
@@ -69,7 +69,7 @@ public class TimetableController {
     }
     
     @DeleteMapping("/clear")
-    public ResponseEntity<?> clearTimetable(@RequestParam Long userId, @RequestParam(required = false) String semester) {
+    public ResponseEntity<?> clearTimetable(@RequestParam Long userId, @RequestParam String semester) {
         try {
             timetableService.removeAllSubjectsFromTimetable(userId, semester);
             String message = semester != null && !semester.isEmpty() 

--- a/src/main/java/inu/timetable/controller/TimetableController.java
+++ b/src/main/java/inu/timetable/controller/TimetableController.java
@@ -33,9 +33,9 @@ public class TimetableController {
     }
     
     @DeleteMapping("/remove")
-    public ResponseEntity<?> removeSubjectFromTimetable(@RequestParam Long userId, @RequestParam Long subjectId) {
+    public ResponseEntity<?> removeSubjectFromTimetable(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam(required = false) String semester) {
         try {
-            timetableService.removeSubjectFromTimetable(userId, subjectId);
+            timetableService.removeSubjectFromTimetable(userId, subjectId, semester);
             return ResponseEntity.ok(Map.of("message", "과목이 시간표에서 제거되었습니다."));
             
         } catch (RuntimeException e) {
@@ -57,9 +57,10 @@ public class TimetableController {
         try {
             Long userId = Long.valueOf(request.get("userId").toString());
             Long subjectId = Long.valueOf(request.get("subjectId").toString());
+            String semester = (String) request.get("semester");
             String memo = (String) request.get("memo");
             
-            UserTimetable userTimetable = timetableService.updateMemo(userId, subjectId, memo);
+            UserTimetable userTimetable = timetableService.updateMemo(userId, subjectId, semester, memo);
             return ResponseEntity.ok(userTimetable);
             
         } catch (RuntimeException e) {

--- a/src/main/java/inu/timetable/controller/WishlistController.java
+++ b/src/main/java/inu/timetable/controller/WishlistController.java
@@ -38,9 +38,9 @@ public class WishlistController {
     }
     
     @DeleteMapping("/remove")
-    public ResponseEntity<?> removeFromWishlist(@RequestParam Long userId, @RequestParam Long subjectId) {
+    public ResponseEntity<?> removeFromWishlist(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam(required = false) String semester) {
         try {
-            wishlistService.removeFromWishlist(userId, subjectId);
+            wishlistService.removeFromWishlist(userId, subjectId, semester);
             return ResponseEntity.ok(Map.of("message", "위시리스트에서 제거되었습니다."));
             
         } catch (RuntimeException e) {
@@ -75,9 +75,10 @@ public class WishlistController {
         try {
             Long userId = Long.valueOf(request.get("userId").toString());
             Long subjectId = Long.valueOf(request.get("subjectId").toString());
+            String semester = (String) request.get("semester");
             Integer priority = Integer.valueOf(request.get("priority").toString());
             
-            wishlistService.updatePriority(userId, subjectId, priority);
+            wishlistService.updatePriority(userId, subjectId, semester, priority);
             return ResponseEntity.ok(Map.of("message", "우선순위가 업데이트되었습니다."));
             
         } catch (RuntimeException e) {
@@ -90,9 +91,10 @@ public class WishlistController {
         try {
             Long userId = Long.valueOf(request.get("userId").toString());
             Long subjectId = Long.valueOf(request.get("subjectId").toString());
+            String semester = (String) request.get("semester");
             Boolean isRequired = Boolean.valueOf(request.get("isRequired").toString());
             
-            wishlistService.updateRequired(userId, subjectId, isRequired);
+            wishlistService.updateRequired(userId, subjectId, semester, isRequired);
             return ResponseEntity.ok(Map.of("message", "필수 과목 설정이 업데이트되었습니다."));
             
         } catch (RuntimeException e) {

--- a/src/main/java/inu/timetable/controller/WishlistController.java
+++ b/src/main/java/inu/timetable/controller/WishlistController.java
@@ -38,7 +38,7 @@ public class WishlistController {
     }
     
     @DeleteMapping("/remove")
-    public ResponseEntity<?> removeFromWishlist(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam(required = false) String semester) {
+    public ResponseEntity<?> removeFromWishlist(@RequestParam Long userId, @RequestParam Long subjectId, @RequestParam String semester) {
         try {
             wishlistService.removeFromWishlist(userId, subjectId, semester);
             return ResponseEntity.ok(Map.of("message", "위시리스트에서 제거되었습니다."));

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -2,6 +2,7 @@ package inu.timetable.repository;
 
 import inu.timetable.entity.UserTimetable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -16,8 +17,14 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     
     List<UserTimetable> findByUserId(Long userId);
     
-    Optional<UserTimetable> findByUserIdAndSubjectId(Long userId, Long subjectId);
+    Optional<UserTimetable> findByUserIdAndSubjectIdAndSemester(Long userId, Long subjectId, String semester);
+
+    java.util.List<UserTimetable> findByUserIdAndSubjectId(Long userId, Long subjectId);
     
+    @Modifying
+    @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId AND ut.subject.id = :subjectId AND (:semester IS NULL OR ut.semester = :semester)")
+    int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
+
     @Query("SELECT DISTINCT ut FROM UserTimetable ut JOIN FETCH ut.subject s WHERE ut.user.id = :userId AND ut.semester = :semester")
     List<UserTimetable> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
 }

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -18,11 +18,9 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     List<UserTimetable> findByUserId(Long userId);
     
     Optional<UserTimetable> findByUserIdAndSubjectIdAndSemester(Long userId, Long subjectId, String semester);
-
-    java.util.List<UserTimetable> findByUserIdAndSubjectId(Long userId, Long subjectId);
     
-    @Modifying
-    @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId AND ut.subject.id = :subjectId AND (:semester IS NULL OR ut.semester = :semester)")
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId AND ut.subject.id = :subjectId AND ut.semester = :semester")
     int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
 
     @Query("SELECT DISTINCT ut FROM UserTimetable ut JOIN FETCH ut.subject s WHERE ut.user.id = :userId AND ut.semester = :semester")

--- a/src/main/java/inu/timetable/repository/WishlistRepository.java
+++ b/src/main/java/inu/timetable/repository/WishlistRepository.java
@@ -24,10 +24,8 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     
     @Query("SELECT w FROM WishlistItem w JOIN FETCH w.subject s WHERE w.user.id = :userId AND s.id = :subjectId AND w.semester = :semester")
     Optional<WishlistItem> findByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
-
-    List<WishlistItem> findByUserIdAndSubjectId(Long userId, Long subjectId);
     
-    @Modifying
-    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId AND (:semester IS NULL OR w.semester = :semester)")
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId AND w.semester = :semester")
     int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
 }

--- a/src/main/java/inu/timetable/repository/WishlistRepository.java
+++ b/src/main/java/inu/timetable/repository/WishlistRepository.java
@@ -22,10 +22,12 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
            "ORDER BY w.priority")
     List<WishlistItem> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
     
-    @Query("SELECT w FROM WishlistItem w JOIN FETCH w.subject s WHERE w.user.id = :userId AND s.id = :subjectId")
-    Optional<WishlistItem> findByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
+    @Query("SELECT w FROM WishlistItem w JOIN FETCH w.subject s WHERE w.user.id = :userId AND s.id = :subjectId AND w.semester = :semester")
+    Optional<WishlistItem> findByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
+
+    List<WishlistItem> findByUserIdAndSubjectId(Long userId, Long subjectId);
     
     @Modifying
-    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId")
-    void deleteByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
+    @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId AND (:semester IS NULL OR w.semester = :semester)")
+    int deleteByUserIdAndSubjectIdAndSemester(@Param("userId") Long userId, @Param("subjectId") Long subjectId, @Param("semester") String semester);
 }

--- a/src/main/java/inu/timetable/service/TimetableService.java
+++ b/src/main/java/inu/timetable/service/TimetableService.java
@@ -15,6 +15,13 @@ import java.util.Optional;
 
 @Service
 public class TimetableService {
+
+    private String requireSemester(String semester) {
+        if (semester == null || semester.isBlank()) {
+            throw new RuntimeException("학기(semester)는 필수입니다.");
+        }
+        return semester;
+    }
     
     private final UserTimetableRepository userTimetableRepository;
     private final UserRepository userRepository;
@@ -37,13 +44,14 @@ public class TimetableService {
             .orElseThrow(() -> new RuntimeException("과목을 찾을 수 없습니다."));
         
         // 이미 추가된 과목인지 확인
-        Optional<UserTimetable> existing = userTimetableRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
+        String sem = requireSemester(semester);
+        Optional<UserTimetable> existing = userTimetableRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, sem);
         if (existing.isPresent()) {
             throw new RuntimeException("이미 시간표에 추가된 과목입니다.");
         }
         
         // 시간표 겹침 확인
-        List<UserTimetable> currentTimetable = userTimetableRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
+        List<UserTimetable> currentTimetable = userTimetableRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, sem);
         if (hasTimeConflict(currentTimetable, subject)) {
             throw new RuntimeException("시간표가 겹치는 과목이 있습니다.");
         }
@@ -51,7 +59,7 @@ public class TimetableService {
         UserTimetable userTimetable = UserTimetable.builder()
             .user(user)
             .subject(subject)
-            .semester(semester)
+            .semester(sem)
             .memo(memo)
             .build();
             
@@ -60,7 +68,8 @@ public class TimetableService {
     
     @Transactional
     public void removeSubjectFromTimetable(Long userId, Long subjectId, String semester) {
-        int deleted = userTimetableRepository.deleteByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
+        String sem = requireSemester(semester);
+        int deleted = userTimetableRepository.deleteByUserIdAndSubjectIdAndSemester(userId, subjectId, sem);
         if (deleted == 0) {
             throw new RuntimeException("시간표에서 해당 과목을 찾을 수 없습니다.");
         }
@@ -75,7 +84,8 @@ public class TimetableService {
     }
     
     public UserTimetable updateMemo(Long userId, Long subjectId, String semester, String memo) {
-        UserTimetable userTimetable = userTimetableRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)
+        String sem = requireSemester(semester);
+        UserTimetable userTimetable = userTimetableRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, sem)
             .orElseThrow(() -> new RuntimeException("시간표에서 해당 과목을 찾을 수 없습니다."));
             
         userTimetable.setMemo(memo);

--- a/src/main/java/inu/timetable/service/WishlistService.java
+++ b/src/main/java/inu/timetable/service/WishlistService.java
@@ -41,7 +41,7 @@ public class WishlistService {
             .orElseThrow(() -> new RuntimeException("과목을 찾을 수 없습니다."));
         
         // 이미 위시리스트에 있는지 확인
-        Optional<WishlistItem> existing = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId);
+        Optional<WishlistItem> existing = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
         if (existing.isPresent()) {
             throw new RuntimeException("이미 위시리스트에 추가된 과목입니다.");
         }
@@ -58,24 +58,27 @@ public class WishlistService {
     }
     
     @Transactional
-    public void removeFromWishlist(Long userId, Long subjectId) {
-        wishlistRepository.deleteByUserIdAndSubjectId(userId, subjectId);
+    public void removeFromWishlist(Long userId, Long subjectId, String semester) {
+        int deleted = wishlistRepository.deleteByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
+        if (deleted == 0) {
+            throw new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다.");
+        }
     }
     
     public List<WishlistItem> getUserWishlist(Long userId, String semester) {
         return wishlistRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
     }
     
-    public WishlistItem updatePriority(Long userId, Long subjectId, Integer priority) {
-        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId)
+    public WishlistItem updatePriority(Long userId, Long subjectId, String semester, Integer priority) {
+        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)
             .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
             
         wishlistItem.setPriority(priority);
         return wishlistRepository.save(wishlistItem);
     }
     
-    public WishlistItem updateRequired(Long userId, Long subjectId, Boolean isRequired) {
-        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectId(userId, subjectId)
+    public WishlistItem updateRequired(Long userId, Long subjectId, String semester, Boolean isRequired) {
+        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)
             .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
             
         wishlistItem.setIsRequired(isRequired);

--- a/src/main/java/inu/timetable/service/WishlistService.java
+++ b/src/main/java/inu/timetable/service/WishlistService.java
@@ -15,6 +15,13 @@ import java.util.Optional;
 
 @Service
 public class WishlistService {
+
+    private String requireSemester(String semester) {
+        if (semester == null || semester.isBlank()) {
+            throw new RuntimeException("학기(semester)는 필수입니다.");
+        }
+        return semester;
+    }
     
     private final WishlistRepository wishlistRepository;
     private final UserRepository userRepository;
@@ -41,7 +48,8 @@ public class WishlistService {
             .orElseThrow(() -> new RuntimeException("과목을 찾을 수 없습니다."));
         
         // 이미 위시리스트에 있는지 확인
-        Optional<WishlistItem> existing = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
+        String sem = requireSemester(semester);
+        Optional<WishlistItem> existing = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, sem);
         if (existing.isPresent()) {
             throw new RuntimeException("이미 위시리스트에 추가된 과목입니다.");
         }
@@ -49,7 +57,7 @@ public class WishlistService {
         WishlistItem wishlistItem = WishlistItem.builder()
             .user(user)
             .subject(subject)
-            .semester(semester)
+            .semester(sem)
             .priority(priority != null ? priority : 3) // 기본 우선순위: 중간
             .isRequired(isRequired != null ? isRequired : false)
             .build();
@@ -59,7 +67,8 @@ public class WishlistService {
     
     @Transactional
     public void removeFromWishlist(Long userId, Long subjectId, String semester) {
-        int deleted = wishlistRepository.deleteByUserIdAndSubjectIdAndSemester(userId, subjectId, semester);
+        String sem = requireSemester(semester);
+        int deleted = wishlistRepository.deleteByUserIdAndSubjectIdAndSemester(userId, subjectId, sem);
         if (deleted == 0) {
             throw new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다.");
         }
@@ -70,7 +79,8 @@ public class WishlistService {
     }
     
     public WishlistItem updatePriority(Long userId, Long subjectId, String semester, Integer priority) {
-        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)
+        String sem = requireSemester(semester);
+        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, sem)
             .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
             
         wishlistItem.setPriority(priority);
@@ -78,7 +88,8 @@ public class WishlistService {
     }
     
     public WishlistItem updateRequired(Long userId, Long subjectId, String semester, Boolean isRequired) {
-        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)
+        String sem = requireSemester(semester);
+        WishlistItem wishlistItem = wishlistRepository.findByUserIdAndSubjectIdAndSemester(userId, subjectId, sem)
             .orElseThrow(() -> new RuntimeException("위시리스트에서 해당 과목을 찾을 수 없습니다."));
             
         wishlistItem.setIsRequired(isRequired);


### PR DESCRIPTION
## 변경 사항
- 시간표/위시리스트 remove API에 `semester`(optional) 파라미터 추가
- 서비스 레이어에서 `userId + subjectId + semester` 기준으로 조회/수정/삭제
- repository에 semester 조건 포함 메서드 추가
  - `findByUserIdAndSubjectIdAndSemester`
  - `deleteByUserIdAndSubjectIdAndSemester`
- memo/priority/required 업데이트도 semester 기준으로 동작하도록 수정

## 분리 목적
- timetable/wishlist 도메인 파일만 수정하여 auth 리팩토링 PR과 충돌 최소화

## 기대 효과
- 다른 학기 데이터 오염/오삭제 방지
- 중복/삭제 불일치 케이스 감소
