### PR TITLE
fix: 회원정보 수정 PATCH CORS 허용

### DIFF
--- a/src/main/java/inu/timetable/config/CorsConfig.java
+++ b/src/main/java/inu/timetable/config/CorsConfig.java
@@ -21,7 +21,7 @@ public class CorsConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins(allowedOrigins)
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);
     }

--- a/src/test/java/inu/timetable/config/CorsConfigTest.java
+++ b/src/test/java/inu/timetable/config/CorsConfigTest.java
@@ -1,0 +1,37 @@
+package inu.timetable.config;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties =
+        "cors.allowed-origins=https://inuu-timetable.vercel.app")
+class CorsConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void allowsProfilePatchPreflightFromProductionFrontend() throws Exception {
+        mockMvc.perform(options("/api/auth/me")
+                        .header("Origin", "https://inuu-timetable.vercel.app")
+                        .header("Access-Control-Request-Method", "PATCH")
+                        .header("Access-Control-Request-Headers", "content-type,x-xsrf-token"))
+                .andExpect(status().isOk())
+                .andExpect(header().string(
+                        "Access-Control-Allow-Origin",
+                        "https://inuu-timetable.vercel.app"))
+                .andExpect(header().string("Access-Control-Allow-Methods", org.hamcrest.Matchers.containsString("PATCH")));
+    }
+}


### PR DESCRIPTION
## 문제
운영 프론트에서 회원정보 수정 시 `PATCH /api/auth/me`의 CORS 사전 요청이 403 `Invalid CORS request`로 거부되었습니다.

## 변경
- CORS 허용 메서드에 `PATCH` 추가
- 운영 프론트 origin의 회원정보 수정 preflight 회귀 테스트 추가

## 검증
- 수정 전 회귀 테스트 403 실패 재현
- `CorsConfigTest` 통과
- 회원정보 수정 통합 테스트 통과
- 전체 `./gradlew test` 통과