### PR TITLE
feat: 과목 반영 일지 + 시간 변경 충돌 자동 해소

### DIFF
--- a/src/main/java/inu/timetable/config/SecurityConfig.java
+++ b/src/main/java/inu/timetable/config/SecurityConfig.java
@@ -92,6 +92,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/dev/**").permitAll()
                         .requestMatchers("/api/auth/me", "/api/auth/logout").authenticated()
                         .requestMatchers("/api/wishlist/**", "/api/timetable/**", "/api/timetable-combination/**").authenticated()
+                        .requestMatchers("/api/notifications/**").authenticated()
                         .requestMatchers("/api/subjects/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/settings/current-semester").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/events").permitAll()

--- a/src/main/java/inu/timetable/controller/NotificationController.java
+++ b/src/main/java/inu/timetable/controller/NotificationController.java
@@ -1,0 +1,39 @@
+package inu.timetable.controller;
+
+import inu.timetable.dto.UserNotificationResponse;
+import inu.timetable.security.AuthenticatedUser;
+import inu.timetable.service.UserNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 로그인 유저 본인의 1회성 알림 조회/읽음 처리 API.
+ */
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final UserNotificationService userNotificationService;
+
+    @GetMapping("/unread")
+    public ResponseEntity<List<UserNotificationResponse>> getUnreadNotifications(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        return ResponseEntity.ok(userNotificationService.getUnreadNotifications(authenticatedUser.id()));
+    }
+
+    @PostMapping("/read")
+    public ResponseEntity<Map<String, Integer>> markAllRead(
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
+        int readCount = userNotificationService.markAllRead(authenticatedUser.id());
+        return ResponseEntity.ok(Map.of("readCount", readCount));
+    }
+}

--- a/src/main/java/inu/timetable/controller/SubjectUpdateLogController.java
+++ b/src/main/java/inu/timetable/controller/SubjectUpdateLogController.java
@@ -1,0 +1,27 @@
+package inu.timetable.controller;
+
+import inu.timetable.dto.SubjectUpdateLogResponse;
+import inu.timetable.service.SubjectUpdateLogService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * 과목 데이터 업데이트 일지 공개 조회 API. 인증 없이 접근 가능하다.
+ */
+@RestController
+@RequestMapping("/api/subjects/update-logs")
+@RequiredArgsConstructor
+public class SubjectUpdateLogController {
+
+    private final SubjectUpdateLogService subjectUpdateLogService;
+
+    @GetMapping
+    public List<SubjectUpdateLogResponse> getUpdateLogs(@RequestParam(defaultValue = "20") int limit) {
+        return subjectUpdateLogService.getRecentLogs(limit);
+    }
+}

--- a/src/main/java/inu/timetable/dto/SubjectUpdateLogResponse.java
+++ b/src/main/java/inu/timetable/dto/SubjectUpdateLogResponse.java
@@ -1,0 +1,24 @@
+package inu.timetable.dto;
+
+import inu.timetable.entity.SubjectUpdateLog;
+
+import java.time.LocalDateTime;
+
+public record SubjectUpdateLogResponse(
+        LocalDateTime appliedAt,
+        String semester,
+        String sourceFormat,
+        int addedCount,
+        int modifiedCount,
+        int removedCount) {
+
+    public static SubjectUpdateLogResponse fromEntity(SubjectUpdateLog log) {
+        return new SubjectUpdateLogResponse(
+                log.getAppliedAt(),
+                log.getSemester(),
+                log.getSourceFormat(),
+                log.getAddedCount(),
+                log.getModifiedCount(),
+                log.getRemovedCount());
+    }
+}

--- a/src/main/java/inu/timetable/dto/UserNotificationResponse.java
+++ b/src/main/java/inu/timetable/dto/UserNotificationResponse.java
@@ -1,0 +1,18 @@
+package inu.timetable.dto;
+
+import inu.timetable.entity.UserNotification;
+
+import java.time.LocalDateTime;
+
+public record UserNotificationResponse(
+        Long id,
+        String message,
+        LocalDateTime createdAt) {
+
+    public static UserNotificationResponse fromEntity(UserNotification notification) {
+        return new UserNotificationResponse(
+                notification.getId(),
+                notification.getMessage(),
+                notification.getCreatedAt());
+    }
+}

