### PR TITLE
Cloud Run 관리자 세션 배포 검증 추가

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -76,6 +76,8 @@ jobs:
             --quiet
 
       - name: Verify production API
+        env:
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
         run: |
           SERVICE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
             --project "$GCP_PROJECT_ID" \
@@ -85,3 +87,26 @@ jobs:
             --retry-delay 5 "$SERVICE_URL/actuator/health"
           test "$(curl --fail --show-error --silent --retry 3 \
             "$SERVICE_URL/api/subjects/count")" = "2894"
+
+          COOKIE_JAR="$(mktemp)"
+          LOGIN_BODY="$(mktemp)"
+          trap 'rm -f "$COOKIE_JAR" "$LOGIN_BODY"' EXIT
+
+          LOGIN_STATUS="$(curl --show-error --silent \
+            --output "$LOGIN_BODY" \
+            --write-out '%{http_code}' \
+            --cookie-jar "$COOKIE_JAR" \
+            --header 'Content-Type: application/json' \
+            --data "$(jq --compact-output --null-input \
+              --arg username admin \
+              --arg password "$ADMIN_PASSWORD" \
+              '{username: $username, password: $password}')" \
+            "$SERVICE_URL/admin/api/auth/login")"
+          test "$LOGIN_STATUS" = "200"
+          test "$(jq --raw-output '.authenticated' "$LOGIN_BODY")" = "true"
+
+          test "$(curl --show-error --silent \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            --cookie "$COOKIE_JAR" \
+            "$SERVICE_URL/admin/api/auth/me")" = "200"


### PR DESCRIPTION
## 변경 사항
- 배포 검증 단계에서 GitHub Secret의 관리자 비밀번호로 실제 로그인 확인
- 발급된 세션 쿠키로 `/admin/api/auth/me` 재확인
- 비밀번호 및 로그인 응답은 Actions 로그에 출력하지 않음

## 검증
- 워크플로 YAML 파싱 성공
- `git diff --check` 통과