### PR TITLE
feat: 강의계획서 조회 엑셀 업로드 지원

### DIFF
--- a/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
+++ b/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
@@ -177,6 +177,9 @@ public class OfficialSubjectImportService {
             Sheet sheet = workbook.getSheetAt(0);
             DataFormatter formatter = new DataFormatter();
             HeaderInfo headerInfo = findHeader(sheet, formatter);
+            // 공식 종합강의시간표는 "시간표(교시)", 강의계획서 조회는 "시간표" 헤더를 쓴다.
+            Integer timetableColumn = headerInfo.column("시간표(교시)", "시간표");
+            validateFileSemester(sheet, headerInfo, semester, formatter);
             List<OfficialSubjectRecord> records = new ArrayList<>();
             Set<String> courseCodes = new LinkedHashSet<>();
             Set<String> duplicateCourseCodes = new LinkedHashSet<>();
@@ -211,8 +214,8 @@ public class OfficialSubjectImportService {
                         parseGrade(cellValue(row, headerInfo.column("학년"), formatter)),
                         parseSubjectType(cellValue(row, headerInfo.column("이수구분"), formatter)),
                         parseClassMethod(cellValue(row, headerInfo.optionalColumn("수업유형", "수업구분", "수업방법"), formatter)),
-                        hasNightSchedule(cellValue(row, headerInfo.column("시간표(교시)"), formatter)),
-                        parseSchedules(cellValue(row, headerInfo.column("시간표(교시)"), formatter))));
+                        hasNightSchedule(cellValue(row, timetableColumn, formatter)),
+                        parseSchedules(cellValue(row, timetableColumn, formatter))));
             }
 
             if (!duplicateCourseCodes.isEmpty()) {
@@ -220,6 +223,31 @@ public class OfficialSubjectImportService {
                         "중복 학수번호가 있습니다: " + String.join(", ", duplicateCourseCodes));
             }
             return records;
+        }
+    }
+
+    // 강의계획서 조회 파일에는 년도/학기 컬럼이 있으므로, 업로드 시 선택한 학기와
+    // 파일 데이터의 학기가 다르면 잘못된 학기로 반영되는 사고를 막기 위해 거부한다.
+    private void validateFileSemester(Sheet sheet, HeaderInfo headerInfo, String semester, DataFormatter formatter) {
+        Integer yearColumn = headerInfo.optionalColumn("년도");
+        Integer termColumn = headerInfo.optionalColumn("학기");
+        if (yearColumn == null || termColumn == null) {
+            return;
+        }
+
+        for (int rowIndex = headerInfo.rowIndex() + 1; rowIndex <= sheet.getLastRowNum(); rowIndex++) {
+            Row row = sheet.getRow(rowIndex);
+            String year = cellValue(row, yearColumn, formatter).replaceAll("[^0-9]", "");
+            String term = cellValue(row, termColumn, formatter).replaceAll("[^0-9]", "");
+            if (!hasText(year) || !hasText(term)) {
+                continue;
+            }
+            String fileSemester = year + "-" + term;
+            if (!fileSemester.equals(semester)) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
+                        "파일의 학기(" + fileSemester + ")와 업로드 학기(" + semester + ")가 다릅니다.");
+            }
+            return;
         }
     }
 