--- a/src/main/java/inu/timetable/entity/SubjectUpdateLog.java
+++ b/src/main/java/inu/timetable/entity/SubjectUpdateLog.java
@@ -1,0 +1,48 @@
+package inu.timetable.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 공식 엑셀 반영 이력(공개 일지). apply 성공 시마다 1행 기록한다.
+ */
+@Entity
+@Table(name = "subject_update_logs")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SubjectUpdateLog {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "applied_at", nullable = false)
+    private LocalDateTime appliedAt;
+
+    @Column(nullable = false, length = 20)
+    private String semester;
+
+    @Column(name = "source_format", length = 32)
+    private String sourceFormat;
+
+    @Column(name = "added_count", nullable = false)
+    private Integer addedCount;
+
+    @Column(name = "modified_count", nullable = false)
+    private Integer modifiedCount;
+
+    @Column(name = "removed_count", nullable = false)
+    private Integer removedCount;
+}

--- a/src/main/java/inu/timetable/entity/UserNotification.java
+++ b/src/main/java/inu/timetable/entity/UserNotification.java
@@ -1,0 +1,46 @@
+package inu.timetable.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 유저 1회성 알림. read_at 이 NULL 이면 미읽음이다.
+ * 알림 성격의 로그라 User 연관을 로딩할 일이 없어 user_id 컬럼만 매핑한다(FK 는 DB 마이그레이션에서 보장).
+ */
+@Entity
+@Table(
+        name = "user_notifications",
+        indexes = @Index(name = "idx_user_notifications_unread", columnList = "user_id, read_at"))
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserNotification {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(nullable = false, length = 500)
+    private String message;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+}

--- a/src/main/java/inu/timetable/repository/SubjectUpdateLogRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectUpdateLogRepository.java
@@ -1,0 +1,14 @@
+package inu.timetable.repository;
+
+import inu.timetable.entity.SubjectUpdateLog;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface SubjectUpdateLogRepository extends JpaRepository<SubjectUpdateLog, Long> {
+
+    List<SubjectUpdateLog> findAllByOrderByAppliedAtDescIdDesc(Pageable pageable);
+}

--- a/src/main/java/inu/timetable/repository/UserNotificationRepository.java
+++ b/src/main/java/inu/timetable/repository/UserNotificationRepository.java
@@ -1,0 +1,22 @@
+package inu.timetable.repository;
+
+import inu.timetable.entity.UserNotification;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface UserNotificationRepository extends JpaRepository<UserNotification, Long> {
+
+    List<UserNotification> findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(Long userId);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE UserNotification n SET n.readAt = :readAt " +
+           "WHERE n.userId = :userId AND n.readAt IS NULL")
+    int markAllRead(@Param("userId") Long userId, @Param("readAt") LocalDateTime readAt);
+}

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -38,6 +38,12 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     @Query("SELECT DISTINCT ut FROM UserTimetable ut JOIN FETCH ut.subject s WHERE ut.user.id = :userId AND ut.semester = :semester")
     List<UserTimetable> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
 
