### PR TITLE
feat: 시간 블록 완전 포함 필터 (timeBlocks)

### DIFF
--- a/src/main/java/inu/timetable/controller/SubjectController.java
+++ b/src/main/java/inu/timetable/controller/SubjectController.java
@@ -107,12 +107,13 @@ public class SubjectController {
             @RequestParam(required = false) Boolean isNight,
             @RequestParam(required = false) Boolean unassignedTime,
             @RequestParam(required = false) Integer credits,
+            @RequestParam(required = false) List<String> timeBlocks,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "20") int size) {
         return subjectQueryService.filterSubjects(SubjectFilterCriteria.of(
                 semester, subjectName, professor, courseCode, department, departments, dayOfWeek,
                 startTime, endTime, subjectType, grade, isNight, unassignedTime, credits,
-                Math.max(0, page), clampSize(size)));
+                timeBlocks, Math.max(0, page), clampSize(size)));
     }
 
     private int clampSize(int size) {

--- a/src/main/java/inu/timetable/dto/SubjectFilterCriteria.java
+++ b/src/main/java/inu/timetable/dto/SubjectFilterCriteria.java
@@ -1,10 +1,12 @@
 package inu.timetable.dto;
 
 import inu.timetable.enums.SubjectType;
+import inu.timetable.exception.ApiException;
 
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
+import java.util.regex.Pattern;
 
 public record SubjectFilterCriteria(
         String semester,
@@ -21,8 +23,13 @@ public record SubjectFilterCriteria(
         Boolean isNight,
         Boolean unassignedTime,
         Integer credits,
+        List<String> timeBlocks,
         int page,
         int size) {
+
+    private static final List<String> TIME_BLOCK_DAY_ORDER = List.of("월", "화", "수", "목", "금", "토");
+    private static final Pattern TIME_BLOCK_PATTERN =
+            Pattern.compile("^([월화수목금토]):(\\d+(?:\\.\\d+)?)-(\\d+(?:\\.\\d+)?)$");
 
     public static SubjectFilterCriteria of(
             String semester,
@@ -39,6 +46,7 @@ public record SubjectFilterCriteria(
             Boolean isNight,
             Boolean unassignedTime,
             Integer credits,
+            List<String> timeBlocks,
             int page,
             int size) {
         return new SubjectFilterCriteria(
@@ -56,8 +64,89 @@ public record SubjectFilterCriteria(
                 isNight,
                 unassignedTime,
                 credits,
+                normalizeTimeBlocks(timeBlocks),
                 Math.max(0, page),
                 Math.max(1, Math.min(size, 100)));
+    }
+
+    /**
+     * 요일별 시간 블록 구간을 리포지토리 파라미터로 풀어낸 값.
+     * start/end 는 교시 단위(Double)이며, 선택하지 않은 요일은 null 이다.
+     */
+    public record TimeBlockParams(
+            boolean active,
+            Double monStart, Double monEnd,
+            Double tueStart, Double tueEnd,
+            Double wedStart, Double wedEnd,
+            Double thuStart, Double thuEnd,
+            Double friStart, Double friEnd,
+            Double satStart, Double satEnd) {
+
+        public static TimeBlockParams inactive() {
+            return new TimeBlockParams(false,
+                    null, null, null, null, null, null,
+                    null, null, null, null, null, null);
+        }
+    }
+
+    public TimeBlockParams toTimeBlockParams() {
+        if (timeBlocks.isEmpty()) {
+            return TimeBlockParams.inactive();
+        }
+        Double[] ranges = new Double[TIME_BLOCK_DAY_ORDER.size() * 2];
+        for (String block : timeBlocks) {
+            var matcher = TIME_BLOCK_PATTERN.matcher(block);
+            if (!matcher.matches()) {
+                throw invalidTimeBlock(block);
+            }
+            int dayIndex = TIME_BLOCK_DAY_ORDER.indexOf(matcher.group(1));
+            ranges[dayIndex * 2] = Double.parseDouble(matcher.group(2));
+            ranges[dayIndex * 2 + 1] = Double.parseDouble(matcher.group(3));
+        }
+        return new TimeBlockParams(true,
+                ranges[0], ranges[1], ranges[2], ranges[3], ranges[4], ranges[5],
+                ranges[6], ranges[7], ranges[8], ranges[9], ranges[10], ranges[11]);
+    }
+
+    private static List<String> normalizeTimeBlocks(List<String> timeBlocks) {
+        if (timeBlocks == null) {
+            return List.of();
+        }
+        List<String> normalized = timeBlocks.stream()
+                .filter(Objects::nonNull)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .toList();
+        long distinctDays = normalized.stream()
+                .map(SubjectFilterCriteria::validateTimeBlock)
+                .distinct()
+                .count();
+        if (distinctDays < normalized.size()) {
+            throw ApiException.badRequest("timeBlocks에 같은 요일을 중복해서 지정할 수 없습니다.");
+        }
+        return normalized.stream()
+                .sorted((a, b) -> Integer.compare(
+                        TIME_BLOCK_DAY_ORDER.indexOf(a.substring(0, 1)),
+                        TIME_BLOCK_DAY_ORDER.indexOf(b.substring(0, 1))))
+                .toList();
+    }
+
+    private static String validateTimeBlock(String block) {
+        var matcher = TIME_BLOCK_PATTERN.matcher(block);
+        if (!matcher.matches()) {
+            throw invalidTimeBlock(block);
+        }
+        double start = Double.parseDouble(matcher.group(2));
+        double end = Double.parseDouble(matcher.group(3));
+        if (start > end) {
+            throw invalidTimeBlock(block);
+        }
+        return matcher.group(1);
+    }
+
+    private static ApiException invalidTimeBlock(String block) {
+        return ApiException.badRequest(
+                "timeBlocks 형식이 올바르지 않습니다: '" + block + "' (예: 수:4-10)");
     }
 
     private static String trimToNull(String value) {

--- a/src/main/java/inu/timetable/repository/SubjectRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectRepository.java
@@ -16,6 +16,19 @@ import java.util.Optional;
 @Repository
 public interface SubjectRepository extends JpaRepository<Subject, Long> {
 
+        // 시간 블록 완전 포함 필터.
+        // 과목의 모든 스케줄이 요일별 선택 구간 안에 완전히 포함되어야 한다(위반 스케줄이 하나도 없어야 함).
+        // 스케줄이 없는 과목(온라인 등)은 NOT EXISTS 가 자동으로 만족되어 포함된다.
+        String TIME_BLOCK_CONTAINMENT_CLAUSE = " AND (:timeBlocksActive = false OR NOT EXISTS (" +
+                        "SELECT 1 FROM Schedule vs WHERE vs.subject = s AND NOT (" +
+                        "(vs.dayOfWeek = '월' AND :monStart IS NOT NULL AND vs.startTime >= :monStart AND vs.endTime <= :monEnd) " +
+                        "OR (vs.dayOfWeek = '화' AND :tueStart IS NOT NULL AND vs.startTime >= :tueStart AND vs.endTime <= :tueEnd) " +
+                        "OR (vs.dayOfWeek = '수' AND :wedStart IS NOT NULL AND vs.startTime >= :wedStart AND vs.endTime <= :wedEnd) " +
+                        "OR (vs.dayOfWeek = '목' AND :thuStart IS NOT NULL AND vs.startTime >= :thuStart AND vs.endTime <= :thuEnd) " +
+                        "OR (vs.dayOfWeek = '금' AND :friStart IS NOT NULL AND vs.startTime >= :friStart AND vs.endTime <= :friEnd) " +
+                        "OR (vs.dayOfWeek = '토' AND :satStart IS NOT NULL AND vs.startTime >= :satStart AND vs.endTime <= :satEnd)" +
+                        "))) ";
+
         List<Subject> findBySubjectType(SubjectType subjectType);
 
         List<Subject> findBySubjectTypeAndActiveTrue(SubjectType subjectType);
@@ -87,6 +100,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "AND (:dayOfWeek IS NULL OR sch.dayOfWeek = :dayOfWeek) " +
                         "AND (:startTime IS NULL OR sch.startTime >= :startTime) " +
                         "AND (:endTime IS NULL OR sch.endTime <= :endTime) " +
+                        TIME_BLOCK_CONTAINMENT_CLAUSE +
                         "GROUP BY s.id " +
                         "ORDER BY COUNT(DISTINCT ut.user.id) DESC, s.id ASC", countQuery = "SELECT count(DISTINCT s.id) FROM Subject s LEFT JOIN s.schedules sch "
                                         +
@@ -105,7 +119,8 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                                         "(:unassignedTime = true AND (s.classMethod = :onlineClassMethod OR sch.id IS NULL))) " +
                                         "AND (:dayOfWeek IS NULL OR sch.dayOfWeek = :dayOfWeek) " +
                                         "AND (:startTime IS NULL OR sch.startTime >= :startTime) " +
-                                        "AND (:endTime IS NULL OR sch.endTime <= :endTime)")
+                                        "AND (:endTime IS NULL OR sch.endTime <= :endTime)" +
+                                        TIME_BLOCK_CONTAINMENT_CLAUSE)
         Page<Long> findIdsWithFilters(
                         @Param("semester") String semester,
                         @Param("subjectName") String subjectName,
@@ -123,6 +138,19 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         @Param("credits") Integer credits,
                         @Param("unassignedTime") Boolean unassignedTime,
                         @Param("onlineClassMethod") ClassMethod onlineClassMethod,
+                        @Param("timeBlocksActive") boolean timeBlocksActive,
+                        @Param("monStart") Double monStart,
+                        @Param("monEnd") Double monEnd,
+                        @Param("tueStart") Double tueStart,
+                        @Param("tueEnd") Double tueEnd,
+                        @Param("wedStart") Double wedStart,
+                        @Param("wedEnd") Double wedEnd,
+                        @Param("thuStart") Double thuStart,
+                        @Param("thuEnd") Double thuEnd,
+                        @Param("friStart") Double friStart,
+                        @Param("friEnd") Double friEnd,
+                        @Param("satStart") Double satStart,
+                        @Param("satEnd") Double satEnd,
                         Pageable pageable);
 
         @Query("SELECT DISTINCT s FROM Subject s LEFT JOIN FETCH s.schedules WHERE s.active = true AND s.id IN :subjectIds")

--- a/src/main/java/inu/timetable/service/SubjectCacheWarmupService.java
+++ b/src/main/java/inu/timetable/service/SubjectCacheWarmupService.java
@@ -91,7 +91,7 @@ public class SubjectCacheWarmupService {
         tasks.add(new WarmupTask("default-filter", () -> {
             subjectQueryService.filterSubjects(SubjectFilterCriteria.of(
                     null, null, null, null, null, List.of(), null,
-                    null, null, null, null, null, null, null, 0, pageSize));
+                    null, null, null, null, null, null, null, null, 0, pageSize));
             return "default-filter";
         }));
 
@@ -99,7 +99,7 @@ public class SubjectCacheWarmupService {
             tasks.add(new WarmupTask("grade-filter-" + grade, () -> {
                 subjectQueryService.filterSubjects(SubjectFilterCriteria.of(
                         null, null, null, null, null, List.of(), null,
-                        null, null, null, grade, null, null, null, 0, pageSize));
+                        null, null, null, grade, null, null, null, null, 0, pageSize));
                 return "grade-filter-" + grade;
             }));
         }

--- a/src/main/java/inu/timetable/service/SubjectFilterCacheService.java
+++ b/src/main/java/inu/timetable/service/SubjectFilterCacheService.java
@@ -43,6 +43,7 @@ public class SubjectFilterCacheService {
         List<String> departmentListParam = departments.isEmpty()
                 ? List.of("__unused_department__")
                 : departments;
+        SubjectFilterCriteria.TimeBlockParams timeBlockParams = criteria.toTimeBlockParams();
         Page<Long> subjectIdPage = subjectRepository.findIdsWithFilters(
                 criteria.semester(),
                 criteria.subjectName(),
@@ -60,6 +61,19 @@ public class SubjectFilterCacheService {
                 criteria.credits(),
                 criteria.unassignedTime(),
                 ClassMethod.ONLINE,
+                timeBlockParams.active(),
+                timeBlockParams.monStart(),
+                timeBlockParams.monEnd(),
+                timeBlockParams.tueStart(),
+                timeBlockParams.tueEnd(),
+                timeBlockParams.wedStart(),
+                timeBlockParams.wedEnd(),
+                timeBlockParams.thuStart(),
+                timeBlockParams.thuEnd(),
+                timeBlockParams.friStart(),
+                timeBlockParams.friEnd(),
+                timeBlockParams.satStart(),
+                timeBlockParams.satEnd(),
                 pageable);
 
         List<Long> subjectIds = subjectIdPage.getContent();

--- a/src/test/java/inu/timetable/controller/SubjectControllerTest.java
+++ b/src/test/java/inu/timetable/controller/SubjectControllerTest.java
@@ -2,6 +2,7 @@ package inu.timetable.controller;
 
 import inu.timetable.dto.SubjectDto;
 import inu.timetable.dto.SubjectFilterCriteria;
+import inu.timetable.exception.ApiException;
 import inu.timetable.repository.SubjectRepository;
 import inu.timetable.service.SubjectQueryService;
 import org.junit.jupiter.api.Test;
@@ -10,10 +11,12 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -32,16 +35,57 @@ class SubjectControllerTest {
         SubjectFilterCriteria criteria = SubjectFilterCriteria.of(
                 " 2026-1 ", " 자료구조 ", null, null, "전체",
                 List.of("컴퓨터공학부, 정보통신공학과", "전체"),
-                null, null, null, null, null, null, true, null, 0, 100);
+                null, null, null, null, null, null, true, null, null, 0, 100);
         Page<SubjectDto> expected = new PageImpl<>(List.of(), PageRequest.of(0, 100), 0);
         when(subjectQueryService.filterSubjects(criteria)).thenReturn(expected);
 
         Page<SubjectDto> result = controller.filterSubjects(
                 " 2026-1 ", " 자료구조 ", null, null, "전체",
                 List.of("컴퓨터공학부, 정보통신공학과", "전체"),
-                null, null, null, null, null, null, true, null, -1, 500);
+                null, null, null, null, null, null, true, null, null, -1, 500);
 
         assertThat(result).isSameAs(expected);
         verify(subjectQueryService).filterSubjects(criteria);
+    }
+
+    @Test
+    void filterSubjectsPassesTimeBlocksToQueryService() {
+        SubjectController controller = new SubjectController(subjectRepository, subjectQueryService);
+        List<String> timeBlocks = List.of("금:4-9", "수:4-10");
+        SubjectFilterCriteria criteria = SubjectFilterCriteria.of(
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, timeBlocks, 0, 20);
+        Page<SubjectDto> expected = new PageImpl<>(List.of(), PageRequest.of(0, 20), 0);
+        when(subjectQueryService.filterSubjects(criteria)).thenReturn(expected);
+
+        Page<SubjectDto> result = controller.filterSubjects(
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null, timeBlocks, 0, 20);
+
+        assertThat(result).isSameAs(expected);
+        // 요일 순서(월화수목금토)로 정렬되어 캐시 키가 안정화된다.
+        verify(subjectQueryService).filterSubjects(criteria);
+        assertThat(criteria.timeBlocks()).containsExactly("수:4-10", "금:4-9");
+    }
+
+    @Test
+    void filterSubjectsRejectsMalformedTimeBlocks() {
+        SubjectController controller = new SubjectController(subjectRepository, subjectQueryService);
+
+        assertThatThrownBy(() -> controller.filterSubjects(
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null,
+                List.of("월:abc"), 0, 20))
+                .isInstanceOf(ApiException.class)
+                .satisfies(exception -> assertThat(((ApiException) exception).getStatus())
+                        .isEqualTo(HttpStatus.BAD_REQUEST));
+
+        assertThatThrownBy(() -> controller.filterSubjects(
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null,
+                List.of("일:1-2"), 0, 20))
+                .isInstanceOf(ApiException.class)
+                .satisfies(exception -> assertThat(((ApiException) exception).getStatus())
+                        .isEqualTo(HttpStatus.BAD_REQUEST));
     }
 }

--- a/src/test/java/inu/timetable/dto/SubjectFilterCriteriaTest.java
+++ b/src/test/java/inu/timetable/dto/SubjectFilterCriteriaTest.java
@@ -1,0 +1,82 @@
+package inu.timetable.dto;
+
+import inu.timetable.exception.ApiException;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class SubjectFilterCriteriaTest {
+
+    @Test
+    void ofNormalizesTimeBlocksToDayOrderForStableCacheKey() {
+        SubjectFilterCriteria criteria = criteriaWithTimeBlocks(
+                Arrays.asList(" 금:4-9 ", "수:4-10", null, " "));
+
+        assertThat(criteria.timeBlocks()).containsExactly("수:4-10", "금:4-9");
+
+        SubjectFilterCriteria sameCriteria = criteriaWithTimeBlocks(List.of("수:4-10", "금:4-9"));
+        assertThat(criteria).isEqualTo(sameCriteria);
+    }
+
+    @Test
+    void ofNormalizesMissingTimeBlocksToEmptyList() {
+        assertThat(criteriaWithTimeBlocks(null).timeBlocks()).isEmpty();
+        assertThat(criteriaWithTimeBlocks(List.of()).timeBlocks()).isEmpty();
+    }
+
+    @Test
+    void ofRejectsMalformedTimeBlocks() {
+        for (String invalid : List.of("월:abc", "일:1-2", "수:4~10", "수4-10", "수:9-4")) {
+            assertThatThrownBy(() -> criteriaWithTimeBlocks(List.of(invalid)))
+                    .isInstanceOf(ApiException.class)
+                    .satisfies(exception -> assertThat(((ApiException) exception).getStatus())
+                            .isEqualTo(HttpStatus.BAD_REQUEST));
+        }
+    }
+
+    @Test
+    void ofRejectsDuplicateDaysInTimeBlocks() {
+        assertThatThrownBy(() -> criteriaWithTimeBlocks(List.of("수:1-3", "수:4-10")))
+                .isInstanceOf(ApiException.class)
+                .satisfies(exception -> assertThat(((ApiException) exception).getStatus())
+                        .isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void toTimeBlockParamsExpandsBlocksIntoPerDayRanges() {
+        SubjectFilterCriteria criteria = criteriaWithTimeBlocks(List.of("수:4-10", "금:4.5-9"));
+
+        SubjectFilterCriteria.TimeBlockParams params = criteria.toTimeBlockParams();
+
+        assertThat(params.active()).isTrue();
+        assertThat(params.wedStart()).isEqualTo(4.0);
+        assertThat(params.wedEnd()).isEqualTo(10.0);
+        assertThat(params.friStart()).isEqualTo(4.5);
+        assertThat(params.friEnd()).isEqualTo(9.0);
+        assertThat(params.monStart()).isNull();
+        assertThat(params.tueStart()).isNull();
+        assertThat(params.thuStart()).isNull();
+        assertThat(params.satStart()).isNull();
+    }
+
+    @Test
+    void toTimeBlockParamsIsInactiveWithoutTimeBlocks() {
+        SubjectFilterCriteria.TimeBlockParams params = criteriaWithTimeBlocks(null).toTimeBlockParams();
+
+        assertThat(params.active()).isFalse();
+        assertThat(params.monStart()).isNull();
+        assertThat(params.satEnd()).isNull();
+    }
+
+    private SubjectFilterCriteria criteriaWithTimeBlocks(List<String> timeBlocks) {
+        return SubjectFilterCriteria.of(
+                null, null, null, null, null, null,
+                null, null, null, null, null, null, null, null,
+                timeBlocks, 0, 20);
+    }
+}

--- a/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
+++ b/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
@@ -109,7 +109,9 @@ class SubjectRepositoryIntegrationTest {
         Page<Long> unassignedTimeIds = subjectRepository.findIdsWithFilters(
                 null, null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
                 null, null, null, null, null, null,
-                true, ClassMethod.ONLINE, PageRequest.of(0, 10));
+                true, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
 
         assertThat(unassignedTimeIds.getContent())
                 .containsExactlyInAnyOrder(unscheduledOffline.getId(), scheduledOnline.getId())
@@ -127,7 +129,9 @@ class SubjectRepositoryIntegrationTest {
         Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
                 null, null, null, "AIA6086", null, Collections.singletonList("__unused_department__"), 0, null,
                 null, null, null, null, null, null,
-                null, ClassMethod.ONLINE, PageRequest.of(0, 10));
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
 
         assertThat(subjectIds.getContent()).containsExactly(matched.getId());
     }
@@ -147,7 +151,9 @@ class SubjectRepositoryIntegrationTest {
         Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
                 null, null, null, null, null, Arrays.asList("컴퓨터공학부", "임베디드시스템공학과"), 2, null,
                 null, null, null, null, null, null,
-                null, ClassMethod.ONLINE, PageRequest.of(0, 10));
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
 
         assertThat(subjectIds.getContent())
                 .containsExactlyInAnyOrder(computer.getId(), embedded.getId())
@@ -166,7 +172,9 @@ class SubjectRepositoryIntegrationTest {
         Page<Long> firstSemesterIds = subjectRepository.findIdsWithFilters(
                 "2026-1", null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
                 null, null, null, null, null, null,
-                null, ClassMethod.ONLINE, PageRequest.of(0, 10));
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
 
         assertThat(firstSemesterIds.getContent())
                 .containsExactlyInAnyOrder(firstSemester.getId(), legacySemester.getId())
@@ -184,10 +192,67 @@ class SubjectRepositoryIntegrationTest {
         Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
                 null, null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
                 null, null, null, null, null, null,
-                null, ClassMethod.ONLINE, PageRequest.of(0, 10));
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
 
         assertThat(subjectIds.getContent())
                 .containsExactlyInAnyOrder(firstSemester.getId(), secondSemester.getId());
+    }
+
+    @Test
+    void findIdsWithFiltersKeepsOnlySubjectsFullyContainedInTimeBlocks() {
+        // 사용자 시나리오: 수 12~18시(4~10교시), 금 12~17시(4~9교시) 선택
+        Subject fridayContained = persistSubject("AI01001001", "2026-1", true, "금", 7.0, 9.0);
+        Subject tuesdayOnly = persistSubject("AI01001002", "2026-1", true, "화", 1.0, 2.0);
+        Subject fridayOverflow = persistSubject("AI01001003", "2026-1", true, "수", 5.0, 7.0);
+        persistSchedule(fridayOverflow, "금", 8.0, 10.0);
+        Subject unscheduled = persistSubject("AI01001004", "2026-1", true, null, null, null);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> subjectIds = findIdsWithWedFriTimeBlocks(4.0, 10.0, 4.0, 9.0);
+
+        assertThat(subjectIds.getContent())
+                .containsExactlyInAnyOrder(fridayContained.getId(), unscheduled.getId())
+                .doesNotContain(tuesdayOnly.getId(), fridayOverflow.getId());
+    }
+
+    @Test
+    void findIdsWithFiltersWithoutTimeBlocksReturnsAllActiveSubjects() {
+        Subject monday = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
+        Subject tuesday = persistSubject("AI01001002", "2026-1", true, "화", 1.0, 2.0);
+        Subject unscheduled = persistSubject("AI01001003", "2026-1", true, null, null, null);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
+                null, null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, null, null,
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
+
+        assertThat(subjectIds.getContent())
+                .containsExactlyInAnyOrder(monday.getId(), tuesday.getId(), unscheduled.getId());
+    }
+
+    private Page<Long> findIdsWithWedFriTimeBlocks(
+            Double wedStart, Double wedEnd, Double friStart, Double friEnd) {
+        return subjectRepository.findIdsWithFilters(
+                null, null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, null, null,
+                null, ClassMethod.ONLINE,
+                true,
+                null, null,
+                null, null,
+                wedStart, wedEnd,
+                null, null,
+                friStart, friEnd,
+                null, null,
+                PageRequest.of(0, 10));
     }
 
     @Test
@@ -260,7 +325,9 @@ class SubjectRepositoryIntegrationTest {
         Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
                 null, null, null, null, null, Collections.singletonList("__unused_department__"), 0, null,
                 null, null, null, null, null, null,
-                null, ClassMethod.ONLINE, PageRequest.of(0, 10));
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
 
         assertThat(subjectIds.getContent())
                 .containsExactly(popular.getId(), multiSchedule.getId(), quiet.getId());

--- a/src/test/java/inu/timetable/service/SubjectCacheWarmupServiceTest.java
+++ b/src/test/java/inu/timetable/service/SubjectCacheWarmupServiceTest.java
@@ -31,13 +31,13 @@ class SubjectCacheWarmupServiceTest {
         verify(subjectQueryService).findDistinctDepartments();
         verify(subjectQueryService).filterSubjects(SubjectFilterCriteria.of(
                 null, null, null, null, null, List.of(),
-                null, null, null, null, null, null, null, null, 0, 20));
+                null, null, null, null, null, null, null, null, null, 0, 20));
         verify(subjectQueryService).filterSubjects(SubjectFilterCriteria.of(
                 null, null, null, null, null, List.of(),
-                null, null, null, null, 1, null, null, null, 0, 20));
+                null, null, null, null, 1, null, null, null, null, 0, 20));
         verify(subjectQueryService).filterSubjects(SubjectFilterCriteria.of(
                 null, null, null, null, null, List.of(),
-                null, null, null, null, 2, null, null, null, 0, 20));
+                null, null, null, null, 2, null, null, null, null, 0, 20));
     }
 
     @Test
