### PR TITLE
fix: 2026-2 학과 필터 정확 매칭 및 학기별 목록 제공

### DIFF
--- a/src/main/java/inu/timetable/controller/SubjectController.java
+++ b/src/main/java/inu/timetable/controller/SubjectController.java
@@ -51,8 +51,8 @@ public class SubjectController {
     }
 
     @GetMapping("/departments")
-    public List<String> getAllDepartments() {
-        return subjectQueryService.findDistinctDepartments();
+    public List<String> getAllDepartments(@RequestParam(required = false) String semester) {
+        return subjectQueryService.findDistinctDepartments(semester);
     }
 
     @GetMapping("/grades")

--- a/src/main/java/inu/timetable/repository/SubjectRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectRepository.java
@@ -89,7 +89,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
                         "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
 					"AND (:courseCode IS NULL OR s.courseCode LIKE %:courseCode%) " +
-                        "AND (:department IS NULL OR s.department LIKE %:department%) " +
+                        "AND (:department IS NULL OR s.department = :department) " +
                         "AND (:departmentCount = 0 OR s.department IN :departments) " +
                         "AND (:subjectType IS NULL OR s.subjectType = :subjectType) " +
                         "AND (:grade IS NULL OR s.grade = :grade) " +
@@ -109,7 +109,7 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                                         "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
                                         "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
 					"AND (:courseCode IS NULL OR s.courseCode LIKE %:courseCode%) " +
-                                        "AND (:department IS NULL OR s.department LIKE %:department%) " +
+                                        "AND (:department IS NULL OR s.department = :department) " +
                                         "AND (:departmentCount = 0 OR s.department IN :departments) " +
                                         "AND (:subjectType IS NULL OR s.subjectType = :subjectType) " +
                                         "AND (:grade IS NULL OR s.grade = :grade) " +
@@ -161,6 +161,13 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
 
         @Query("SELECT DISTINCT s.department FROM Subject s WHERE s.active = true AND s.department IS NOT NULL ORDER BY s.department")
         List<String> findDistinctDepartments();
+
+        @Query("SELECT DISTINCT s.department FROM Subject s " +
+                        "WHERE s.active = true " +
+                        "AND (s.semester = :semester OR s.semester IS NULL) " +
+                        "AND s.department IS NOT NULL " +
+                        "ORDER BY s.department")
+        List<String> findDistinctDepartmentsBySemester(@Param("semester") String semester);
 
         @Query("SELECT DISTINCT s.grade FROM Subject s WHERE s.active = true AND s.grade IS NOT NULL ORDER BY s.grade")
         List<Integer> findDistinctGrades();

--- a/src/main/java/inu/timetable/service/AppSettingService.java
+++ b/src/main/java/inu/timetable/service/AppSettingService.java
@@ -15,7 +15,7 @@ import java.util.regex.Pattern;
 public class AppSettingService {
 
     static final String CURRENT_SEMESTER_KEY = "current_semester";
-    static final String DEFAULT_SEMESTER = "2026-1";
+    static final String DEFAULT_SEMESTER = "2026-2";
 
     private static final Pattern SEMESTER_PATTERN = Pattern.compile("^\\d{4}-[12]$");
 

--- a/src/main/java/inu/timetable/service/SubjectQueryService.java
+++ b/src/main/java/inu/timetable/service/SubjectQueryService.java
@@ -30,6 +30,17 @@ public class SubjectQueryService {
         return subjectRepository.findDistinctDepartments();
     }
 
+    @Cacheable(
+            cacheNames = SubjectCacheNames.SUBJECT_DEPARTMENTS,
+            key = "#semester == null || #semester.isBlank() ? 'all' : #semester.trim()",
+            sync = true)
+    public List<String> findDistinctDepartments(String semester) {
+        if (semester == null || semester.isBlank()) {
+            return subjectRepository.findDistinctDepartments();
+        }
+        return subjectRepository.findDistinctDepartmentsBySemester(semester.trim());
+    }
+
     @Cacheable(cacheNames = SubjectCacheNames.SUBJECT_GRADES, key = "'all'", sync = true)
     public List<Integer> findDistinctGrades() {
         return subjectRepository.findDistinctGrades();

--- a/src/test/java/inu/timetable/controller/SettingsControllerTest.java
+++ b/src/test/java/inu/timetable/controller/SettingsControllerTest.java
@@ -30,11 +30,11 @@ class SettingsControllerTest {
     private AppSettingRepository appSettingRepository;
 
     @Test
-    @DisplayName("현재 학기 설정이 없으면 기본값 2026-1을 반환한다")
+    @DisplayName("현재 학기 설정이 없으면 기본값 2026-2를 반환한다")
     void getCurrentSemesterReturnsFallbackWhenSettingMissing() throws Exception {
         mockMvc.perform(get("/api/settings/current-semester"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.semester").value("2026-1"));
+                .andExpect(jsonPath("$.semester").value("2026-2"));
     }
 
     @Test

--- a/src/test/java/inu/timetable/controller/SubjectControllerTest.java
+++ b/src/test/java/inu/timetable/controller/SubjectControllerTest.java
@@ -30,6 +30,16 @@ class SubjectControllerTest {
     private SubjectQueryService subjectQueryService;
 
     @Test
+    void getAllDepartmentsDelegatesSemesterToQueryService() {
+        SubjectController controller = new SubjectController(subjectRepository, subjectQueryService);
+        List<String> expected = List.of("경제학과(야)", "지능형로봇시스템연계전공");
+        when(subjectQueryService.findDistinctDepartments("2026-2")).thenReturn(expected);
+
+        assertThat(controller.getAllDepartments("2026-2")).isSameAs(expected);
+        verify(subjectQueryService).findDistinctDepartments("2026-2");
+    }
+
+    @Test
     void filterSubjectsNormalizesRequestAndDelegatesToQueryService() {
         SubjectController controller = new SubjectController(subjectRepository, subjectQueryService);
         SubjectFilterCriteria criteria = SubjectFilterCriteria.of(

--- a/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
+++ b/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
@@ -97,6 +97,21 @@ class SubjectRepositoryIntegrationTest {
     }
 
     @Test
+    void findDistinctDepartmentsBySemesterExcludesOtherSemestersAndIncludesLegacySubjects() {
+        Subject firstSemester = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
+        firstSemester.setDepartment("컴퓨터공학부");
+        Subject secondSemester = persistSubject("AI01001002", "2026-2", true, "화", 1.0, 3.0);
+        secondSemester.setDepartment("경제학과(야)");
+        Subject legacySemester = persistSubject("AI01001003", null, true, "수", 1.0, 3.0);
+        legacySemester.setDepartment("지능형로봇시스템연계전공");
+
+        entityManager.flush();
+
+        assertThat(subjectRepository.findDistinctDepartmentsBySemester("2026-2"))
+                .containsExactly("경제학과(야)", "지능형로봇시스템연계전공");
+    }
+
+    @Test
     void findIdsWithFiltersCanFindOnlineAndUnscheduledSubjects() {
         Subject scheduledOffline = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
         Subject unscheduledOffline = persistSubject("AI01001002", "2026-1", true, null, null, null);
@@ -158,6 +173,29 @@ class SubjectRepositoryIntegrationTest {
         assertThat(subjectIds.getContent())
                 .containsExactlyInAnyOrder(computer.getId(), embedded.getId())
                 .doesNotContain(math.getId());
+    }
+
+    @Test
+    void findIdsWithFiltersMatchesSingleDepartmentExactly() {
+        Subject economics = persistSubject("AI01001001", "2026-2", true, "월", 4.0, 7.0);
+        economics.setDepartment("경제학과");
+        Subject nightEconomics = persistSubject("AI01001002", "2026-2", true, "화", 1.0, 3.0);
+        nightEconomics.setDepartment("경제학과(야)");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> subjectIds = subjectRepository.findIdsWithFilters(
+                "2026-2", null, null, null, "경제학과",
+                Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, null, null,
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, 10));
+
+        assertThat(subjectIds.getContent())
+                .containsExactly(economics.getId())
+                .doesNotContain(nightEconomics.getId());
     }
 
     @Test

--- a/src/test/java/inu/timetable/service/SubjectQueryServiceCacheTest.java
+++ b/src/test/java/inu/timetable/service/SubjectQueryServiceCacheTest.java
@@ -106,6 +106,24 @@ class SubjectQueryServiceCacheTest {
     }
 
     @Test
+    void distinctDepartmentsAreCachedSeparatelyBySemester() {
+        when(subjectRepository.findDistinctDepartmentsBySemester("2026-1"))
+                .thenReturn(List.of("컴퓨터공학부"));
+        when(subjectRepository.findDistinctDepartmentsBySemester("2026-2"))
+                .thenReturn(List.of("경제학과(야)"));
+
+        assertThat(subjectQueryService.findDistinctDepartments(" 2026-1 "))
+                .containsExactly("컴퓨터공학부");
+        assertThat(subjectQueryService.findDistinctDepartments("2026-1"))
+                .containsExactly("컴퓨터공학부");
+        assertThat(subjectQueryService.findDistinctDepartments("2026-2"))
+                .containsExactly("경제학과(야)");
+
+        verify(subjectRepository, times(1)).findDistinctDepartmentsBySemester("2026-1");
+        verify(subjectRepository, times(1)).findDistinctDepartmentsBySemester("2026-2");
+    }
+
+    @Test
     void filterSubjectsCachesSameCriteriaUntilRelevantDataChanges() {
         Pageable pageable = PageRequest.of(0, 20);
         SubjectFilterCriteria criteria = SubjectFilterCriteria.of(


### PR DESCRIPTION
## 변경 사항
- 단일 학과 필터를 부분 일치에서 정확 일치로 변경해 `경제학과`가 `경제학과(야)`까지 포함하던 문제를 수정했습니다.
- `GET /api/subjects/departments?semester=2026-2`로 해당 학기에 존재하는 학과 목록만 조회할 수 있도록 추가했습니다.
- 학기별 학과 목록 캐시를 분리하고, 기본 학기를 `2026-2`로 갱신했습니다.

## 검증
- `./gradlew test`
- 단일 학과 exact match 회귀 테스트
- 학기별 학과 목록 및 캐시 분리 테스트
- 현재 학기 기본값 테스트