+    // 시간 변경 충돌 검사용: 특정 과목을 해당 학기 시간표에 담아둔 모든 유저 항목을 조회한다.
+    @Query("SELECT ut FROM UserTimetable ut JOIN FETCH ut.user u " +
+           "WHERE ut.subject.id = :subjectId AND ut.semester = :semester")
+    List<UserTimetable> findAllBySubjectIdAndSemesterWithUser(@Param("subjectId") Long subjectId,
+                                                              @Param("semester") String semester);
+
     @Query("SELECT ut.subject.id AS subjectId, COUNT(DISTINCT ut.user.id) AS timetableAddCount " +
            "FROM UserTimetable ut " +
            "WHERE ut.subject.id IN :subjectIds " +

--- a/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
+++ b/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
@@ -47,6 +47,8 @@ public class OfficialSubjectImportService {
 
     private final SubjectRepository subjectRepository;
     private final ApplicationEventPublisher eventPublisher;
+    private final SubjectUpdateLogService subjectUpdateLogService;
+    private final TimetableConflictResolutionService timetableConflictResolutionService;
 
     @Transactional(readOnly = true)
     public OfficialSubjectImportResponse preview(MultipartFile file, String semester) throws IOException {
@@ -84,8 +86,30 @@ public class OfficialSubjectImportService {
             }
         }
 
+        // 시간표가 바뀐 과목은 이미 담아둔 유저 시간표와 겹칠 수 있으므로 같은 트랜잭션에서 충돌을 해소한다.
+        timetableConflictResolutionService.resolveScheduleConflicts(
+                timeChangedSubjects(diff, subjectsToSave), normalizedSemester);
+
+        subjectUpdateLogService.record(
+                normalizedSemester,
+                parsed.sourceFormat(),
+                diff.addedSubjects().size(),
+                diff.modifiedSubjects().size(),
+                deactivateMissing ? diff.removed().size() : 0);
+
         eventPublisher.publishEvent(new SubjectDataChangedEvent("official-subject-import"));
         return toResponse(true, normalizedSemester, parsed.sourceFormat(), records, diff, deactivateMissing);
+    }
+
+    // diff 에서 "시간표" 필드가 변경된 기존 과목만 추린다(스케줄은 applyRecord 로 이미 새 시간으로 갱신됨).
+    private List<Subject> timeChangedSubjects(ImportDiff diff, List<Subject> subjectsToSave) {
+        Set<Long> timeChangedSubjectIds = diff.modifiedSubjects().stream()
+                .filter(item -> item.getChangedFields().contains("시간표"))
+                .map(OfficialSubjectImportResponse.ModifiedSubjectImportItem::getId)
+                .collect(Collectors.toSet());
+        return subjectsToSave.stream()
+                .filter(subject -> subject.getId() != null && timeChangedSubjectIds.contains(subject.getId()))
+                .toList();
     }
 
     private ImportDiff diff(List<OfficialSubjectRecord> records, List<Subject> candidates) {

--- a/src/main/java/inu/timetable/service/SubjectUpdateLogService.java
+++ b/src/main/java/inu/timetable/service/SubjectUpdateLogService.java
@@ -1,0 +1,46 @@
+package inu.timetable.service;
+
+import inu.timetable.dto.SubjectUpdateLogResponse;
+import inu.timetable.entity.SubjectUpdateLog;
+import inu.timetable.repository.SubjectUpdateLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class SubjectUpdateLogService {
+
+    static final int MAX_LIMIT = 50;
+
+    private final SubjectUpdateLogRepository subjectUpdateLogRepository;
+    private final Clock clock;
+
+    @Transactional
+    public SubjectUpdateLog record(
+            String semester, String sourceFormat, int addedCount, int modifiedCount, int removedCount) {
+        return subjectUpdateLogRepository.save(SubjectUpdateLog.builder()
+                .appliedAt(LocalDateTime.now(clock))
+                .semester(semester)
+                .sourceFormat(sourceFormat)
+                .addedCount(addedCount)
+                .modifiedCount(modifiedCount)
+                .removedCount(removedCount)
+                .build());
+    }
+
+    @Transactional(readOnly = true)
+    public List<SubjectUpdateLogResponse> getRecentLogs(int limit) {
+        int clampedLimit = Math.min(Math.max(limit, 1), MAX_LIMIT);
+        return subjectUpdateLogRepository
+                .findAllByOrderByAppliedAtDescIdDesc(PageRequest.of(0, clampedLimit))
+                .stream()
+                .map(SubjectUpdateLogResponse::fromEntity)
+                .toList();
+    }
+}

--- a/src/main/java/inu/timetable/service/TimetableConflictResolutionService.java
+++ b/src/main/java/inu/timetable/service/TimetableConflictResolutionService.java
@@ -1,0 +1,90 @@
+package inu.timetable.service;
+
+import inu.timetable.entity.Schedule;
+import inu.timetable.entity.Subject;
+import inu.timetable.entity.UserNotification;
+import inu.timetable.entity.UserTimetable;
+import inu.timetable.repository.UserNotificationRepository;
+import inu.timetable.repository.UserTimetableRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 공식 엑셀 반영으로 과목 시간이 바뀌었을 때, 그 과목을 담아둔 유저 시간표에서
+ * 새 시간이 다른 과목과 겹치면 해당 과목을 시간표에서 제거하고 1회성 알림을 남긴다.
+ * 겹치지 않으면 시간만 바뀐 채로 유지한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class TimetableConflictResolutionService {
+
+    private final UserTimetableRepository userTimetableRepository;
+    private final UserNotificationRepository userNotificationRepository;
+    private final Clock clock;
+
+    /**
+     * @param timeChangedSubjects 시간표가 변경된 과목들(스케줄은 이미 '새' 시간으로 갱신된 상태)
+     * @param semester            반영 대상 학기
+     * @return 시간표에서 제거된 항목 수
+     */
+    @Transactional
+    public int resolveScheduleConflicts(List<Subject> timeChangedSubjects, String semester) {
+        int removedCount = 0;
+        for (Subject subject : timeChangedSubjects) {
+            removedCount += resolveForSubject(subject, semester);
+        }
+        if (removedCount > 0) {
+            log.info("시간 변경 충돌로 유저 시간표 {}건을 제거하고 알림을 생성했습니다. semester={}", removedCount, semester);
+        }
+        return removedCount;
+    }
+
+    private int resolveForSubject(Subject subject, String semester) {
+        List<UserTimetable> entries =
+                userTimetableRepository.findAllBySubjectIdAndSemesterWithUser(subject.getId(), semester);
+
+        int removed = 0;
+        for (UserTimetable entry : entries) {
+            Long userId = entry.getUser().getId();
+            if (hasConflictWithOtherSubjects(userId, subject, semester)) {
+                userTimetableRepository.delete(entry);
+                userNotificationRepository.save(UserNotification.builder()
+                        .userId(userId)
+                        .message(conflictMessage(subject.getSubjectName()))
+                        .createdAt(LocalDateTime.now(clock))
+                        .build());
+                removed++;
+            }
+        }
+        return removed;
+    }
+
+    private boolean hasConflictWithOtherSubjects(Long userId, Subject changedSubject, String semester) {
+        List<UserTimetable> userEntries =
+                userTimetableRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
+        return userEntries.stream()
+                .map(UserTimetable::getSubject)
+                .filter(other -> !other.getId().equals(changedSubject.getId()))
+                .anyMatch(other -> overlaps(changedSubject.getSchedules(), other.getSchedules()));
+    }
+
+    // 같은 요일이고 newStart < otherEnd AND newEnd > otherStart 이면 겹침으로 본다.
+    private boolean overlaps(List<Schedule> newSchedules, List<Schedule> otherSchedules) {
+        return newSchedules.stream().anyMatch(changed -> otherSchedules.stream()
+                .anyMatch(other -> changed.getDayOfWeek() != null
+                        && changed.getDayOfWeek().equals(other.getDayOfWeek())
+                        && changed.getStartTime() < other.getEndTime()
+                        && changed.getEndTime() > other.getStartTime()));
+    }
+
+    private String conflictMessage(String subjectName) {
+        return "'" + subjectName + "' 수업 시간이 변경되어 기존 시간표의 다른 과목과 겹쳐 시간표에서 제거했어요. 필요하면 다시 담아주세요.";
+    }
+}

--- a/src/main/java/inu/timetable/service/UserNotificationService.java
+++ b/src/main/java/inu/timetable/service/UserNotificationService.java
@@ -1,0 +1,32 @@
+package inu.timetable.service;
+
+import inu.timetable.dto.UserNotificationResponse;
+import inu.timetable.repository.UserNotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class UserNotificationService {
+
+    private final UserNotificationRepository userNotificationRepository;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public List<UserNotificationResponse> getUnreadNotifications(Long userId) {
+        return userNotificationRepository.findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(userId)
+                .stream()
+                .map(UserNotificationResponse::fromEntity)
+                .toList();
+    }
+
+    @Transactional
+    public int markAllRead(Long userId) {
+        return userNotificationRepository.markAllRead(userId, LocalDateTime.now(clock));
+    }
+}

--- a/src/main/resources/db/migration/V20260726_01__create_subject_update_logs_and_user_notifications.sql
+++ b/src/main/resources/db/migration/V20260726_01__create_subject_update_logs_and_user_notifications.sql
@@ -1,0 +1,26 @@
+-- 공식 엑셀 반영 이력(공개 일지) 테이블.
+-- admin 이 OfficialSubjectImportService.apply 로 반영할 때마다 1행씩 기록한다.
+CREATE TABLE IF NOT EXISTS subject_update_logs (
+    id BIGSERIAL PRIMARY KEY,
+    applied_at TIMESTAMP NOT NULL,
+    semester VARCHAR(20) NOT NULL,
+    source_format VARCHAR(32),
+    added_count INT NOT NULL,
+    modified_count INT NOT NULL,
+    removed_count INT NOT NULL
+);
+
+-- 유저 1회성 알림 테이블.
+-- 과목 시간 변경으로 시간표에서 자동 제거된 경우 등 유저에게 알릴 내용을 보관한다.
+-- read_at 이 NULL 이면 미읽음, 읽음 처리 시 일괄로 read_at 을 채운다.
+CREATE TABLE IF NOT EXISTS user_notifications (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    message VARCHAR(500) NOT NULL,
+    created_at TIMESTAMP NOT NULL,
+    read_at TIMESTAMP
+);
+
+-- 미읽음 알림 조회(user_id + read_at IS NULL)를 커버하는 인덱스.
+CREATE INDEX IF NOT EXISTS idx_user_notifications_unread
+    ON user_notifications (user_id, read_at);

--- a/src/test/java/inu/timetable/controller/NotificationControllerIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/NotificationControllerIntegrationTest.java
@@ -1,0 +1,130 @@
+package inu.timetable.controller;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inu.timetable.entity.UserNotification;
+import inu.timetable.repository.UserNotificationRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static inu.timetable.controller.CsrfTestSupport.fetchCsrfProof;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+class NotificationControllerIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserNotificationRepository userNotificationRepository;
+
+    @Test
+    @DisplayName("미인증 유저는 알림 조회가 거부된다")
+    void unreadNotificationsRequireLogin() throws Exception {
+        mockMvc.perform(get("/api/notifications/unread"))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("로그인 유저는 본인 미읽음 알림만 생성순으로 조회한다")
+    void getUnreadNotificationsReturnsOwnUnreadOnly() throws Exception {
+        RegisteredUser registeredUser = registerAndReturnSession();
+        RegisteredUser otherUser = registerAndReturnSession();
+
+        saveNotification(registeredUser.userId(), "첫 번째 알림", LocalDateTime.of(2026, 7, 25, 9, 0));
+        saveNotification(registeredUser.userId(), "두 번째 알림", LocalDateTime.of(2026, 7, 25, 10, 0));
+        saveNotification(otherUser.userId(), "남의 알림", LocalDateTime.of(2026, 7, 25, 11, 0));
+
+        mockMvc.perform(get("/api/notifications/unread").session(registeredUser.session()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)))
+                .andExpect(jsonPath("$[0].message").value("첫 번째 알림"))
+                .andExpect(jsonPath("$[1].message").value("두 번째 알림"));
+    }
+
+    @Test
+    @DisplayName("읽음 처리하면 미읽음 전부 read_at 이 채워지고 이후 조회는 비어 있다")
+    void markAllReadFillsReadAtAndEmptiesUnreadList() throws Exception {
+        RegisteredUser registeredUser = registerAndReturnSession();
+        saveNotification(registeredUser.userId(), "시간 변경 알림 1", LocalDateTime.of(2026, 7, 25, 9, 0));
+        saveNotification(registeredUser.userId(), "시간 변경 알림 2", LocalDateTime.of(2026, 7, 25, 10, 0));
+        CsrfTestSupport.CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, registeredUser.session());
+
+        mockMvc.perform(post("/api/notifications/read")
+                        .session(registeredUser.session())
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", csrfProof.token()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.readCount").value(2));
+
+        mockMvc.perform(get("/api/notifications/unread").session(registeredUser.session()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(0)));
+
+        assertThat(userNotificationRepository.findAll())
+                .filteredOn(notification -> notification.getUserId().equals(registeredUser.userId()))
+                .allSatisfy(notification -> assertThat(notification.getReadAt()).isNotNull());
+    }
+
+    @Test
+    @DisplayName("읽음 처리 POST 는 CSRF 토큰 없이는 거부된다")
+    void markAllReadRequiresCsrfToken() throws Exception {
+        RegisteredUser registeredUser = registerAndReturnSession();
+
+        mockMvc.perform(post("/api/notifications/read").session(registeredUser.session()))
+                .andExpect(status().isForbidden());
+    }
+
+    private void saveNotification(Long userId, String message, LocalDateTime createdAt) {
+        userNotificationRepository.save(UserNotification.builder()
+                .userId(userId)
+                .message(message)
+                .createdAt(createdAt)
+                .build());
+    }
+
+    private RegisteredUser registerAndReturnSession() throws Exception {
+        String username = "student-" + UUID.randomUUID();
+        var result = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "username": "%s",
+                                  "password": "password123",
+                                  "grade": 2,
+                                  "major": "컴퓨터공학부"
+                                }
+                                """.formatted(username)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        JsonNode responseBody = objectMapper.readTree(result.getResponse().getContentAsString());
+        return new RegisteredUser(
+                (MockHttpSession) result.getRequest().getSession(false),
+                responseBody.get("id").asLong());
+    }
+
+    private record RegisteredUser(MockHttpSession session, Long userId) {
+    }
+}

--- a/src/test/java/inu/timetable/controller/SubjectUpdateLogControllerTest.java
+++ b/src/test/java/inu/timetable/controller/SubjectUpdateLogControllerTest.java
@@ -1,0 +1,79 @@
+package inu.timetable.controller;
+
+import inu.timetable.entity.SubjectUpdateLog;
+import inu.timetable.repository.SubjectUpdateLogRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@Transactional
+class SubjectUpdateLogControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private SubjectUpdateLogRepository subjectUpdateLogRepository;
+
+    @Test
+    @DisplayName("업데이트 일지는 인증 없이 최신순으로 조회된다")
+    void getUpdateLogsIsPublicAndOrderedByAppliedAtDesc() throws Exception {
+        saveLog(LocalDateTime.of(2026, 7, 24, 10, 0), "2026-1", 5, 2, 1);
+        saveLog(LocalDateTime.of(2026, 7, 26, 10, 0), "2026-2", 10, 3, 0);
+        saveLog(LocalDateTime.of(2026, 7, 25, 10, 0), "2026-1", 7, 0, 2);
+
+        mockMvc.perform(get("/api/subjects/update-logs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].semester").value("2026-2"))
+                .andExpect(jsonPath("$[0].sourceFormat").value("OFFICIAL_TIMETABLE"))
+                .andExpect(jsonPath("$[0].addedCount").value(10))
+                .andExpect(jsonPath("$[0].modifiedCount").value(3))
+                .andExpect(jsonPath("$[0].removedCount").value(0))
+                .andExpect(jsonPath("$[1].addedCount").value(7))
+                .andExpect(jsonPath("$[2].addedCount").value(5));
+    }
+
+    @Test
+    @DisplayName("limit 파라미터를 적용하고 최대 50으로 클램프한다")
+    void getUpdateLogsClampsLimit() throws Exception {
+        for (int index = 0; index < 55; index++) {
+            saveLog(LocalDateTime.of(2026, 7, 1, 0, 0).plusMinutes(index), "2026-1", index, 0, 0);
+        }
+
+        mockMvc.perform(get("/api/subjects/update-logs").param("limit", "2"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(2)));
+
+        mockMvc.perform(get("/api/subjects/update-logs").param("limit", "100"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(50)));
+    }
+
+    private void saveLog(
+            LocalDateTime appliedAt, String semester, int addedCount, int modifiedCount, int removedCount) {
+        subjectUpdateLogRepository.save(SubjectUpdateLog.builder()
+                .appliedAt(appliedAt)
+                .semester(semester)
+                .sourceFormat("OFFICIAL_TIMETABLE")
+                .addedCount(addedCount)
+                .modifiedCount(modifiedCount)
+                .removedCount(removedCount)
+                .build());
+    }
+}

--- a/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
+++ b/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
@@ -29,7 +29,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -41,11 +43,18 @@ class OfficialSubjectImportServiceTest {
     @Mock
     private ApplicationEventPublisher eventPublisher;
 
+    @Mock
+    private SubjectUpdateLogService subjectUpdateLogService;
+
+    @Mock
+    private TimetableConflictResolutionService timetableConflictResolutionService;
+
     private OfficialSubjectImportService officialSubjectImportService;
 
     @BeforeEach
     void setUp() {
-        officialSubjectImportService = new OfficialSubjectImportService(subjectRepository, eventPublisher);
+        officialSubjectImportService = new OfficialSubjectImportService(
+                subjectRepository, eventPublisher, subjectUpdateLogService, timetableConflictResolutionService);
     }
 
     @Test
@@ -64,6 +73,44 @@ class OfficialSubjectImportServiceTest {
         assertThat(response.getRemovedCount()).isEqualTo(1);
         assertThat(response.getUnchangedCount()).isZero();
         assertThat(response.getModifiedSubjects().get(0).getChangedFields()).contains("담당교수");
+        // preview 는 반영이 아니므로 일지 기록/충돌 해소를 수행하지 않는다.
+        verifyNoInteractions(subjectUpdateLogService, timetableConflictResolutionService);
+    }
+
+    @Test
+    void applyRecordsSubjectUpdateLogOnce() throws Exception {
+        Subject existing = subject("AI01001001", "기존교수", true);
+        Subject removed = subject("OLD0000001", "이전교수", true);
+        when(subjectRepository.findImportCandidatesBySemester("2026-1"))
+                .thenReturn(List.of(existing, removed));
+
+        officialSubjectImportService.apply(sampleWorkbook(), "2026-1", true);
+
+        // added=새과목 1, modified=기존과목 1, removed=엑셀에서 빠진 과목 1
+        verify(subjectUpdateLogService).record("2026-1", "OFFICIAL_TIMETABLE", 1, 1, 1);
+    }
+
+    @Test
+    void applyResolvesConflictsOnlyForScheduleChangedSubjects() throws Exception {
+        // 기존 월4-7 → 엑셀 금5-9 이므로 시간표가 변경되는 과목.
+        Subject timeChanged = subject("AI01001001", "신규교수", true);
+        // 엑셀 레코드와 완전히 동일해 아무 것도 변경되지 않는 과목.
+        Subject unchanged = unchangedSecondRowSubject();
+        when(subjectRepository.findImportCandidatesBySemester("2026-1"))
+                .thenReturn(List.of(timeChanged, unchanged));
+
+        officialSubjectImportService.apply(sampleWorkbook(), "2026-1", true);
+
+        ArgumentCaptor<List<Subject>> captor = ArgumentCaptor.forClass(List.class);
+        verify(timetableConflictResolutionService).resolveScheduleConflicts(captor.capture(), eq("2026-1"));
+        assertThat(captor.getValue())
+                .extracting(Subject::getCourseCode)
+                .containsExactly("AI01001001");
+        // 충돌 검사 대상 과목의 스케줄은 이미 '새' 시간으로 갱신되어 있어야 한다.
+        Subject passed = captor.getValue().get(0);
+        assertThat(passed.getSchedules())
+                .extracting(Schedule::getDayOfWeek)
+                .containsExactly("금");
     }
 
     @Test
@@ -262,6 +309,32 @@ class OfficialSubjectImportServiceTest {
         row.createCell(11).setCellValue(time);
         row.createCell(14).setCellValue(credits);
         row.createCell(16).setCellValue(classMethod);
+    }
+
+    // sampleWorkbook 의 2번째 행(AI01001002)과 완전히 동일한 기존 과목(변경 없음 케이스용).
+    private Subject unchangedSecondRowSubject() {
+        Subject subject = Subject.builder()
+                .id(2L)
+                .courseCode("AI01001002")
+                .semester("2026-1")
+                .active(true)
+                .subjectName("새과목")
+                .credits(3)
+                .professor("새교수")
+                .department("컴퓨터공학부")
+                .grade(2)
+                .subjectType(SubjectType.전심)
+                .classMethod(ClassMethod.OFFLINE)
+                .isNight(false)
+                .schedules(new ArrayList<>())
+                .build();
+        subject.getSchedules().add(Schedule.builder()
+                .subject(subject)
+                .dayOfWeek("화")
+                .startTime(7.0)
+                .endTime(8.0)
+                .build());
+        return subject;
     }
 
     private Subject subject(String courseCode, String professor, boolean active) {

--- a/src/test/java/inu/timetable/service/TimetableConflictResolutionServiceTest.java
+++ b/src/test/java/inu/timetable/service/TimetableConflictResolutionServiceTest.java
@@ -1,0 +1,185 @@
+package inu.timetable.service;
+
+import inu.timetable.entity.Schedule;
+import inu.timetable.entity.Subject;
+import inu.timetable.entity.User;
+import inu.timetable.entity.UserNotification;
+import inu.timetable.entity.UserTimetable;
+import inu.timetable.enums.ClassMethod;
+import inu.timetable.enums.SubjectType;
+import inu.timetable.repository.UserNotificationRepository;
+import inu.timetable.repository.UserTimetableRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+@TestPropertySource(properties = {
+        "spring.flyway.enabled=false",
+        "spring.jpa.hibernate.ddl-auto=create-drop",
+        "spring.datasource.url=jdbc:h2:mem:conflict_resolution;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+        "spring.datasource.driver-class-name=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password="
+})
+@Import({TimetableConflictResolutionService.class, TimetableConflictResolutionServiceTest.FixedClockConfig.class})
+class TimetableConflictResolutionServiceTest {
+
+    private static final String SEMESTER = "2026-1";
+
+    @TestConfiguration
+    static class FixedClockConfig {
+        @Bean
+        Clock clock() {
+            return Clock.fixed(Instant.parse("2026-07-26T00:00:00Z"), ZoneOffset.UTC);
+        }
+    }
+
+    @Autowired
+    private TimetableConflictResolutionService timetableConflictResolutionService;
+
+    @Autowired
+    private UserTimetableRepository userTimetableRepository;
+
+    @Autowired
+    private UserNotificationRepository userNotificationRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    private Subject changedSubject;
+
+    @BeforeEach
+    void setUp() {
+        // 시간이 '월 5-7' 로 이미 변경 반영된 과목.
+        changedSubject = persistSubject("자료구조", "월", 5.0, 7.0);
+    }
+
+    @Test
+    @DisplayName("새 시간이 다른 과목과 겹치는 유저는 시간표에서 제거되고 알림이 생성된다")
+    void removesConflictingEntryAndCreatesNotification() {
+        User conflictUser = persistUser();
+        persistTimetableEntry(conflictUser, changedSubject);
+        persistTimetableEntry(conflictUser, persistSubject("겹치는과목", "월", 6.0, 8.0));
+        entityManager.flush();
+
+        int removedCount = timetableConflictResolutionService
+                .resolveScheduleConflicts(List.of(changedSubject), SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(removedCount).isEqualTo(1);
+        assertThat(userTimetableRepository.findByUserIdAndSemester(conflictUser.getId(), SEMESTER))
+                .extracting(entry -> entry.getSubject().getSubjectName())
+                .containsExactly("겹치는과목");
+        List<UserNotification> notifications = userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(conflictUser.getId());
+        assertThat(notifications).hasSize(1);
+        assertThat(notifications.get(0).getMessage()).contains("'자료구조'");
+        assertThat(notifications.get(0).getReadAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("새 시간이 겹치지 않는 유저는 시간표가 유지되고 알림도 생성되지 않는다")
+    void keepsNonConflictingEntryWithoutNotification() {
+        User safeUser = persistUser();
+        persistTimetableEntry(safeUser, changedSubject);
+        persistTimetableEntry(safeUser, persistSubject("다른요일과목", "화", 5.0, 7.0));
+        // 같은 요일이라도 끝나는 시각과 시작 시각이 맞닿기만 하면(월 7-9) 겹침이 아니다.
+        persistTimetableEntry(safeUser, persistSubject("연강과목", "월", 7.0, 9.0));
+        entityManager.flush();
+
+        int removedCount = timetableConflictResolutionService
+                .resolveScheduleConflicts(List.of(changedSubject), SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(removedCount).isZero();
+        assertThat(userTimetableRepository.findByUserIdAndSemester(safeUser.getId(), SEMESTER)).hasSize(3);
+        assertThat(userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(safeUser.getId())).isEmpty();
+    }
+
+    @Test
+    @DisplayName("여러 유저가 담아둔 경우 겹치는 유저만 제거되고 각자 알림을 받는다")
+    void resolvesPerUserIndependently() {
+        User conflictUser = persistUser();
+        persistTimetableEntry(conflictUser, changedSubject);
+        persistTimetableEntry(conflictUser, persistSubject("겹치는과목", "월", 4.0, 6.0));
+
+        User safeUser = persistUser();
+        persistTimetableEntry(safeUser, changedSubject);
+        persistTimetableEntry(safeUser, persistSubject("안겹치는과목", "금", 1.0, 3.0));
+        entityManager.flush();
+
+        int removedCount = timetableConflictResolutionService
+                .resolveScheduleConflicts(List.of(changedSubject), SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(removedCount).isEqualTo(1);
+        assertThat(userTimetableRepository.findByUserIdAndSemester(conflictUser.getId(), SEMESTER)).hasSize(1);
+        assertThat(userTimetableRepository.findByUserIdAndSemester(safeUser.getId(), SEMESTER)).hasSize(2);
+        assertThat(userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(conflictUser.getId())).hasSize(1);
+        assertThat(userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(safeUser.getId())).isEmpty();
+    }
+
+    private User persistUser() {
+        return entityManager.persist(User.builder()
+                .username("student-" + UUID.randomUUID())
+                .password("encoded-password")
+                .grade(2)
+                .major("컴퓨터공학부")
+                .build());
+    }
+
+    private Subject persistSubject(String subjectName, String dayOfWeek, double startTime, double endTime) {
+        Subject subject = Subject.builder()
+                .courseCode("CC" + UUID.randomUUID().toString().substring(0, 8))
+                .semester(SEMESTER)
+                .active(true)
+                .subjectName(subjectName)
+                .credits(3)
+                .professor("교수")
+                .department("컴퓨터공학부")
+                .grade(2)
+                .subjectType(SubjectType.전심)
+                .classMethod(ClassMethod.OFFLINE)
+                .isNight(false)
+                .build();
+        subject.getSchedules().add(Schedule.builder()
+                .subject(subject)
+                .dayOfWeek(dayOfWeek)
+                .startTime(startTime)
+                .endTime(endTime)
+                .build());
+        return entityManager.persist(subject);
+    }
+
+    private void persistTimetableEntry(User user, Subject subject) {
+        entityManager.persist(UserTimetable.builder()
+                .user(user)
+                .subject(subject)
+                .semester(SEMESTER)
+                .build());
+    }
+}


### PR DESCRIPTION
## 요약

프론트 카운터파트: inu_timetable_front 의 업데이트 소식 PR.

### 과목 데이터 반영 일지
- apply 성공 시 `subject_update_logs` 에 기록(시각·학기·형식·추가/변경/비활성 수)
- `GET /api/subjects/update-logs?limit=` 공개 조회(최신순, limit≤50)

### 시간 변경 충돌 자동 해소
- apply 시 시간표가 변경된 과목을 담고 있는 유저를 검사
- 그 유저의 같은 학기 **다른 과목과 새 시간이 겹치면**: 시간표에서 자동 제거 + `user_notifications` 알림 생성("'과목명' 수업 시간이 변경되어 … 다시 담아주세요.")
- 겹치지 않으면 유지(시간만 갱신). 끝==시작 연강은 겹침 아님
- `GET /api/notifications/unread` / `POST /api/notifications/read` (인증+CSRF)

## 테스트
- [x] `./gradlew build` 전체 통과 — 충돌 삭제+알림/연강 유지/다수 유저 독립 처리, 일지 기록·클램프, 알림 인증·읽음·CSRF 등 18건 추가