@@ -64,7 +64,7 @@ class SubjectCacheWarmupServiceTest {
         assertThat(result.succeeded()).isEqualTo(3);
         verify(subjectQueryService).filterSubjects(SubjectFilterCriteria.of(
                 null, null, null, null, null, List.of(),
-                null, null, null, null, null, null, null, null, 0,
+                null, null, null, null, null, null, null, null, null, 0,
                 SubjectFilterCacheService.MAX_CACHEABLE_PAGE_SIZE));
     }
 }

--- a/src/test/java/inu/timetable/service/SubjectQueryServiceCacheTest.java
+++ b/src/test/java/inu/timetable/service/SubjectQueryServiceCacheTest.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
@@ -109,7 +110,7 @@ class SubjectQueryServiceCacheTest {
         Pageable pageable = PageRequest.of(0, 20);
         SubjectFilterCriteria criteria = SubjectFilterCriteria.of(
                 "2026-1", "자료", null, null, "컴퓨터공학부", List.of(),
-                null, null, null, SubjectType.전심, 2, null, null, null, 0, 20);
+                null, null, null, SubjectType.전심, 2, null, null, null, null, 0, 20);
         when(subjectRepository.findIdsWithFilters(
                 eq("2026-1"),
                 nullable(String.class),
@@ -127,6 +128,19 @@ class SubjectQueryServiceCacheTest {
                 nullable(Integer.class),
                 nullable(Boolean.class),
                 nullable(ClassMethod.class),
+                anyBoolean(),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
                 any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(1L), pageable, 1));
         when(subjectRepository.findWithSchedulesByIds(List.of(1L)))
@@ -137,7 +151,7 @@ class SubjectQueryServiceCacheTest {
         Page<SubjectDto> first = subjectQueryService.filterSubjects(criteria);
         Page<SubjectDto> second = subjectQueryService.filterSubjects(SubjectFilterCriteria.of(
                 "2026-1", "자료", null, null, "컴퓨터공학부", List.of(),
-                null, null, null, SubjectType.전심, 2, null, null, null, 0, 20));
+                null, null, null, SubjectType.전심, 2, null, null, null, null, 0, 20));
 
         assertThat(first.getContent()).extracting(SubjectDto::getTimetableAddCount).containsExactly(7L);
         assertThat(second.getContent()).extracting(SubjectDto::getTimetableAddCount).containsExactly(7L);
