### PR TITLE
feat: 관리자 학기 목록 API + 과거 과목 학기 백필

### DIFF
--- a/src/main/java/inu/timetable/controller/AdminSubjectController.java
+++ b/src/main/java/inu/timetable/controller/AdminSubjectController.java
@@ -63,6 +63,13 @@ public class AdminSubjectController {
         return subjectAdminService.getSubject(id);
     }
 
+    // 관리자 화면의 학기 필터 옵션. 비활성 과목의 학기도 포함해 최신순으로 반환한다.
+    @GetMapping("/semesters")
+    public List<String> getSemesters(HttpServletRequest servletRequest) {
+        adminAccessGuard.requireAuthenticated(servletRequest);
+        return subjectRepository.findDistinctSemesters();
+    }
+
     @PutMapping("/{id}")
     public SubjectManagementResponse updateSubject(
             HttpServletRequest servletRequest,

--- a/src/main/java/inu/timetable/repository/SubjectRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectRepository.java
@@ -134,6 +134,10 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
         @Query("SELECT DISTINCT s.grade FROM Subject s WHERE s.active = true AND s.grade IS NOT NULL ORDER BY s.grade")
         List<Integer> findDistinctGrades();
 
+        // 관리자 학기 필터용. 비활성 과목 포함 전체 학기를 최신순으로 반환한다.
+        @Query("SELECT DISTINCT s.semester FROM Subject s WHERE s.semester IS NOT NULL ORDER BY s.semester DESC")
+        List<String> findDistinctSemesters();
+
         @Query("SELECT DISTINCT s FROM Subject s LEFT JOIN FETCH s.schedules")
         List<Subject> findAllWithSchedules();
 

--- a/src/main/resources/db/migration/V20260725_02__backfill_subject_semester.sql
+++ b/src/main/resources/db/migration/V20260725_02__backfill_subject_semester.sql
@@ -1,0 +1,2 @@
+-- 학기 구분 도입 이전에 등록되어 학기 정보가 없는 과목을 2026-1 학기로 백필한다.
+UPDATE subjects SET semester = '2026-1' WHERE semester IS NULL;

--- a/src/test/java/inu/timetable/controller/AdminSubjectControllerTest.java
+++ b/src/test/java/inu/timetable/controller/AdminSubjectControllerTest.java
@@ -29,6 +29,7 @@ import static java.util.Map.entry;
 import static inu.timetable.controller.CsrfTestSupport.fetchCsrfProof;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.groups.Tuple.tuple;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -231,6 +232,45 @@ class AdminSubjectControllerTest {
                 tuple("월", 5.5, 7.0),
                 tuple("목", 8.5, 10.0));
         assertSchedules(savedSubjects, "0011255002", tuple("목", 10.0, 14.0));
+    }
+
+    @Test
+    @DisplayName("학기 목록 API는 관리자 인증 없이는 거부한다")
+    void getSemestersRequiresAdminSession() throws Exception {
+        mockMvc.perform(get("/admin/api/subjects/semesters"))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("학기 목록 API는 등록된 학기를 최신순으로 반환한다")
+    void getSemestersReturnsDistinctSemestersDescending() throws Exception {
+        subjectRepository.save(Subject.builder()
+                .semester("2025-2")
+                .subjectName("학기목록테스트A")
+                .credits(3)
+                .professor("교수A")
+                .subjectType(SubjectType.전심)
+                .classMethod(ClassMethod.OFFLINE)
+                .isNight(false)
+                .build());
+        subjectRepository.save(Subject.builder()
+                .semester("2026-1")
+                .subjectName("학기목록테스트B")
+                .credits(3)
+                .professor("교수B")
+                .subjectType(SubjectType.전심)
+                .classMethod(ClassMethod.OFFLINE)
+                .isNight(false)
+                .build());
+
+        String body = mockMvc.perform(get("/admin/api/subjects/semesters").session(adminSession()))
+                .andExpect(status().isOk())
+                .andReturn().getResponse().getContentAsString(java.nio.charset.StandardCharsets.UTF_8);
+
+        List<String> semesters = objectMapper.readValue(body, objectMapper.getTypeFactory()
+                .constructCollectionType(List.class, String.class));
+        assertThat(semesters).contains("2026-1", "2025-2");
+        assertThat(semesters).isSortedAccordingTo(java.util.Comparator.reverseOrder());
     }
 
     private MockHttpSession adminSession() {


### PR DESCRIPTION
## 요약

관리자 화면의 학기 구분(필터·배지) 지원을 위한 백엔드 작업입니다. 프론트 카운터파트: inu_timetable_front 의 admin 학기 UI PR.

- `GET /admin/api/subjects/semesters` — 등록된 학기 목록(비활성 포함, 최신순), 관리자 인증 필수
- Flyway `V20260725_02` — 학기 정보가 없는 기존 과목을 `2026-1` 로 백필 (학기 구분 도입 이전 데이터 정리)
- 참고: 과목 생성/수정의 semester 처리는 기존 `SubjectManagementRequest` 가 이미 지원 (변경 없음)

## 테스트

- [x] `./gradlew build` 전체 통과
- [x] 신규: 학기 목록 미인증 403 / 등록 학기 최신순 반환