### PR TITLE
feat: 현재 학기 설정 API + 관리자 학기 전환

### DIFF
--- a/src/main/java/inu/timetable/config/SecurityConfig.java
+++ b/src/main/java/inu/timetable/config/SecurityConfig.java
@@ -93,6 +93,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/auth/me", "/api/auth/logout").authenticated()
                         .requestMatchers("/api/wishlist/**", "/api/timetable/**", "/api/timetable-combination/**").authenticated()
                         .requestMatchers("/api/subjects/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/settings/current-semester").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/events").permitAll()
                         .anyRequest().denyAll())
                 .exceptionHandling(exception -> exception

--- a/src/main/java/inu/timetable/controller/AdminSettingsController.java
+++ b/src/main/java/inu/timetable/controller/AdminSettingsController.java
@@ -1,0 +1,29 @@
+package inu.timetable.controller;
+
+import inu.timetable.dto.CurrentSemesterResponse;
+import inu.timetable.dto.CurrentSemesterUpdateRequest;
+import inu.timetable.service.AdminAccessGuard;
+import inu.timetable.service.AppSettingService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/api/settings")
+@RequiredArgsConstructor
+public class AdminSettingsController {
+
+    private final AdminAccessGuard adminAccessGuard;
+    private final AppSettingService appSettingService;
+
+    @PutMapping("/current-semester")
+    public CurrentSemesterResponse updateCurrentSemester(
+            HttpServletRequest servletRequest,
+            @RequestBody CurrentSemesterUpdateRequest request) {
+        adminAccessGuard.requireAuthenticated(servletRequest);
+        return new CurrentSemesterResponse(appSettingService.updateCurrentSemester(request.semester()));
+    }
+}

--- a/src/main/java/inu/timetable/controller/SettingsController.java
+++ b/src/main/java/inu/timetable/controller/SettingsController.java
@@ -1,0 +1,21 @@
+package inu.timetable.controller;
+
+import inu.timetable.dto.CurrentSemesterResponse;
+import inu.timetable.service.AppSettingService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/settings")
+@RequiredArgsConstructor
+public class SettingsController {
+
+    private final AppSettingService appSettingService;
+
+    @GetMapping("/current-semester")
+    public CurrentSemesterResponse getCurrentSemester() {
+        return new CurrentSemesterResponse(appSettingService.getCurrentSemester());
+    }
+}

--- a/src/main/java/inu/timetable/controller/SubjectController.java
+++ b/src/main/java/inu/timetable/controller/SubjectController.java
@@ -117,6 +117,7 @@ public class SubjectController {
 
     @GetMapping("/filter")
     public Page<SubjectDto> filterSubjects(
+            @RequestParam(required = false) String semester,
             @RequestParam(required = false) String subjectName,
             @RequestParam(required = false) String professor,
             @RequestParam(required = false) String department,
@@ -143,6 +144,7 @@ public class SubjectController {
 
         // 1단계: 필터로 과목 ID 조회 (페이지네이션 적용)
         Page<Long> subjectIdPage = subjectRepository.findIdsWithFilters(
+                normalizeSemester(semester),
                 subjectName, professor, normalizedDepartment, departmentListParam, normalizedDepartments.size(), dayOfWeek,
                 startTime, endTime, subjectType, grade, isNight, credits,
                 unassignedTime, ClassMethod.ONLINE, pageable);
@@ -185,6 +187,13 @@ public class SubjectController {
 
     private boolean isTooShort(String keyword) {
         return keyword == null || keyword.trim().length() < MIN_KEYWORD_LENGTH;
+    }
+
+    private String normalizeSemester(String semester) {
+        if (semester == null || semester.isBlank()) {
+            return null;
+        }
+        return semester.trim();
     }
 
     private String normalizeDepartment(String department) {

--- a/src/main/java/inu/timetable/dto/CurrentSemesterResponse.java
+++ b/src/main/java/inu/timetable/dto/CurrentSemesterResponse.java
@@ -1,0 +1,4 @@
+package inu.timetable.dto;
+
+public record CurrentSemesterResponse(String semester) {
+}

--- a/src/main/java/inu/timetable/dto/CurrentSemesterUpdateRequest.java
+++ b/src/main/java/inu/timetable/dto/CurrentSemesterUpdateRequest.java
@@ -1,0 +1,4 @@
+package inu.timetable.dto;
+
+public record CurrentSemesterUpdateRequest(String semester) {
+}

--- a/src/main/java/inu/timetable/entity/AppSetting.java
+++ b/src/main/java/inu/timetable/entity/AppSetting.java
@@ -1,0 +1,33 @@
+package inu.timetable.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "app_settings")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AppSetting {
+
+    @Id
+    @Column(name = "setting_key", length = 64)
+    private String settingKey;
+
+    @Column(name = "setting_value", length = 255, nullable = false)
+    private String settingValue;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/inu/timetable/repository/AppSettingRepository.java
+++ b/src/main/java/inu/timetable/repository/AppSettingRepository.java
@@ -1,0 +1,7 @@
+package inu.timetable.repository;
+
+import inu.timetable.entity.AppSetting;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AppSettingRepository extends JpaRepository<AppSetting, String> {
+}

--- a/src/main/java/inu/timetable/repository/SubjectRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectRepository.java
@@ -72,6 +72,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "LEFT JOIN s.schedules sch " +
                         "LEFT JOIN UserTimetable ut ON ut.subject = s " +
                         "WHERE s.active = true " +
+                        "AND (:semester IS NULL OR s.semester = :semester) " +
                         "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
                         "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
                         "AND (:department IS NULL OR s.department LIKE %:department%) " +
@@ -89,6 +90,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "ORDER BY COUNT(DISTINCT ut.user.id) DESC, s.id ASC", countQuery = "SELECT count(DISTINCT s.id) FROM Subject s LEFT JOIN s.schedules sch "
                                         +
                                         "WHERE s.active = true " +
+                                        "AND (:semester IS NULL OR s.semester = :semester) " +
                                         "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
                                         "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
                                         "AND (:department IS NULL OR s.department LIKE %:department%) " +
@@ -103,6 +105,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                                         "AND (:startTime IS NULL OR sch.startTime >= :startTime) " +
                                         "AND (:endTime IS NULL OR sch.endTime <= :endTime)")
         Page<Long> findIdsWithFilters(
+                        @Param("semester") String semester,
                         @Param("subjectName") String subjectName,
                         @Param("professor") String professor,
                         @Param("department") String department,

--- a/src/main/java/inu/timetable/service/AppSettingService.java
+++ b/src/main/java/inu/timetable/service/AppSettingService.java
@@ -1,0 +1,45 @@
+package inu.timetable.service;
+
+import inu.timetable.entity.AppSetting;
+import inu.timetable.repository.AppSettingRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.regex.Pattern;
+
+@Service
+@RequiredArgsConstructor
+public class AppSettingService {
+
+    static final String CURRENT_SEMESTER_KEY = "current_semester";
+    static final String DEFAULT_SEMESTER = "2026-1";
+
+    private static final Pattern SEMESTER_PATTERN = Pattern.compile("^\\d{4}-[12]$");
+
+    private final AppSettingRepository appSettingRepository;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public String getCurrentSemester() {
+        return appSettingRepository.findById(CURRENT_SEMESTER_KEY)
+                .map(AppSetting::getSettingValue)
+                .orElse(DEFAULT_SEMESTER);
+    }
+
+    @Transactional
+    public String updateCurrentSemester(String semester) {
+        if (semester == null || !SEMESTER_PATTERN.matcher(semester).matches()) {
+            throw new IllegalArgumentException("학기 형식이 올바르지 않습니다. (예: 2026-1)");
+        }
+
+        AppSetting setting = AppSetting.builder()
+                .settingKey(CURRENT_SEMESTER_KEY)
+                .settingValue(semester)
+                .updatedAt(LocalDateTime.now(clock))
+                .build();
+        return appSettingRepository.save(setting).getSettingValue();
+    }
+}

--- a/src/main/resources/db/migration/V20260725_01__create_app_settings.sql
+++ b/src/main/resources/db/migration/V20260725_01__create_app_settings.sql
@@ -1,0 +1,7 @@
+-- 애플리케이션 전역 설정 키-값 저장 테이블.
+-- 현재 학기(current_semester) 등 운영자가 전환하는 설정을 보관한다.
+CREATE TABLE IF NOT EXISTS app_settings (
+    setting_key   VARCHAR(64) PRIMARY KEY,
+    setting_value VARCHAR(255) NOT NULL,
+    updated_at    TIMESTAMP NOT NULL
+);

--- a/src/test/java/inu/timetable/controller/AdminSettingsControllerTest.java
+++ b/src/test/java/inu/timetable/controller/AdminSettingsControllerTest.java
@@ -1,0 +1,132 @@
+package inu.timetable.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inu.timetable.controller.CsrfTestSupport.CsrfProof;
+import inu.timetable.entity.AppSetting;
+import inu.timetable.repository.AppSettingRepository;
+import inu.timetable.service.AdminAuthService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+import static inu.timetable.controller.CsrfTestSupport.fetchCsrfProof;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@Transactional
+class AdminSettingsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private AppSettingRepository appSettingRepository;
+
+    @Test
+    @DisplayName("관리자 인증이 없으면 현재 학기 변경을 거부한다")
+    void updateCurrentSemesterRejectsUnauthenticatedRequest() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
+
+        mockMvc.perform(put("/admin/api/settings/current-semester")
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("semester", "2026-2"))))
+                .andExpect(status().isForbidden());
+
+        assertThat(appSettingRepository.findById("current_semester")).isEmpty();
+    }
+
+    @Test
+    @DisplayName("관리자 인증 시 현재 학기를 변경하고 저장한다")
+    void updateCurrentSemesterSavesValueWhenAuthenticated() throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
+
+        mockMvc.perform(put("/admin/api/settings/current-semester")
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("semester", "2026-2"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.semester").value("2026-2"));
+
+        AppSetting saved = appSettingRepository.findById("current_semester").orElseThrow();
+        assertThat(saved.getSettingValue()).isEqualTo("2026-2");
+        assertThat(saved.getUpdatedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("현재 학기를 여러 번 변경하면 마지막 값으로 덮어쓴다")
+    void updateCurrentSemesterOverwritesExistingValue() throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
+
+        mockMvc.perform(put("/admin/api/settings/current-semester")
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("semester", "2026-1"))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(put("/admin/api/settings/current-semester")
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("semester", "2026-2"))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.semester").value("2026-2"));
+
+        AppSetting saved = appSettingRepository.findById("current_semester").orElseThrow();
+        assertThat(saved.getSettingValue()).isEqualTo("2026-2");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"2026-3", "abc", "2026", "26-1", "2026-12"})
+    @DisplayName("잘못된 학기 형식이면 400을 반환하고 저장하지 않는다")
+    void updateCurrentSemesterRejectsInvalidFormat(String invalidSemester) throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
+
+        mockMvc.perform(put("/admin/api/settings/current-semester")
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of("semester", invalidSemester))))
+                .andExpect(status().isBadRequest());
+
+        assertThat(appSettingRepository.findById("current_semester")).isEmpty();
+    }
+
+    private MockHttpSession adminSession() {
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(AdminAuthService.SESSION_AUTHENTICATED, true);
+        session.setAttribute(AdminAuthService.SESSION_USERNAME, "admin");
+        return session;
+    }
+}