@@ -158,6 +172,19 @@ class SubjectQueryServiceCacheTest {
                 nullable(Integer.class),
                 nullable(Boolean.class),
                 nullable(ClassMethod.class),
+                anyBoolean(),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
                 any(Pageable.class));
         verify(subjectRepository, times(1)).findWithSchedulesByIds(List.of(1L));
         verify(userTimetableRepository, times(1)).countAddedUsersBySubjectIds(List.of(1L));
@@ -183,6 +210,19 @@ class SubjectQueryServiceCacheTest {
                 nullable(Integer.class),
                 nullable(Boolean.class),
                 nullable(ClassMethod.class),
+                anyBoolean(),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
                 any(Pageable.class));
         verify(subjectRepository, times(2)).findWithSchedulesByIds(List.of(1L));
         verify(userTimetableRepository, times(2)).countAddedUsersBySubjectIds(List.of(1L));
@@ -193,7 +233,7 @@ class SubjectQueryServiceCacheTest {
         Pageable pageable = PageRequest.of(0, SubjectFilterCacheService.MAX_CACHEABLE_PAGE_SIZE);
         SubjectFilterCriteria criteria = SubjectFilterCriteria.of(
                 null, null, null, null, null, List.of(),
-                null, null, null, null, null, null, null, null, 0, 101);
+                null, null, null, null, null, null, null, null, null, 0, 101);
         when(subjectRepository.findIdsWithFilters(
                 nullable(String.class),
                 nullable(String.class),
@@ -211,6 +251,19 @@ class SubjectQueryServiceCacheTest {
                 nullable(Integer.class),
                 nullable(Boolean.class),
                 nullable(ClassMethod.class),
+                anyBoolean(),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
                 any(Pageable.class)))
                 .thenReturn(new PageImpl<>(List.of(), pageable, 0));
 
@@ -235,6 +288,19 @@ class SubjectQueryServiceCacheTest {
                 nullable(Integer.class),
                 nullable(Boolean.class),
                 nullable(ClassMethod.class),
+                anyBoolean(),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
+                nullable(Double.class),
                 any(Pageable.class));
     }
 


