### PR TITLE
관리자 배포 검증에 Spring CSRF 토큰 반영

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -89,14 +89,25 @@ jobs:
             "$SERVICE_URL/api/subjects/count")" = "2894"
 
           COOKIE_JAR="$(mktemp)"
+          CSRF_BODY="$(mktemp)"
           LOGIN_BODY="$(mktemp)"
-          trap 'rm -f "$COOKIE_JAR" "$LOGIN_BODY"' EXIT
+          trap 'rm -f "$COOKIE_JAR" "$CSRF_BODY" "$LOGIN_BODY"' EXIT
+
+          test "$(curl --show-error --silent \
+            --output "$CSRF_BODY" \
+            --write-out '%{http_code}' \
+            --cookie-jar "$COOKIE_JAR" \
+            "$SERVICE_URL/api/auth/csrf")" = "200"
+          CSRF_TOKEN="$(jq --raw-output '.token' "$CSRF_BODY")"
+          test -n "$CSRF_TOKEN"
 
           LOGIN_STATUS="$(curl --show-error --silent \
             --output "$LOGIN_BODY" \
             --write-out '%{http_code}' \
+            --cookie "$COOKIE_JAR" \
             --cookie-jar "$COOKIE_JAR" \
             --header 'Content-Type: application/json' \
+            --header "X-XSRF-TOKEN: $CSRF_TOKEN" \
             --data "$(jq --compact-output --null-input \
               --arg username admin \
               --arg password "$ADMIN_PASSWORD" \


### PR DESCRIPTION
## 변경 사항
- 관리자 로그인 검증 전에 `/api/auth/csrf`에서 토큰과 쿠키 획득
- 로그인 요청에 `X-XSRF-TOKEN`과 쿠키를 함께 전달
- 로그인 세션으로 `/admin/api/auth/me`까지 확인

## 검증
- 동일 흐름으로 로컬 프론트 proxy에서 관리자 로그인 `200`, `authenticated=true` 확인
- 워크플로 YAML 파싱 및 `git diff --check` 통과