### PR TITLE
[codex] 관리자 CSRF를 Spring Security로 통합

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew clean build -x test
+      - name: Run tests and build with Gradle
+        run: ./gradlew clean build
 
       - name: Log in to Docker Hub
         uses: docker/login-action@v3

--- a/src/main/java/inu/timetable/config/SecurityConfig.java
+++ b/src/main/java/inu/timetable/config/SecurityConfig.java
@@ -71,8 +71,6 @@ public class SecurityConfig {
                         .ignoringRequestMatchers(
                                 "/",
                                 "/error",
-                                "/admin/**",
-                                "/admin/api/**",
                                 "/actuator/**",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",

--- a/src/main/java/inu/timetable/controller/AdminController.java
+++ b/src/main/java/inu/timetable/controller/AdminController.java
@@ -74,7 +74,7 @@ public class AdminController {
     /**
      * 로그아웃
      */
-    @GetMapping("/logout")
+    @PostMapping("/logout")
     public String logout(HttpServletRequest request) {
         adminAuthService.logout(request);
         return "redirect:/admin/login";

--- a/src/main/java/inu/timetable/dto/AdminAuthResponse.java
+++ b/src/main/java/inu/timetable/dto/AdminAuthResponse.java
@@ -2,7 +2,6 @@ package inu.timetable.dto;
 
 public record AdminAuthResponse(
         boolean authenticated,
-        String username,
-        String csrfToken
+        String username
 ) {
 }

--- a/src/main/java/inu/timetable/service/AdminAccessGuard.java
+++ b/src/main/java/inu/timetable/service/AdminAccessGuard.java
@@ -5,14 +5,11 @@ import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 @Component
 @RequiredArgsConstructor
 public class AdminAccessGuard {
-
-    public static final String ADMIN_CSRF_HEADER = "X-Admin-Csrf";
 
     private final AdminAuthService adminAuthService;
 
@@ -21,23 +18,9 @@ public class AdminAccessGuard {
         if (!adminAuthService.isAuthenticated(session)) {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Admin login required");
         }
-        if (requiresCsrfToken(request)) {
-            String expectedToken = (String) session.getAttribute(AdminAuthService.SESSION_CSRF_TOKEN);
-            String providedToken = request.getHeader(ADMIN_CSRF_HEADER);
-            if (!StringUtils.hasText(expectedToken) || !expectedToken.equals(providedToken)) {
-                throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Admin CSRF token required");
-            }
-        }
     }
 
     public boolean isAuthenticated(HttpSession session) {
         return adminAuthService.isAuthenticated(session);
-    }
-
-    private boolean requiresCsrfToken(HttpServletRequest request) {
-        String method = request.getMethod();
-        return !"GET".equalsIgnoreCase(method)
-                && !"HEAD".equalsIgnoreCase(method)
-                && !"OPTIONS".equalsIgnoreCase(method);
     }
 }

--- a/src/main/java/inu/timetable/service/AdminAuthService.java
+++ b/src/main/java/inu/timetable/service/AdminAuthService.java
@@ -13,10 +13,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.Base64;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -26,9 +24,6 @@ public class AdminAuthService {
 
     public static final String SESSION_AUTHENTICATED = "admin_authenticated";
     public static final String SESSION_USERNAME = "admin_username";
-    public static final String SESSION_CSRF_TOKEN = "admin_csrf_token";
-
-    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final BCryptPasswordEncoder passwordEncoder;
     private final Map<String, LoginAttempt> loginAttempts = new ConcurrentHashMap<>();
@@ -66,12 +61,10 @@ public class AdminAuthService {
         HttpSession session = request.getSession(true);
         request.changeSessionId();
 
-        String csrfToken = newCsrfToken();
         session.setAttribute(SESSION_AUTHENTICATED, true);
         session.setAttribute(SESSION_USERNAME, adminUsername);
-        session.setAttribute(SESSION_CSRF_TOKEN, csrfToken);
 
-        return new AdminAuthResponse(true, adminUsername, csrfToken);
+        return new AdminAuthResponse(true, adminUsername);
     }
 
     public AdminAuthResponse currentAuthentication(HttpServletRequest request) {
@@ -81,8 +74,7 @@ public class AdminAuthService {
         }
         return new AdminAuthResponse(
                 true,
-                (String) session.getAttribute(SESSION_USERNAME),
-                (String) session.getAttribute(SESSION_CSRF_TOKEN));
+                (String) session.getAttribute(SESSION_USERNAME));
     }
 
     public void logout(HttpServletRequest request) {
@@ -145,12 +137,6 @@ public class AdminAuthService {
 
     private String clientIp(HttpServletRequest request) {
         return request.getRemoteAddr();
-    }
-
-    private String newCsrfToken() {
-        byte[] bytes = new byte[32];
-        SECURE_RANDOM.nextBytes(bytes);
-        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
     }
 
     private static class LoginAttempt {

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -96,7 +96,6 @@
         <div th:if="${error}" class="error" th:text="${error}"></div>
 
         <form th:action="@{/admin/login}" method="post">
-            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
             <div class="form-group">
                 <label for="username">관리자 아이디</label>
                 <input type="text" id="username" name="username"

--- a/src/main/resources/templates/admin/login.html
+++ b/src/main/resources/templates/admin/login.html
@@ -96,6 +96,7 @@
         <div th:if="${error}" class="error" th:text="${error}"></div>
 
         <form th:action="@{/admin/login}" method="post">
+            <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
             <div class="form-group">
                 <label for="username">관리자 아이디</label>
                 <input type="text" id="username" name="username"

--- a/src/main/resources/templates/admin/upload.html
+++ b/src/main/resources/templates/admin/upload.html
@@ -36,14 +36,23 @@
         .nav-links {
             display: flex;
             gap: 15px;
+            align-items: center;
         }
-        .nav-links a {
+        .nav-links a,
+        .nav-links button {
+            background: none;
+            border: 0;
+            padding: 0;
             color: #667eea;
+            cursor: pointer;
+            font: inherit;
             text-decoration: none;
             font-weight: 600;
         }
-        .nav-links a:hover {
+        .nav-links a:hover,
+        .nav-links button:hover {
             text-decoration: underline;
+            transform: none;
         }
         .card {
             background: white;
@@ -110,7 +119,10 @@
             <h1>📤 파일 업로드</h1>
             <div class="nav-links">
                 <a href="/admin/validate">검증 페이지</a>
-                <a href="/admin/logout">로그아웃</a>
+                <form th:action="@{/admin/logout}" method="post">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <button type="submit">로그아웃</button>
+                </form>
             </div>
         </div>
 
@@ -121,6 +133,7 @@
             <h2>📄 PDF 업로드 (수강편람)</h2>
             <p class="description">수강편람 PDF 파일을 업로드하면 Gemini AI로 파싱하여 DB에 저장합니다.</p>
             <form th:action="@{/admin/upload/pdf}" method="post" enctype="multipart/form-data">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div class="file-input-wrapper">
                     <input type="file" name="file" accept=".pdf" required>
                 </div>
@@ -132,6 +145,7 @@
             <h2>📊 Excel 업로드 (종합강의시간표)</h2>
             <p class="description">종합강의시간표 Excel 파일(.xlsx)을 학수번호 기준으로 비교하여 DB에 반영합니다. 삭제 대상은 물리 삭제하지 않고 비활성화합니다.</p>
             <form th:action="@{/admin/upload/excel}" method="post" enctype="multipart/form-data">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div style="margin-bottom: 15px;">
                     <label for="semester" style="display:block; margin-bottom:8px; font-weight:600;">학기</label>
                     <input id="semester" type="text" name="semester" placeholder="예: 2026-2" required

--- a/src/main/resources/templates/admin/upload.html
+++ b/src/main/resources/templates/admin/upload.html
@@ -120,7 +120,6 @@
             <div class="nav-links">
                 <a href="/admin/validate">검증 페이지</a>
                 <form th:action="@{/admin/logout}" method="post">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                     <button type="submit">로그아웃</button>
                 </form>
             </div>
@@ -133,7 +132,6 @@
             <h2>📄 PDF 업로드 (수강편람)</h2>
             <p class="description">수강편람 PDF 파일을 업로드하면 Gemini AI로 파싱하여 DB에 저장합니다.</p>
             <form th:action="@{/admin/upload/pdf}" method="post" enctype="multipart/form-data">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div class="file-input-wrapper">
                     <input type="file" name="file" accept=".pdf" required>
                 </div>
@@ -145,7 +143,6 @@
             <h2>📊 Excel 업로드 (종합강의시간표)</h2>
             <p class="description">종합강의시간표 Excel 파일(.xlsx)을 학수번호 기준으로 비교하여 DB에 반영합니다. 삭제 대상은 물리 삭제하지 않고 비활성화합니다.</p>
             <form th:action="@{/admin/upload/excel}" method="post" enctype="multipart/form-data">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div style="margin-bottom: 15px;">
                     <label for="semester" style="display:block; margin-bottom:8px; font-weight:600;">학기</label>
                     <input id="semester" type="text" name="semester" placeholder="예: 2026-2" required

--- a/src/main/resources/templates/admin/validate-result.html
+++ b/src/main/resources/templates/admin/validate-result.html
@@ -186,7 +186,6 @@
                 <a href="/admin/validate">다시 검증하기</a>
                 <a href="/admin/upload">업로드 페이지</a>
                 <form th:action="@{/admin/logout}" method="post">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                     <button type="submit">로그아웃</button>
                 </form>
             </div>

--- a/src/main/resources/templates/admin/validate-result.html
+++ b/src/main/resources/templates/admin/validate-result.html
@@ -42,16 +42,25 @@
         .nav-links {
             display: flex;
             gap: 15px;
+            align-items: center;
         }
 
-        .nav-links a {
+        .nav-links a,
+        .nav-links button {
+            background: none;
+            border: 0;
+            padding: 0;
             color: #667eea;
+            cursor: pointer;
+            font: inherit;
             text-decoration: none;
             font-weight: 600;
         }
 
-        .nav-links a:hover {
+        .nav-links a:hover,
+        .nav-links button:hover {
             text-decoration: underline;
+            transform: none;
         }
 
         .card {
@@ -176,7 +185,10 @@
             <div class="nav-links">
                 <a href="/admin/validate">다시 검증하기</a>
                 <a href="/admin/upload">업로드 페이지</a>
-                <a href="/admin/logout">로그아웃</a>
+                <form th:action="@{/admin/logout}" method="post">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <button type="submit">로그아웃</button>
+                </form>
             </div>
         </div>
 

--- a/src/main/resources/templates/admin/validate.html
+++ b/src/main/resources/templates/admin/validate.html
@@ -122,7 +122,6 @@
             <div class="nav-links">
                 <a href="/admin/upload">업로드 페이지</a>
                 <form th:action="@{/admin/logout}" method="post">
-                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                     <button type="submit">로그아웃</button>
                 </form>
             </div>
@@ -134,7 +133,6 @@
             <h2>📄 PDF 파싱 검증</h2>
             <p class="description">PDF를 파싱하여 DB 데이터와 비교합니다. (DB에 저장하지 않음)</p>
             <form th:action="@{/admin/validate/pdf}" method="post" enctype="multipart/form-data">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div class="form-group">
                     <label for="pdf-file">PDF 파일</label>
                     <input type="file" id="pdf-file" name="file" accept=".pdf" required>
@@ -151,7 +149,6 @@
             <h2>📊 Excel 파싱 검증</h2>
             <p class="description">Excel을 파싱하여 DB 데이터와 비교합니다. (DB에 저장하지 않음)</p>
             <form th:action="@{/admin/validate/excel}" method="post" enctype="multipart/form-data">
-                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div class="form-group">
                     <label for="excel-file">Excel 파일</label>
                     <input type="file" id="excel-file" name="file" accept=".xlsx" required>

--- a/src/main/resources/templates/admin/validate.html
+++ b/src/main/resources/templates/admin/validate.html
@@ -36,14 +36,23 @@
         .nav-links {
             display: flex;
             gap: 15px;
+            align-items: center;
         }
-        .nav-links a {
+        .nav-links a,
+        .nav-links button {
+            background: none;
+            border: 0;
+            padding: 0;
             color: #667eea;
+            cursor: pointer;
+            font: inherit;
             text-decoration: none;
             font-weight: 600;
         }
-        .nav-links a:hover {
+        .nav-links a:hover,
+        .nav-links button:hover {
             text-decoration: underline;
+            transform: none;
         }
         .card {
             background: white;
@@ -112,7 +121,10 @@
             <h1>🔍 파싱 검증</h1>
             <div class="nav-links">
                 <a href="/admin/upload">업로드 페이지</a>
-                <a href="/admin/logout">로그아웃</a>
+                <form th:action="@{/admin/logout}" method="post">
+                    <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
+                    <button type="submit">로그아웃</button>
+                </form>
             </div>
         </div>
 
@@ -122,6 +134,7 @@
             <h2>📄 PDF 파싱 검증</h2>
             <p class="description">PDF를 파싱하여 DB 데이터와 비교합니다. (DB에 저장하지 않음)</p>
             <form th:action="@{/admin/validate/pdf}" method="post" enctype="multipart/form-data">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div class="form-group">
                     <label for="pdf-file">PDF 파일</label>
                     <input type="file" id="pdf-file" name="file" accept=".pdf" required>
@@ -138,6 +151,7 @@
             <h2>📊 Excel 파싱 검증</h2>
             <p class="description">Excel을 파싱하여 DB 데이터와 비교합니다. (DB에 저장하지 않음)</p>
             <form th:action="@{/admin/validate/excel}" method="post" enctype="multipart/form-data">
+                <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}">
                 <div class="form-group">
                     <label for="excel-file">Excel 파일</label>
                     <input type="file" id="excel-file" name="file" accept=".xlsx" required>

--- a/src/test/java/inu/timetable/controller/AdminCsrfIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/AdminCsrfIntegrationTest.java
@@ -1,8 +1,7 @@
 package inu.timetable.controller;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jakarta.servlet.http.Cookie;
+import inu.timetable.controller.CsrfTestSupport.CsrfProof;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static inu.timetable.controller.CsrfTestSupport.fetchCsrfProof;
 import static org.hamcrest.Matchers.containsString;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -56,7 +55,7 @@ class AdminCsrfIntegrationTest {
     @DisplayName("관리자 API 로그인은 Spring CSRF 토큰이 있으면 성공한다")
     void adminApiLoginAllowsSpringCsrfToken() throws Exception {
         MockHttpSession session = new MockHttpSession();
-        CsrfProof csrfProof = fetchCsrfProof(session);
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
 
         mockMvc.perform(post("/admin/api/auth/login")
                 .session(session)
@@ -82,17 +81,4 @@ class AdminCsrfIntegrationTest {
                 .andExpect(content().string(containsString("name=\"_csrf\"")));
     }
 
-    private CsrfProof fetchCsrfProof(MockHttpSession session) throws Exception {
-        var result = mockMvc.perform(get("/api/auth/csrf").session(session))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
-        Cookie cookie = result.getResponse().getCookie("XSRF-TOKEN");
-        assertThat(cookie).isNotNull();
-        return new CsrfProof(responseBody.get("token").asText(), cookie);
-    }
-
-    private record CsrfProof(String token, Cookie cookie) {
-    }
 }

--- a/src/test/java/inu/timetable/controller/AdminCsrfIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/AdminCsrfIntegrationTest.java
@@ -1,0 +1,98 @@
+package inu.timetable.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "admin.username=admin",
+        "admin.password=test-admin-password",
+        "admin.password-hash="
+})
+class AdminCsrfIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("관리자 API 로그인은 Spring CSRF 토큰을 요구한다")
+    void adminApiLoginRequiresSpringCsrfToken() throws Exception {
+        mockMvc.perform(post("/admin/api/auth/login")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "username": "admin",
+                          "password": "test-admin-password"
+                        }
+                        """))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("관리자 API 로그인은 Spring CSRF 토큰이 있으면 성공한다")
+    void adminApiLoginAllowsSpringCsrfToken() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        CsrfProof csrfProof = fetchCsrfProof(session);
+
+        mockMvc.perform(post("/admin/api/auth/login")
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                        {
+                          "username": "admin",
+                          "password": "test-admin-password"
+                        }
+                        """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.username").value("admin"));
+    }
+
+    @Test
+    @DisplayName("관리자 로그인 폼은 Spring CSRF hidden input을 포함한다")
+    void adminLoginFormIncludesSpringCsrfInput() throws Exception {
+        mockMvc.perform(get("/admin/login"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString("name=\"_csrf\"")));
+    }
+
+    private CsrfProof fetchCsrfProof(MockHttpSession session) throws Exception {
+        var result = mockMvc.perform(get("/api/auth/csrf").session(session))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+        Cookie cookie = result.getResponse().getCookie("XSRF-TOKEN");
+        assertThat(cookie).isNotNull();
+        return new CsrfProof(responseBody.get("token").asText(), cookie);
+    }
+
+    private record CsrfProof(String token, Cookie cookie) {
+    }
+}

--- a/src/test/java/inu/timetable/controller/AdminSubjectControllerTest.java
+++ b/src/test/java/inu/timetable/controller/AdminSubjectControllerTest.java
@@ -1,14 +1,15 @@
 package inu.timetable.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.JsonNode;
 import inu.timetable.dto.SubjectManagementRequest;
 import inu.timetable.entity.Schedule;
 import inu.timetable.entity.Subject;
 import inu.timetable.enums.ClassMethod;
 import inu.timetable.enums.SubjectType;
 import inu.timetable.repository.SubjectRepository;
-import inu.timetable.service.AdminAccessGuard;
 import inu.timetable.service.AdminAuthService;
+import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -28,6 +29,7 @@ import java.util.Map;
 import static java.util.Map.entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -38,8 +40,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ActiveProfiles("dev")
 @Transactional
 class AdminSubjectControllerTest {
-
-    private static final String CSRF_TOKEN = "test-csrf-token";
 
     @Autowired
     private MockMvc mockMvc;
@@ -53,6 +53,8 @@ class AdminSubjectControllerTest {
     @Test
     @DisplayName("관리자 과목 추가 API는 과목과 시간표를 함께 저장한다")
     void createSubjectSavesSubjectAndSchedules() throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(session);
         SubjectManagementRequest request = new SubjectManagementRequest(
                 "CSE9999001",
                 "2026-2",
@@ -68,8 +70,9 @@ class AdminSubjectControllerTest {
                 List.of(new SubjectManagementRequest.ScheduleRequest("월", 1.0, 2.5)));
 
         mockMvc.perform(post("/admin/api/subjects")
-                .session(adminSession())
-                .header(AdminAccessGuard.ADMIN_CSRF_HEADER, CSRF_TOKEN)
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -97,6 +100,8 @@ class AdminSubjectControllerTest {
     @Test
     @DisplayName("수동 과목 추가 API는 시간 문자열을 파싱해 시간표를 저장한다")
     void manualAddParsesTimeStringAndSavesSchedules() throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(session);
         List<Map<String, Object>> request = List.of(Map.ofEntries(
                 entry("subjectName", "수동추가테스트"),
                 entry("credits", 2),
@@ -109,8 +114,9 @@ class AdminSubjectControllerTest {
                 entry("timeString", "월 1A-2B 수 3-4")));
 
         mockMvc.perform(post("/admin/api/subjects/manual")
-                .session(adminSession())
-                .header(AdminAccessGuard.ADMIN_CSRF_HEADER, CSRF_TOKEN)
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isOk())
@@ -129,8 +135,8 @@ class AdminSubjectControllerTest {
     }
 
     @Test
-    @DisplayName("관리자 과목 추가 API는 CSRF 헤더가 없으면 저장하지 않는다")
-    void createSubjectRejectsMissingCsrfHeader() throws Exception {
+    @DisplayName("관리자 과목 추가 API는 Spring CSRF 토큰이 없으면 저장하지 않는다")
+    void createSubjectRejectsMissingSpringCsrfToken() throws Exception {
         SubjectManagementRequest request = new SubjectManagementRequest(
                 "CSE9999002",
                 "2026-2",
@@ -157,11 +163,15 @@ class AdminSubjectControllerTest {
     @Test
     @DisplayName("실제 공식 Excel 파일 preview는 전체 과목 행을 읽는다")
     void previewActualOfficialExcelFile() throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(session);
+
         mockMvc.perform(multipart("/admin/api/subjects/import/preview")
                 .file(actualOfficialExcelFile())
                 .param("semester", "2025-2")
-                .session(adminSession())
-                .header(AdminAccessGuard.ADMIN_CSRF_HEADER, CSRF_TOKEN))
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.applied").value(false))
                 .andExpect(jsonPath("$.semester").value("2025-2"))
@@ -176,12 +186,16 @@ class AdminSubjectControllerTest {
     @Test
     @DisplayName("실제 공식 Excel 파일 apply는 과목과 시간표를 DB에 저장한다")
     void applyActualOfficialExcelFile() throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(session);
+
         mockMvc.perform(multipart("/admin/api/subjects/import/apply")
                 .file(actualOfficialExcelFile())
                 .param("semester", "2025-2")
                 .param("deactivateMissing", "true")
-                .session(adminSession())
-                .header(AdminAccessGuard.ADMIN_CSRF_HEADER, CSRF_TOKEN))
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token()))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.applied").value(true))
                 .andExpect(jsonPath("$.semester").value("2025-2"))
@@ -224,8 +238,18 @@ class AdminSubjectControllerTest {
         MockHttpSession session = new MockHttpSession();
         session.setAttribute(AdminAuthService.SESSION_AUTHENTICATED, true);
         session.setAttribute(AdminAuthService.SESSION_USERNAME, "admin");
-        session.setAttribute(AdminAuthService.SESSION_CSRF_TOKEN, CSRF_TOKEN);
         return session;
+    }
+
+    private CsrfProof fetchCsrfProof(MockHttpSession session) throws Exception {
+        var result = mockMvc.perform(get("/api/auth/csrf").session(session))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+        Cookie cookie = result.getResponse().getCookie("XSRF-TOKEN");
+        assertThat(cookie).isNotNull();
+        return new CsrfProof(responseBody.get("token").asText(), cookie);
     }
 
     private MockMultipartFile actualOfficialExcelFile() throws Exception {
@@ -262,5 +286,8 @@ class AdminSubjectControllerTest {
         return subjectRepository.findAllWithSchedules().stream()
                 .filter(subject -> subjectName.equals(subject.getSubjectName()))
                 .toList();
+    }
+
+    private record CsrfProof(String token, Cookie cookie) {
     }
 }

--- a/src/test/java/inu/timetable/controller/AdminSubjectControllerTest.java
+++ b/src/test/java/inu/timetable/controller/AdminSubjectControllerTest.java
@@ -1,7 +1,7 @@
 package inu.timetable.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.JsonNode;
+import inu.timetable.controller.CsrfTestSupport.CsrfProof;
 import inu.timetable.dto.SubjectManagementRequest;
 import inu.timetable.entity.Schedule;
 import inu.timetable.entity.Subject;
@@ -9,7 +9,6 @@ import inu.timetable.enums.ClassMethod;
 import inu.timetable.enums.SubjectType;
 import inu.timetable.repository.SubjectRepository;
 import inu.timetable.service.AdminAuthService;
-import jakarta.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,9 +26,9 @@ import java.util.List;
 import java.util.Map;
 
 import static java.util.Map.entry;
+import static inu.timetable.controller.CsrfTestSupport.fetchCsrfProof;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -54,7 +53,7 @@ class AdminSubjectControllerTest {
     @DisplayName("관리자 과목 추가 API는 과목과 시간표를 함께 저장한다")
     void createSubjectSavesSubjectAndSchedules() throws Exception {
         MockHttpSession session = adminSession();
-        CsrfProof csrfProof = fetchCsrfProof(session);
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
         SubjectManagementRequest request = new SubjectManagementRequest(
                 "CSE9999001",
                 "2026-2",
@@ -101,7 +100,7 @@ class AdminSubjectControllerTest {
     @DisplayName("수동 과목 추가 API는 시간 문자열을 파싱해 시간표를 저장한다")
     void manualAddParsesTimeStringAndSavesSchedules() throws Exception {
         MockHttpSession session = adminSession();
-        CsrfProof csrfProof = fetchCsrfProof(session);
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
         List<Map<String, Object>> request = List.of(Map.ofEntries(
                 entry("subjectName", "수동추가테스트"),
                 entry("credits", 2),
@@ -164,7 +163,7 @@ class AdminSubjectControllerTest {
     @DisplayName("실제 공식 Excel 파일 preview는 전체 과목 행을 읽는다")
     void previewActualOfficialExcelFile() throws Exception {
         MockHttpSession session = adminSession();
-        CsrfProof csrfProof = fetchCsrfProof(session);
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
 
         mockMvc.perform(multipart("/admin/api/subjects/import/preview")
                 .file(actualOfficialExcelFile())
@@ -187,7 +186,7 @@ class AdminSubjectControllerTest {
     @DisplayName("실제 공식 Excel 파일 apply는 과목과 시간표를 DB에 저장한다")
     void applyActualOfficialExcelFile() throws Exception {
         MockHttpSession session = adminSession();
-        CsrfProof csrfProof = fetchCsrfProof(session);
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
 
         mockMvc.perform(multipart("/admin/api/subjects/import/apply")
                 .file(actualOfficialExcelFile())
@@ -241,17 +240,6 @@ class AdminSubjectControllerTest {
         return session;
     }
 
-    private CsrfProof fetchCsrfProof(MockHttpSession session) throws Exception {
-        var result = mockMvc.perform(get("/api/auth/csrf").session(session))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
-        Cookie cookie = result.getResponse().getCookie("XSRF-TOKEN");
-        assertThat(cookie).isNotNull();
-        return new CsrfProof(responseBody.get("token").asText(), cookie);
-    }
-
     private MockMultipartFile actualOfficialExcelFile() throws Exception {
         InputStream inputStream = getClass().getResourceAsStream("/sample_timetable.xlsx");
         assertThat(inputStream).isNotNull();
@@ -286,8 +274,5 @@ class AdminSubjectControllerTest {
         return subjectRepository.findAllWithSchedules().stream()
                 .filter(subject -> subjectName.equals(subject.getSubjectName()))
                 .toList();
-    }
-
-    private record CsrfProof(String token, Cookie cookie) {
     }
 }

--- a/src/test/java/inu/timetable/controller/CsrfTestSupport.java
+++ b/src/test/java/inu/timetable/controller/CsrfTestSupport.java
@@ -1,0 +1,34 @@
+package inu.timetable.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+final class CsrfTestSupport {
+
+    private CsrfTestSupport() {
+    }
+
+    static CsrfProof fetchCsrfProof(
+            MockMvc mockMvc,
+            ObjectMapper objectMapper,
+            MockHttpSession session) throws Exception {
+        var result = mockMvc.perform(get("/api/auth/csrf").session(session))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+        Cookie cookie = result.getResponse().getCookie("XSRF-TOKEN");
+        assertThat(cookie).isNotNull();
+        return new CsrfProof(responseBody.get("token").asText(), cookie);
+    }
+
+    record CsrfProof(String token, Cookie cookie) {
+    }
+}

--- a/src/test/java/inu/timetable/service/AdminAccessGuardTest.java
+++ b/src/test/java/inu/timetable/service/AdminAccessGuardTest.java
@@ -22,16 +22,16 @@ class AdminAccessGuardTest {
     }
 
     @Test
-    void getRequestAllowsAuthenticatedSessionWithoutCsrfHeader() {
-        MockHttpServletRequest request = authenticatedRequest("GET", "token");
+    void authenticatedRequestIsAllowed() {
+        MockHttpServletRequest request = authenticatedRequest("POST");
 
         assertThatCode(() -> adminAccessGuard.requireAuthenticated(request))
                 .doesNotThrowAnyException();
     }
 
     @Test
-    void postRequestRequiresCsrfHeader() {
-        MockHttpServletRequest request = authenticatedRequest("POST", "token");
+    void unauthenticatedRequestIsRejected() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/admin/api/subjects");
 
         assertThatThrownBy(() -> adminAccessGuard.requireAuthenticated(request))
                 .isInstanceOf(ResponseStatusException.class)
@@ -39,19 +39,9 @@ class AdminAccessGuardTest {
                         .isEqualTo(HttpStatus.FORBIDDEN));
     }
 
-    @Test
-    void postRequestAllowsMatchingCsrfHeader() {
-        MockHttpServletRequest request = authenticatedRequest("POST", "token");
-        request.addHeader(AdminAccessGuard.ADMIN_CSRF_HEADER, "token");
-
-        assertThatCode(() -> adminAccessGuard.requireAuthenticated(request))
-                .doesNotThrowAnyException();
-    }
-
-    private MockHttpServletRequest authenticatedRequest(String method, String csrfToken) {
+    private MockHttpServletRequest authenticatedRequest(String method) {
         MockHttpServletRequest request = new MockHttpServletRequest(method, "/admin/api/subjects");
         request.getSession(true).setAttribute(AdminAuthService.SESSION_AUTHENTICATED, true);
-        request.getSession(false).setAttribute(AdminAuthService.SESSION_CSRF_TOKEN, csrfToken);
         return request;
     }
 }

--- a/src/test/java/inu/timetable/service/AdminAuthServiceTest.java
+++ b/src/test/java/inu/timetable/service/AdminAuthServiceTest.java
@@ -29,7 +29,7 @@ class AdminAuthServiceTest {
     }
 
     @Test
-    void loginCreatesAdminSessionAndCsrfToken() {
+    void loginCreatesAdminSession() {
         MockHttpServletRequest request = new MockHttpServletRequest();
 
         AdminAuthResponse response = adminAuthService.login("admin", "secret", request);
@@ -37,10 +37,9 @@ class AdminAuthServiceTest {
         HttpSession session = request.getSession(false);
         assertThat(response.authenticated()).isTrue();
         assertThat(response.username()).isEqualTo("admin");
-        assertThat(response.csrfToken()).isNotBlank();
         assertThat(session).isNotNull();
         assertThat(session.getAttribute(AdminAuthService.SESSION_AUTHENTICATED)).isEqualTo(true);
-        assertThat(session.getAttribute(AdminAuthService.SESSION_CSRF_TOKEN)).isEqualTo(response.csrfToken());
+        assertThat(session.getAttribute(AdminAuthService.SESSION_USERNAME)).isEqualTo("admin");
     }
 
     @Test


### PR DESCRIPTION
## 변경 사항
- `/admin/**`, `/admin/api/**`를 Spring Security CSRF 예외에서 제거했습니다.
- 기존 관리자 전용 `X-Admin-Csrf` 검증과 응답 DTO의 `csrfToken` 필드를 제거하고, admin 인증 가드는 세션 인증 확인만 담당하도록 정리했습니다.
- Thymeleaf 관리자 로그인/업로드/검증/로그아웃 폼에 Spring CSRF hidden input을 추가했습니다.
- 관리자 API 로그인 및 과목 import/생성 요청이 Spring CSRF 토큰으로 보호되는지 통합 테스트를 추가했습니다.

## 배경
이전 사용자 인증 보안 강화 작업에서 사용자 API는 Spring Security CSRF 흐름으로 보호됐지만, 관리자 MVC/API 경로는 호환성 때문에 예외로 남아 있었습니다. 이번 변경은 관리자 POST/PUT/DELETE 요청도 동일한 CSRF 보호선 안으로 통합합니다.

## 배포 영향
- 프론트엔드 PR도 함께 배포해야 합니다. 백엔드만 먼저 배포하면 기존 관리자 React 화면의 로그인/저장 요청이 CSRF 403으로 실패할 수 있습니다.
- 기존 학생 사용자 로그인/시간표/위시리스트 흐름은 같은 `XSRF-TOKEN` 기반 흐름을 계속 사용합니다.

## 검증
- `./gradlew test`
- `./gradlew bootJar`
- 프론트엔드 연동 빌드: `npm run build`