@@ -518,6 +546,7 @@ public class OfficialSubjectImportService {
         }
         if (normalized.contains("ONLINE")
                 || normalized.contains("E-LEARNING")
+                || normalized.contains("MOOC")
                 || normalized.contains("온라인")
                 || normalized.contains("비대면")) {
             return ClassMethod.ONLINE;
@@ -541,8 +570,16 @@ public class OfficialSubjectImportService {
         if (!hasText(credits)) {
             return 0;
         }
-        String numeric = credits.replaceAll("[^0-9]", "");
-        return hasText(numeric) ? Integer.parseInt(numeric) : 0;
+        // 강의계획서 조회 파일은 "3.0"처럼 소수점으로 표기된다. 소수점을 버리면 30이 되므로 실수로 파싱한다.
+        String numeric = credits.replaceAll("[^0-9.]", "");
+        if (!hasText(numeric)) {
+            return 0;
+        }
+        try {
+            return (int) Math.round(Double.parseDouble(numeric));
+        } catch (NumberFormatException exception) {
+            return 0;
+        }
     }
 
     private boolean hasNightSchedule(String timeSchedule) {
@@ -577,12 +614,15 @@ public class OfficialSubjectImportService {
     }
 
     private record HeaderInfo(int rowIndex, Map<String, Integer> columns) {
-        Integer column(String name) {
-            Integer index = columns.get(name);
-            if (index == null) {
-                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "필수 컬럼이 없습니다: " + name);
+        // 이름 후보를 순서대로 조회한다(파일 형식별 헤더 표기 차이 흡수).
+        Integer column(String... names) {
+            for (String name : names) {
+                Integer index = columns.get(name);
+                if (index != null) {
+                    return index;
+                }
             }
-            return index;
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "필수 컬럼이 없습니다: " + String.join("/", names));
         }
 
         Integer optionalColumn(String... names) {

--- a/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
+++ b/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
@@ -23,7 +23,10 @@ import java.io.ByteArrayOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.web.server.ResponseStatusException;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.verify;
@@ -106,6 +109,105 @@ class OfficialSubjectImportServiceTest {
         assertThat(schedule.getDayOfWeek()).isEqualTo("금");
         assertThat(schedule.getStartTime()).isEqualTo(5.0);
         assertThat(schedule.getEndTime()).isEqualTo(9.0);
+    }
+
+    @Test
+    void previewParsesSyllabusFormatWorkbook() throws Exception {
+        when(subjectRepository.findImportCandidatesBySemester("2026-1")).thenReturn(List.of());
+
+        OfficialSubjectImportResponse response = officialSubjectImportService.preview(syllabusWorkbook(), "2026-1");
+
+        assertThat(response.getTotalRows()).isEqualTo(2);
+        assertThat(response.getAddedCount()).isEqualTo(2);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void applyParsesSyllabusFormatValues() throws Exception {
+        when(subjectRepository.findImportCandidatesBySemester("2026-1")).thenReturn(List.of());
+
+        officialSubjectImportService.apply(syllabusWorkbook(), "2026-1", true);
+
+        ArgumentCaptor<List<Subject>> captor = ArgumentCaptor.forClass(List.class);
+        verify(subjectRepository).saveAll(captor.capture());
+        List<Subject> saved = captor.getValue();
+
+        Subject offline = saved.stream()
+                .filter(subject -> "HS90001001".equals(subject.getCourseCode()))
+                .findFirst().orElseThrow();
+        // 강의계획서 학점 표기 "3.0" 은 30이 아니라 3으로 파싱되어야 한다.
+        assertThat(offline.getCredits()).isEqualTo(3);
+        assertThat(offline.getSubjectType()).isEqualTo(SubjectType.전심);
+        assertThat(offline.getClassMethod()).isEqualTo(ClassMethod.OFFLINE);
+        assertThat(offline.getSchedules()).hasSize(1);
+        Schedule schedule = offline.getSchedules().get(0);
+        assertThat(schedule.getDayOfWeek()).isEqualTo("목");
+        assertThat(schedule.getStartTime()).isEqualTo(2.0);
+        assertThat(schedule.getEndTime()).isEqualTo(5.0);
+
+        Subject mooc = saved.stream()
+                .filter(subject -> "HS90002001".equals(subject.getCourseCode()))
+                .findFirst().orElseThrow();
+        assertThat(mooc.getCredits()).isEqualTo(2);
+        assertThat(mooc.getClassMethod()).isEqualTo(ClassMethod.ONLINE);
+        assertThat(mooc.getIsNight()).isTrue();
+    }
+
+    @Test
+    void previewRejectsSemesterMismatchAgainstSyllabusFile() {
+        assertThatThrownBy(() -> officialSubjectImportService.preview(syllabusWorkbook(), "2026-2"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("2026-1");
+    }
+
+    private MockMultipartFile syllabusWorkbook() throws Exception {
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("sheet1");
+            // 강의계획서 조회 파일은 1행이 곧 헤더이고 시간표 컬럼명이 "시간표" 다.
+            Row header = sheet.createRow(0);
+            List<String> headers = List.of(
+                    "0", "순번", "년도", "학기", "소속분류", "학과(부)", "이수구분", "학년", "학수번호", "교과목명",
+                    "수업방법", "담당교수", "강의계획서입력여부", "시간표", "학점", "총시수", "이론", "실습",
+                    "과정", "이수영역", "수업구분", "수업유형");
+            for (int index = 0; index < headers.size(); index++) {
+                header.createCell(index).setCellValue(headers.get(index));
+            }
+
+            createSyllabusRow(sheet, 1, "HS90001001", "포용의문화", "전공심화", "1",
+                    " [ZZ-200:목(2)(3)(4)]", "3.0", "강의(이론)");
+            createSyllabusRow(sheet, 2, "HS90002001", "야간무크과목", "기초교양", "2",
+                    " [ZZ-200:금(야1)(야2)]", "2.0", "K-MOOC");
+
+            workbook.write(outputStream);
+            return new MockMultipartFile(
+                    "file",
+                    "syllabus.xlsx",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    outputStream.toByteArray());
+        }
+    }
+
+    private void createSyllabusRow(
+            Sheet sheet, int rowIndex, String courseCode, String subjectName,
+            String subjectType, String grade, String timetable, String credits, String classType) {
+        Row row = sheet.createRow(rowIndex);
+        row.createCell(0).setCellValue("0");
+        row.createCell(1).setCellValue(String.valueOf(rowIndex));
+        row.createCell(2).setCellValue("2026");
+        row.createCell(3).setCellValue("1학기");
+        row.createCell(4).setCellValue("기타");
+        row.createCell(5).setCellValue("HUSS(타대학)");
+        row.createCell(6).setCellValue(subjectType);
+        row.createCell(7).setCellValue(grade);
+        row.createCell(8).setCellValue(courseCode);
+        row.createCell(9).setCellValue(subjectName);
+        row.createCell(10).setCellValue("-");
+        row.createCell(11).setCellValue("테스트교수");
+        row.createCell(12).setCellValue("입력");
+        row.createCell(13).setCellValue(timetable);
+        row.createCell(14).setCellValue(credits);
+        row.createCell(21).setCellValue(classType);
     }
 
     private MockMultipartFile sampleWorkbook() throws Exception {


### PR DESCRIPTION
## 요약

admin 과목 업로드가 공식 종합강의시간표 엑셀만 지원했는데, 학교 포털의 **강의계획서 조회** 엑셀도 같은 플로우로 반영할 수 있게 합니다.

### 형식 차이와 대응
| 항목 | 공식 시간표 | 강의계획서 조회 | 대응 |
|---|---|---|---|
| 시간표 헤더 | `시간표(교시)` | `시간표` | 두 이름 모두 허용 |
| 학점 표기 | `3` | `3.0` | 실수 파싱 (기존엔 **30학점**으로 오파싱되는 버그) |
| 수업유형 | 강의(이론) 등 | K-MOOC 포함 | K-MOOC → ONLINE 분류 추가 |
| 년도/학기 컬럼 | 없음 | 있음 | 업로드 학기와 대조, 불일치 시 400 (오업로드 방지) |

시간표 토큰 문법(교시/야간/반교시 A·B, 복수 강의실 브래킷)은 두 형식이 동일해 기존 파서를 그대로 사용합니다. 이수구분 풀네임(전공심화 등), 전학년, e-Learning 매핑도 기존 로직으로 호환 확인.

## 테스트

- [x] `./gradlew build` 전체 통과
- [x] 신규 단위 테스트 3건: 계획서 형식 preview/apply 값 검증(학점 3.0→3, 시간표 목 2~5교시, 야간, K-MOOC→ONLINE), 학기 불일치 400
- [x] **실제 강의계획서 조회 파일(2026-1, 2,422과목) 스모크**: 전량 파싱 성공, 시간표 없는 115과목은 기존 경고로 안내, 중복/누락 학수번호 0