--- a/src/test/java/inu/timetable/controller/SettingsControllerTest.java
+++ b/src/test/java/inu/timetable/controller/SettingsControllerTest.java
@@ -1,0 +1,53 @@
+package inu.timetable.controller;
+
+import inu.timetable.entity.AppSetting;
+import inu.timetable.repository.AppSettingRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@Transactional
+class SettingsControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private AppSettingRepository appSettingRepository;
+
+    @Test
+    @DisplayName("현재 학기 설정이 없으면 기본값 2026-1을 반환한다")
+    void getCurrentSemesterReturnsFallbackWhenSettingMissing() throws Exception {
+        mockMvc.perform(get("/api/settings/current-semester"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.semester").value("2026-1"));
+    }
+
+    @Test
+    @DisplayName("현재 학기 설정이 저장되어 있으면 저장된 값을 반환한다")
+    void getCurrentSemesterReturnsStoredValue() throws Exception {
+        appSettingRepository.save(AppSetting.builder()
+                .settingKey("current_semester")
+                .settingValue("2026-2")
+                .updatedAt(LocalDateTime.now())
+                .build());
+
+        mockMvc.perform(get("/api/settings/current-semester"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.semester").value("2026-2"));
+    }
+}

--- a/src/test/java/inu/timetable/controller/SubjectControllerTest.java
+++ b/src/test/java/inu/timetable/controller/SubjectControllerTest.java
@@ -44,6 +44,7 @@ class SubjectControllerTest {
                 nullable(String.class),
                 nullable(String.class),
                 nullable(String.class),
+                nullable(String.class),
                 anyList(),
                 anyInt(),
                 nullable(String.class),
@@ -63,7 +64,7 @@ class SubjectControllerTest {
                 .thenReturn(List.of(count(101L, 7L)));
 
         Page<SubjectDto> result = controller.filterSubjects(
-                null, null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null,
                 null, null, null, null, null, 0, 20);
 
         assertThat(result.getTotalElements()).isEqualTo(2);
@@ -72,6 +73,45 @@ class SubjectControllerTest {
                 .containsExactly(
                         org.assertj.core.groups.Tuple.tuple("운영체제", 7L, 7L),
                         org.assertj.core.groups.Tuple.tuple("자료구조", 0L, 0L));
+    }
+
+    @Test
+    void filterSubjectsPassesTrimmedSemesterToRepository() {
+        Subject targetSubject = subject(201L, "운영체제");
+        PageRequest pageRequest = PageRequest.of(0, 20);
+        SubjectController controller = new SubjectController(subjectRepository, userTimetableRepository);
+
+        when(subjectRepository.findIdsWithFilters(
+                eq("2026-1"),
+                nullable(String.class),
+                nullable(String.class),
+                nullable(String.class),
+                anyList(),
+                anyInt(),
+                nullable(String.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(SubjectType.class),
+                nullable(Integer.class),
+                nullable(Boolean.class),
+                nullable(Integer.class),
+                nullable(Boolean.class),
+                eq(ClassMethod.ONLINE),
+                any()))
+                .thenReturn(new PageImpl<>(List.of(201L), pageRequest, 1));
+        when(subjectRepository.findWithSchedulesByIds(List.of(201L)))
+                .thenReturn(List.of(targetSubject));
+        when(userTimetableRepository.countAddedUsersBySubjectIds(List.of(201L)))
+                .thenReturn(List.of());
+
+        Page<SubjectDto> result = controller.filterSubjects(
+                " 2026-1 ", null, null, null, null, null, null, null,
+                null, null, null, null, null, 0, 20);
+
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent())
+                .extracting(SubjectDto::getSubjectName)
+                .containsExactly("운영체제");
     }
 
     private Subject subject(Long id, String subjectName) {

--- a/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
+++ b/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
@@ -107,7 +107,7 @@ class SubjectRepositoryIntegrationTest {
         entityManager.clear();
 
         Page<Long> unassignedTimeIds = subjectRepository.findIdsWithFilters(
-                null, null, null, Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
                 null, null, null, null, null, null,
                 true, ClassMethod.ONLINE, PageRequest.of(0, 10));
 
@@ -129,13 +129,48 @@ class SubjectRepositoryIntegrationTest {
         entityManager.clear();
 
         Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
-                null, null, null, Arrays.asList("컴퓨터공학부", "임베디드시스템공학과"), 2, null,
+                null, null, null, null, Arrays.asList("컴퓨터공학부", "임베디드시스템공학과"), 2, null,
                 null, null, null, null, null, null,
                 null, ClassMethod.ONLINE, PageRequest.of(0, 10));
 
         assertThat(subjectIds.getContent())
                 .containsExactlyInAnyOrder(computer.getId(), embedded.getId())
                 .doesNotContain(math.getId());
+    }
+
+    @Test
+    void findIdsWithFiltersCanFilterBySemester() {
+        Subject firstSemester = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
+        Subject secondSemester = persistSubject("AI01001002", "2026-2", true, "화", 1.0, 3.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> firstSemesterIds = subjectRepository.findIdsWithFilters(
+                "2026-1", null, null, null, Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, null, null,
+                null, ClassMethod.ONLINE, PageRequest.of(0, 10));
+
+        assertThat(firstSemesterIds.getContent())
+                .containsExactly(firstSemester.getId())
+                .doesNotContain(secondSemester.getId());
+    }
+
+    @Test
+    void findIdsWithFiltersWithoutSemesterReturnsAllSemesters() {
+        Subject firstSemester = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
+        Subject secondSemester = persistSubject("AI01001002", "2026-2", true, "화", 1.0, 3.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
+                null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, null, null,
+                null, ClassMethod.ONLINE, PageRequest.of(0, 10));
+
+        assertThat(subjectIds.getContent())
+                .containsExactlyInAnyOrder(firstSemester.getId(), secondSemester.getId());
     }
 
     @Test
@@ -206,7 +241,7 @@ class SubjectRepositoryIntegrationTest {
         entityManager.clear();
 
         Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
-                null, null, null, Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
                 null, null, null, null, null, null,
                 null, ClassMethod.ONLINE, PageRequest.of(0, 10));
 


### PR DESCRIPTION
## 요약

관리자 페이지에서 버튼 한 번으로 학기를 전환하기 위한 백엔드 API입니다. 프론트 카운터파트는 inu_timetable_front#40 에 포함되어 있습니다(설정 API 미배포 시 기본 학기로 폴백하므로 배포 순서 무관).

### 추가된 API
- `GET /api/settings/current-semester` — 공개 조회. 설정이 없으면 "2026-1" 폴백 (시드 데이터 불필요)
- `PUT /admin/api/settings/current-semester` — body `{"semester":"2026-2"}`. AdminAccessGuard 인증 + CSRF 필수, AdminAuditInterceptor 감사 로그 자동 기록. 형식(`^\d{4}-[12]$`) 불일치 시 400
- `GET /api/subjects/filter` 에 `semester` 파라미터 추가 — null/blank 면 기존 동작 그대로(하위호환). 본 쿼리·count 쿼리 모두 적용

### 스키마
- Flyway `V20260725_01__create_app_settings.sql` — `app_settings` 키-값 테이블. prod(`ddl-auto: validate`)는 기동 시 자동 적용

### 학기 전환 운영 흐름
1. 새 학기 엑셀을 미리 업로드 (semester 필터 덕분에 현재 학기 검색에 섞이지 않음)
2. 전환일에 admin 페이지 "학기 전환" 버튼으로 PUT 호출
3. 학생들은 재배포 없이 새 학기 빈 상태로 시작, 이전 학기 위시리스트/시간표는 학기 키로 보존

## 테스트

- [x] `./gradlew build` — 134개 테스트 통과, 실패 0 (origin/main 리베이스 후 재실행 확인)
- [x] 신규 테스트: 설정 폴백/저장값 조회, 관리자 미인증 거부·변경·형식 오류 400, 리포지토리 semester 필터, 컨트롤러 파라미터 전달
- [ ] 배포 후 확인: Flyway 마이그레이션 적용, admin 페이지에서 실제 전환 1회