### PR TITLE
feat: 엑셀 업로드 미리보기에 파일 형식 감지 결과 노출

### DIFF
--- a/src/main/java/inu/timetable/dto/OfficialSubjectImportResponse.java
+++ b/src/main/java/inu/timetable/dto/OfficialSubjectImportResponse.java
@@ -13,6 +13,8 @@ public class OfficialSubjectImportResponse {
 
     private boolean applied;
     private String semester;
+    // 감지된 업로드 파일 형식: OFFICIAL_TIMETABLE(종합강의시간표) | SYLLABUS(강의계획서 조회)
+    private String sourceFormat;
     private int totalRows;
     private int addedCount;
     private int modifiedCount;

--- a/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
+++ b/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
@@ -51,16 +51,17 @@ public class OfficialSubjectImportService {
     @Transactional(readOnly = true)
     public OfficialSubjectImportResponse preview(MultipartFile file, String semester) throws IOException {
         String normalizedSemester = normalizeSemester(semester);
-        List<OfficialSubjectRecord> records = parseOfficialExcel(file, normalizedSemester);
-        ImportDiff diff = diff(records, loadImportCandidates(normalizedSemester));
-        return toResponse(false, normalizedSemester, records, diff, true);
+        ParsedWorkbook parsed = parseOfficialExcel(file, normalizedSemester);
+        ImportDiff diff = diff(parsed.records(), loadImportCandidates(normalizedSemester));
+        return toResponse(false, normalizedSemester, parsed.sourceFormat(), parsed.records(), diff, true);
     }
 
     @Transactional
     public OfficialSubjectImportResponse apply(MultipartFile file, String semester, boolean deactivateMissing)
             throws IOException {
         String normalizedSemester = normalizeSemester(semester);
-        List<OfficialSubjectRecord> records = parseOfficialExcel(file, normalizedSemester);
+        ParsedWorkbook parsed = parseOfficialExcel(file, normalizedSemester);
+        List<OfficialSubjectRecord> records = parsed.records();
         List<Subject> candidates = loadImportCandidates(normalizedSemester);
         ImportDiff diff = diff(records, candidates);
 
@@ -84,7 +85,7 @@ public class OfficialSubjectImportService {
         }
 
         eventPublisher.publishEvent(new SubjectDataChangedEvent("official-subject-import"));
-        return toResponse(true, normalizedSemester, records, diff, deactivateMissing);
+        return toResponse(true, normalizedSemester, parsed.sourceFormat(), records, diff, deactivateMissing);
     }
 
     private ImportDiff diff(List<OfficialSubjectRecord> records, List<Subject> candidates) {
@@ -130,6 +131,7 @@ public class OfficialSubjectImportService {
     private OfficialSubjectImportResponse toResponse(
             boolean applied,
             String semester,
+            String sourceFormat,
             List<OfficialSubjectRecord> records,
             ImportDiff diff,
             boolean includeRemoved) {
@@ -151,6 +153,7 @@ public class OfficialSubjectImportService {
         return OfficialSubjectImportResponse.builder()
                 .applied(applied)
                 .semester(semester)
+                .sourceFormat(sourceFormat)
                 .totalRows(records.size())
                 .addedCount(diff.addedSubjects().size())
                 .modifiedCount(diff.modifiedSubjects().size())
@@ -167,7 +170,7 @@ public class OfficialSubjectImportService {
         return subjectRepository.findImportCandidatesBySemester(semester);
     }
 
-    private List<OfficialSubjectRecord> parseOfficialExcel(MultipartFile file, String semester) throws IOException {
+    private ParsedWorkbook parseOfficialExcel(MultipartFile file, String semester) throws IOException {
         if (file == null || file.isEmpty()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Excel file is required");
         }
@@ -179,6 +182,9 @@ public class OfficialSubjectImportService {
             HeaderInfo headerInfo = findHeader(sheet, formatter);
             // 공식 종합강의시간표는 "시간표(교시)", 강의계획서 조회는 "시간표" 헤더를 쓴다.
             Integer timetableColumn = headerInfo.column("시간표(교시)", "시간표");
+            String sourceFormat = headerInfo.optionalColumn("시간표(교시)") != null
+                    ? "OFFICIAL_TIMETABLE"
+                    : "SYLLABUS";
             validateFileSemester(sheet, headerInfo, semester, formatter);
             List<OfficialSubjectRecord> records = new ArrayList<>();
             Set<String> courseCodes = new LinkedHashSet<>();
@@ -222,8 +228,11 @@ public class OfficialSubjectImportService {
                 throw new ResponseStatusException(HttpStatus.BAD_REQUEST,
                         "중복 학수번호가 있습니다: " + String.join(", ", duplicateCourseCodes));
             }
-            return records;
+            return new ParsedWorkbook(records, sourceFormat);
         }
+    }
+
+    private record ParsedWorkbook(List<OfficialSubjectRecord> records, String sourceFormat) {
     }
 
     // 강의계획서 조회 파일에는 년도/학기 컬럼이 있으므로, 업로드 시 선택한 학기와

--- a/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
+++ b/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
@@ -57,6 +57,7 @@ class OfficialSubjectImportServiceTest {
 
         OfficialSubjectImportResponse response = officialSubjectImportService.preview(sampleWorkbook(), "2026-1");
 
+        assertThat(response.getSourceFormat()).isEqualTo("OFFICIAL_TIMETABLE");
         assertThat(response.getTotalRows()).isEqualTo(2);
         assertThat(response.getAddedCount()).isEqualTo(1);
         assertThat(response.getModifiedCount()).isEqualTo(1);
@@ -119,6 +120,7 @@ class OfficialSubjectImportServiceTest {
 
         assertThat(response.getTotalRows()).isEqualTo(2);
         assertThat(response.getAddedCount()).isEqualTo(2);
+        assertThat(response.getSourceFormat()).isEqualTo("SYLLABUS");
     }
 
     @Test


### PR DESCRIPTION
## 요약

#34 후속. preview/apply 응답에 `sourceFormat` 필드를 추가합니다 — `OFFICIAL_TIMETABLE`(종합강의시간표) / `SYLLABUS`(강의계획서 조회). admin 미리보기 화면에서 어떤 형식의 파일이 감지됐는지 반영 전에 배지로 보여주기 위한 것입니다(프론트 카운터파트 별도 PR).

## 테스트
- [x] `./gradlew build` 통과 (형식 감지 단언 2건 추가)