### PR DESCRIPTION
## 요약

모바일 에타식 시간 그리드(프론트 카운터파트: inu_timetable_front 의 시간 픽커 PR)를 위한 검색 필터입니다.

- `GET /api/subjects/filter` 에 `timeBlocks` 반복 파라미터 추가 — `요일:시작교시-끝교시` (예: `수:4-10&timeBlocks=금:4-9`)
- **완전 포함 시맨틱**: 과목의 **모든** 수업 시간이 선택 구간 안에 들어와야 표시. 한 과목이 금 15~17시 + 화 9~10시에 수업하면, 화가 영역 밖이므로 과목 전체 제외
- 스케줄 없는(온라인) 과목은 시간 제약이 없으므로 포함
- 미지정 시 기존 동작 그대로(하위호환), 기존 dayOfWeek/startTime/endTime 병행 유지
- SubjectFilterCriteria(캐시 키)에 정규화(정렬·검증) 포함 — 형식 오류/중복 요일 400

## 테스트
- [x] `./gradlew build` 전체 통과
- [x] 사용자 시나리오: 수 12~18·금 12~17 필터에서 금 15~17 포함 / 화 9~10 제외 / 수·금 걸친 과목 중 금 초과 제외 / 온라인 포함
- [x] criteria 정규화·400·캐시 키 안정성 6건, 컨트롤러 전달 2건

## 주의
- 일요일 스케줄 과목은 timeBlocks 사용 시 항상 제외됨(요일 파라미터가 월~토) — 현재 데이터엔 일요일 수업 없음