### PR TITLE
fix: 기존 과목을 현재 학기 검색에 포함

### DIFF
--- a/src/main/java/inu/timetable/repository/SubjectRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectRepository.java
@@ -72,7 +72,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "LEFT JOIN s.schedules sch " +
                         "LEFT JOIN UserTimetable ut ON ut.subject = s " +
                         "WHERE s.active = true " +
-                        "AND (:semester IS NULL OR s.semester = :semester) " +
+                        "AND (:semester IS NULL OR s.semester = :semester OR s.semester IS NULL) " +
                         "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
                         "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
                         "AND (:department IS NULL OR s.department LIKE %:department%) " +
@@ -90,7 +90,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "ORDER BY COUNT(DISTINCT ut.user.id) DESC, s.id ASC", countQuery = "SELECT count(DISTINCT s.id) FROM Subject s LEFT JOIN s.schedules sch "
                                         +
                                         "WHERE s.active = true " +
-                                        "AND (:semester IS NULL OR s.semester = :semester) " +
+                                        "AND (:semester IS NULL OR s.semester = :semester OR s.semester IS NULL) " +
                                         "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
                                         "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
                                         "AND (:department IS NULL OR s.department LIKE %:department%) " +

--- a/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
+++ b/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
@@ -142,6 +142,7 @@ class SubjectRepositoryIntegrationTest {
     void findIdsWithFiltersCanFilterBySemester() {
         Subject firstSemester = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
         Subject secondSemester = persistSubject("AI01001002", "2026-2", true, "화", 1.0, 3.0);
+        Subject legacySemester = persistSubject("AI01001003", null, true, "수", 1.0, 3.0);
 
         entityManager.flush();
         entityManager.clear();
@@ -152,7 +153,7 @@ class SubjectRepositoryIntegrationTest {
                 null, ClassMethod.ONLINE, PageRequest.of(0, 10));
 
         assertThat(firstSemesterIds.getContent())
-                .containsExactly(firstSemester.getId())
+                .containsExactlyInAnyOrder(firstSemester.getId(), legacySemester.getId())
                 .doesNotContain(secondSemester.getId());
     }
 


### PR DESCRIPTION
## 문제

현재 학기 설정 도입 후 프론트가 `semester=2026-1`을 전달하지만, 운영의 기존 과목 2,894개는 학기 값이 `NULL`이라 검색 결과에서 모두 제외됐습니다.

## 변경

- 학기별 과목 검색에서 요청 학기와 일치하는 과목뿐 아니라 기존 `NULL` 학기 과목도 포함
- 다른 명시적 학기의 과목은 계속 제외
- 기존 데이터 호환 회귀 테스트 추가

## 검증

- `./gradlew test --tests inu.timetable.repository.SubjectRepositoryIntegrationTest`
- `./gradlew clean test bootJar`
- 변경 전 운영 확인: 전체 과목 `2894`, `semester=2026-1` 검색 `0`