### PR TITLE
CI 배포 대상을 GCP Cloud Run으로 전환

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,7 @@
+# Cloud Run source deploy only needs the prebuilt application image inputs.
+*
+!.gcloudignore
+!Dockerfile
+!build/
+!build/libs/
+!build/libs/*.jar

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,11 +1,26 @@
-name: Deploy to OCI (via Docker Hub)
+name: Deploy to GCP Cloud Run
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: gcp-cloud-run-production
+  cancel-in-progress: true
+
+env:
+  GCP_PROJECT_ID: project-53f7b99e-c306-49a7-a7b
+  GCP_REGION: asia-northeast3
+  CLOUD_RUN_SERVICE: inu-timetable-backend
+  RUNTIME_SERVICE_ACCOUNT: inu-timetable-runner@project-53f7b99e-c306-49a7-a7b.iam.gserviceaccount.com
 
 jobs:
-  build-and-deploy:
+  test-and-deploy:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -14,54 +29,59 @@ jobs:
       - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
-          java-version: '17'
-          distribution: 'temurin'
+          java-version: "17"
+          distribution: temurin
+          cache: gradle
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Run tests and build
+        run: ./gradlew clean test bootJar
 
-      - name: Run tests and build with Gradle
-        run: ./gradlew clean build
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v4
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v3
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          workload_identity_provider: projects/282216427513/locations/global/workloadIdentityPools/github-pool/providers/inu-timetable
+          service_account: github-deployer@project-53f7b99e-c306-49a7-a7b.iam.gserviceaccount.com
 
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
+      - name: Set up Google Cloud CLI
+        uses: google-github-actions/setup-gcloud@v3
         with:
-          context: .
-          push: true
-          tags: ${{ secrets.DOCKERHUB_USERNAME }}/inutable:latest
+          project_id: ${{ env.GCP_PROJECT_ID }}
 
-      - name: Copy deployment script to OCI
-        uses: appleboy/scp-action@v0.1.7
-        with:
-          host: ${{ secrets.OCI_HOST }}
-          username: ${{ secrets.OCI_USER }}
-          key: ${{ secrets.OCI_SSH_KEY }}
-          source: scripts/deploy-blue-green.sh
-          target: /tmp/inu-deploy
-          strip_components: 1
-
-      - name: Deploy to OCI
-        uses: appleboy/ssh-action@master
+      - name: Sync admin password to Secret Manager
         env:
-          IMAGE: ${{ secrets.DOCKERHUB_USERNAME }}/inutable:latest
-          DB_URL: ${{ secrets.DB_URL }}
-          DB_USERNAME: ${{ secrets.DB_USERNAME }}
-          DB_PASSWORD: ${{ secrets.DB_PASSWORD }}
-          GEMINI_API_KEY: ${{ secrets.GEMINI_KEY }}
-          ADMIN_USERNAME: ${{ secrets.ADMIN_USERNAME || 'admin' }}
-          ADMIN_PASSWORD_HASH: ${{ secrets.ADMIN_PASSWORD_HASH }}
           ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
-        with:
-          host: ${{ secrets.OCI_HOST }}
-          username: ${{ secrets.OCI_USER }}
-          key: ${{ secrets.OCI_SSH_KEY }}
-          envs: IMAGE,DB_URL,DB_USERNAME,DB_PASSWORD,GEMINI_API_KEY,ADMIN_USERNAME,ADMIN_PASSWORD_HASH,ADMIN_PASSWORD
-          script: |
-            chmod +x /tmp/inu-deploy/deploy-blue-green.sh
-            /tmp/inu-deploy/deploy-blue-green.sh
+        run: |
+          test -n "$ADMIN_PASSWORD"
+          printf '%s' "$ADMIN_PASSWORD" |
+            gcloud secrets versions add ADMIN_PASSWORD --data-file=-
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --source . \
+            --allow-unauthenticated \
+            --service-account "$RUNTIME_SERVICE_ACCOUNT" \
+            --set-secrets DB_URL=DB_URL:latest,DB_USERNAME=DB_USERNAME:latest,DB_PASSWORD=DB_PASSWORD:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,ADMIN_PASSWORD=ADMIN_PASSWORD:latest \
+            --set-env-vars '^@^SPRING_PROFILES_ACTIVE=prod@ADMIN_USERNAME=admin@CORS_ALLOWED_ORIGINS=https://inu-timetable-front-git-main-jjhs-projects-4d22a2fd.vercel.app,https://inuu-timetable.vercel.app' \
+            --port 8080 \
+            --cpu 1 \
+            --memory 1Gi \
+            --concurrency 80 \
+            --min-instances 0 \
+            --max-instances 1 \
+            --timeout 300 \
+            --cpu-boost \
+            --quiet
+
+      - name: Verify production API
+        run: |
+          SERVICE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format='value(status.url)')"
+          curl --fail --show-error --silent --retry 6 --retry-all-errors \
+            --retry-delay 5 "$SERVICE_URL/actuator/health"
+          test "$(curl --fail --show-error --silent --retry 3 \
+            "$SERVICE_URL/api/subjects/count")" = "2894"


### PR DESCRIPTION
## 변경 사항
- OCI/Docker Hub/SSH 배포를 GCP Cloud Run 소스 배포로 교체
- GitHub OIDC 인증으로 서비스 계정 키 없이 배포
- 기존 `ADMIN_PASSWORD` GitHub Secret을 GCP Secret Manager로 동기화
- 배포 후 헬스체크와 과목 수 API 검증 추가
- `.gcloudignore`로 빌드 JAR만 Cloud Build에 업로드

## 검증
- `./gradlew clean test bootJar` 성공
- 워크플로 YAML 파싱 및 `git diff --check` 통과