### PR TITLE
feat: Cloud Run 다중 인스턴스 세션 호환 브리지

### DIFF
--- a/.github/deploy/production-rollout.env
+++ b/.github/deploy/production-rollout.env
@@ -1,0 +1,8 @@
+# Phase 1: issue opaque migration tokens while keeping the legacy in-memory session.
+# Change to consume/true/max=3/concurrency=40 only after the phase-1 revision is healthy.
+SESSION_BRIDGE_MODE=issue
+SHARED_SESSION_ENABLED=false
+MAX_INSTANCES=1
+CONCURRENCY=80
+DB_POOL_MAXIMUM_SIZE=10
+DB_POOL_MINIMUM_IDLE=2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -11,7 +11,7 @@ permissions:
 
 concurrency:
   group: gcp-cloud-run-production
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   GCP_PROJECT_ID: project-53f7b99e-c306-49a7-a7b
@@ -25,6 +25,34 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+
+      - name: Load and validate rollout phase
+        shell: bash
+        run: |
+          set -a
+          source .github/deploy/production-rollout.env
+          set +a
+
+          case "$SESSION_BRIDGE_MODE" in
+            issue|consume|off) ;;
+            *) echo "Invalid SESSION_BRIDGE_MODE" >&2; exit 1 ;;
+          esac
+          case "$SHARED_SESSION_ENABLED" in
+            true|false) ;;
+            *) echo "Invalid SHARED_SESSION_ENABLED" >&2; exit 1 ;;
+          esac
+          test "$MAX_INSTANCES" -ge 1
+          test "$CONCURRENCY" -ge 1
+          test "$DB_POOL_MAXIMUM_SIZE" -ge "$DB_POOL_MINIMUM_IDLE"
+
+          {
+            echo "SESSION_BRIDGE_MODE=$SESSION_BRIDGE_MODE"
+            echo "SHARED_SESSION_ENABLED=$SHARED_SESSION_ENABLED"
+            echo "MAX_INSTANCES=$MAX_INSTANCES"
+            echo "CONCURRENCY=$CONCURRENCY"
+            echo "DB_POOL_MAXIMUM_SIZE=$DB_POOL_MAXIMUM_SIZE"
+            echo "DB_POOL_MINIMUM_IDLE=$DB_POOL_MINIMUM_IDLE"
+          } >> "$GITHUB_ENV"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v5
@@ -55,38 +83,70 @@ jobs:
           printf '%s' "$ADMIN_PASSWORD" |
             gcloud secrets versions add ADMIN_PASSWORD --data-file=-
 
-      - name: Deploy to Cloud Run
+      - name: Capture current production revision
         run: |
+          CURRENT_REVISION="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format=json |
+            jq --raw-output '.status.traffic[] | select(.percent == 100) | .revisionName' |
+            head -n 1)"
+          test -n "$CURRENT_REVISION"
+          echo "CURRENT_REVISION=$CURRENT_REVISION" >> "$GITHUB_ENV"
+
+      - name: Deploy candidate with zero traffic
+        run: |
+          CANDIDATE_TAG="candidate-${GITHUB_RUN_ID}"
           gcloud run deploy "$CLOUD_RUN_SERVICE" \
             --project "$GCP_PROJECT_ID" \
             --region "$GCP_REGION" \
             --source . \
+            --no-traffic \
+            --tag "$CANDIDATE_TAG" \
             --allow-unauthenticated \
             --service-account "$RUNTIME_SERVICE_ACCOUNT" \
             --set-secrets DB_URL=DB_URL:latest,DB_USERNAME=DB_USERNAME:latest,DB_PASSWORD=DB_PASSWORD:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,ADMIN_PASSWORD=ADMIN_PASSWORD:latest \
-            --set-env-vars '^@^SPRING_PROFILES_ACTIVE=prod@ADMIN_USERNAME=admin@CORS_ALLOWED_ORIGINS=https://inu-timetable-front-git-main-jjhs-projects-4d22a2fd.vercel.app,https://inuu-timetable.vercel.app' \
+            --set-env-vars "^@^SPRING_PROFILES_ACTIVE=prod@ADMIN_USERNAME=admin@CORS_ALLOWED_ORIGINS=https://inu-timetable-front-git-main-jjhs-projects-4d22a2fd.vercel.app,https://inuu-timetable.vercel.app@SESSION_BRIDGE_MODE=$SESSION_BRIDGE_MODE@SHARED_SESSION_ENABLED=$SHARED_SESSION_ENABLED@DB_POOL_MAXIMUM_SIZE=$DB_POOL_MAXIMUM_SIZE@DB_POOL_MINIMUM_IDLE=$DB_POOL_MINIMUM_IDLE" \
             --port 8080 \
             --cpu 1 \
             --memory 1Gi \
-            --concurrency 80 \
+            --concurrency "$CONCURRENCY" \
             --min-instances 0 \
-            --max-instances 1 \
+            --max-instances "$MAX_INSTANCES" \
             --timeout 300 \
             --cpu-boost \
             --quiet
 
-      - name: Verify production API
+          CANDIDATE_REVISION="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format=json |
+            jq --raw-output --arg tag "$CANDIDATE_TAG" \
+              '.status.traffic[] | select(.tag == $tag) | .revisionName')"
+          CANDIDATE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format=json |
+            jq --raw-output --arg tag "$CANDIDATE_TAG" \
+              '.status.traffic[] | select(.tag == $tag) | .url')"
+          test -n "$CANDIDATE_REVISION"
+          test -n "$CANDIDATE_URL"
+          {
+            echo "CANDIDATE_REVISION=$CANDIDATE_REVISION"
+            echo "CANDIDATE_URL=$CANDIDATE_URL"
+          } >> "$GITHUB_ENV"
+
+      - name: Verify candidate revision
         env:
           ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
         run: |
-          SERVICE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
-            --project "$GCP_PROJECT_ID" \
-            --region "$GCP_REGION" \
-            --format='value(status.url)')"
-          curl --fail --show-error --silent --retry 6 --retry-all-errors \
-            --retry-delay 5 "$SERVICE_URL/actuator/health"
-          test "$(curl --fail --show-error --silent --retry 3 \
-            "$SERVICE_URL/api/subjects/count")" = "2894"
+          curl --fail --show-error --silent --retry 12 --retry-all-errors \
+            --retry-delay 5 "$CANDIDATE_URL/actuator/health"
+
+          SUBJECT_COUNT="$(curl --fail --show-error --silent --retry 3 \
+            "$CANDIDATE_URL/api/subjects/count")"
+          [[ "$SUBJECT_COUNT" =~ ^[0-9]+$ ]]
+          test "$SUBJECT_COUNT" -gt 0
 
           COOKIE_JAR="$(mktemp)"
           CSRF_BODY="$(mktemp)"
@@ -97,7 +157,7 @@ jobs:
             --output "$CSRF_BODY" \
             --write-out '%{http_code}' \
             --cookie-jar "$COOKIE_JAR" \
-            "$SERVICE_URL/api/auth/csrf")" = "200"
+            "$CANDIDATE_URL/api/auth/csrf")" = "200"
           CSRF_TOKEN="$(jq --raw-output '.token' "$CSRF_BODY")"
           test -n "$CSRF_TOKEN"
 
@@ -112,12 +172,74 @@ jobs:
               --arg username admin \
               --arg password "$ADMIN_PASSWORD" \
               '{username: $username, password: $password}')" \
-            "$SERVICE_URL/admin/api/auth/login")"
+            "$CANDIDATE_URL/admin/api/auth/login")"
           test "$LOGIN_STATUS" = "200"
           test "$(jq --raw-output '.authenticated' "$LOGIN_BODY")" = "true"
-
+          if [ "$SESSION_BRIDGE_MODE" = "issue" ]; then
+            grep --quiet 'INU_SESSION_BRIDGE' "$COOKIE_JAR"
+          else
+            grep --quiet $'\tSESSION\t' "$COOKIE_JAR"
+          fi
           test "$(curl --show-error --silent \
             --output /dev/null \
             --write-out '%{http_code}' \
             --cookie "$COOKIE_JAR" \
-            "$SERVICE_URL/admin/api/auth/me")" = "200"
+            "$CANDIDATE_URL/admin/api/auth/me")" = "200"
+
+      - name: Promote candidate
+        run: |
+          rollback() {
+            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+              --project "$GCP_PROJECT_ID" \
+              --region "$GCP_REGION" \
+              --to-revisions "$CURRENT_REVISION=100" \
+              --quiet
+          }
+          verify_service() {
+            SERVICE_URL="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+              --project "$GCP_PROJECT_ID" \
+              --region "$GCP_REGION" \
+              --format='value(status.url)')"
+            curl --fail --show-error --silent --retry 6 --retry-all-errors \
+              --retry-delay 5 "$SERVICE_URL/actuator/health" >/dev/null
+            SUBJECT_COUNT="$(curl --fail --show-error --silent --retry 3 \
+              "$SERVICE_URL/api/subjects/count")"
+            [[ "$SUBJECT_COUNT" =~ ^[0-9]+$ ]] && test "$SUBJECT_COUNT" -gt 0
+          }
+
+          if [ "$SESSION_BRIDGE_MODE" = "off" ]; then
+            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+              --project "$GCP_PROJECT_ID" \
+              --region "$GCP_REGION" \
+              --to-revisions "$CURRENT_REVISION=90,$CANDIDATE_REVISION=10" \
+              --quiet
+            sleep 20
+            verify_service || { rollback; exit 1; }
+
+            gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+              --project "$GCP_PROJECT_ID" \
+              --region "$GCP_REGION" \
+              --to-revisions "$CURRENT_REVISION=50,$CANDIDATE_REVISION=50" \
+              --quiet
+            sleep 20
+            verify_service || { rollback; exit 1; }
+          fi
+
+          gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --to-revisions "$CANDIDATE_REVISION=100" \
+            --quiet
+          sleep 10
+          verify_service || { rollback; exit 1; }
+
+      - name: Record deployed revision
+        run: |
+          DEPLOYED_REVISION="$(gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_REGION" \
+            --format=json |
+            jq --raw-output '.status.traffic[] | select(.percent == 100) | .revisionName' |
+            head -n 1)"
+          test "$DEPLOYED_REVISION" = "$CANDIDATE_REVISION"
+          echo "Deployed revision: $DEPLOYED_REVISION"

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.session:spring-session-jdbc'
     implementation 'org.springframework.ai:spring-ai-pdf-document-reader'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.flywaydb:flyway-core'

--- a/reports/performance/2026-07-27-session-scaling-bridge/README.md
+++ b/reports/performance/2026-07-27-session-scaling-bridge/README.md
@@ -1,0 +1,167 @@
+# Cloud Run 3인스턴스 확장과 2단계 세션 호환 브리지
+
+## 요약
+
+단일 Cloud Run 인스턴스의 메모리에 있던 로그인 상태와 동시성 제어를
+PostgreSQL 공유 상태로 옮겼다. 기존 세션 저장소를 즉시 바꾸면 모든 사용자가
+한 번에 로그아웃되므로, 1회용 opaque 토큰을 이용한 `issue -> consume` 두 단계
+브리지를 추가했다.
+
+동시에 3인스턴스에서 달라질 수 있던 관리자 작업 락, 로그인 실패 횟수,
+Caffeine 캐시 무효화도 공유 상태로 전환했다. 배포는 후보 리비전을 0% 트래픽으로
+검증한 후 전환하며, 세션 저장소가 호환되는 정상 상태부터 10% -> 50% -> 100%
+카나리를 적용한다.
+
+## 해결해야 했던 문제
+
+| 영역 | 단일 인스턴스 구현 | 다중 인스턴스 위험 | 변경 |
+|---|---|---|---|
+| 사용자/관리자 세션 | 컨테이너 메모리 | 다른 인스턴스에서 로그인 소실 | Spring Session JDBC |
+| 세션 전환 | 일괄 교체 | 전환 순간 전체 로그아웃 | 1회용 DB 토큰 브리지 |
+| 관리자 중복 작업 | `ConcurrentHashMap` | 인스턴스별로 동시에 실행 | PostgreSQL advisory lock |
+| 로그인 제한 | `ConcurrentHashMap` | 인스턴스를 바꾸면 횟수 초기화 | 해시 키 기반 DB 카운터 |
+| Caffeine 무효화 | 로컬 이벤트 | 다른 인스턴스에 오래된 결과 잔류 | DB 버전 + 1초 폴링 |
+| 배포 | 즉시 100% 트래픽 | 시작/마이그레이션 실패가 바로 노출 | 0% 후보 검증 + 롤백 |
+
+## 세션 마이그레이션
+
+```mermaid
+sequenceDiagram
+    participant B as Browser
+    participant P1 as Phase 1 revision
+    participant DB as PostgreSQL
+    participant P2 as Phase 2 revision
+
+    B->>P1: 기존 로그인 또는 인증 요청
+    P1->>DB: SHA-256(token), principal, expires_at 저장
+    P1-->>B: HttpOnly Secure INU_SESSION_BRIDGE
+    Note over B,P1: raw token은 브라우저에만 존재
+    B->>P2: bridge cookie와 첫 요청
+    P2->>DB: SELECT FOR UPDATE
+    P2->>DB: 토큰 1회 소비
+    P2->>DB: JDBC session 생성
+    P2-->>B: SESSION 발급, bridge cookie 삭제
+    B->>P2: 이후 SESSION으로 요청
+```
+
+### 1단계: issue
+
+- 기존 컨테이너 세션을 유지한다.
+- 로그인·회원가입·관리자 로그인 시 256비트 난수 토큰을 발급한다.
+- 이미 로그인한 세션도 다음 요청에서 토큰을 받는다.
+- 서버에는 raw token 대신 SHA-256 해시만 저장한다.
+- 사용자 토큰에는 `user_id`, 관리자 토큰에는 관리자 식별자만 연결한다.
+- 로그아웃, 회원탈퇴, 다른 계정 로그인 시 기존 토큰을 폐기한다.
+
+### 2단계: consume
+
+- Spring Session JDBC를 활성화한다.
+- 공유 세션이 없고 브리지 쿠키가 있을 때만 토큰을 소비한다.
+- `SELECT ... FOR UPDATE`와 삭제를 같은 트랜잭션에서 수행하므로 동시 요청 중
+  하나만 성공한다.
+- 활성 사용자 여부를 DB에서 다시 확인한 뒤 새 보안 컨텍스트를 만든다.
+- 세션 principal에는 비밀번호 해시를 저장하지 않는다.
+- 성공·만료·거부 결과와 관계없이 브리지 쿠키를 제거한다.
+
+### 피할 수 없는 최초 경계
+
+구현 전에 실행 중이던 구 리비전의 메모리 세션은 외부에서 읽거나 내보낼
+인터페이스가 없다. 따라서 **브리지 1단계를 처음 배포하는 시점의 기존 세션은
+한 번 갱신해야 한다.** 1단계 이후 생성되거나 활동한 세션부터는 2단계 전환과
+후속 다중 인스턴스 배포에서 로그인 연속성을 유지한다.
+
+이 한계 때문에 “현재 존재하는 메모리 상태까지 무손실 이전”이라고 표현하지
+않는다. 포트폴리오의 무중단 범위는 다음과 같다.
+
+- HTTP 요청 가용성: 후보 검증과 Cloud Run 리비전 전환으로 유지
+- 로그인 연속성: 브리지 1단계 이후부터 유지
+- 브리지 도입 전 메모리 세션: 최초 1회 갱신 필요
+
+## 다중 인스턴스 정합성
+
+### 관리자 작업 락
+
+`pg_try_advisory_lock`을 실행한 DB 커넥션을 작업 종료까지 유지한다. 같은 작업
+키는 모든 인스턴스에서 동일한 64비트 값으로 해시된다. 프로세스가 비정상
+종료되더라도 커넥션이 닫히면 PostgreSQL이 락을 자동 해제한다.
+
+### 로그인 제한
+
+`namespace + username + client IP`를 SHA-256으로 해시한 키만 저장한다. 실패 횟수
+증가는 원자적 `UPDATE`로 처리하고, 최초 동시 삽입 충돌은 unique key 이후
+재시도로 합산한다. 사용자와 관리자는 namespace를 분리한다.
+
+### Caffeine 캐시
+
+데이터 변경 커밋 후 `shared_cache_versions`의 scope 버전을 증가시킨다. 각
+인스턴스는 1초마다 버전을 확인하고 자신이 관찰한 값보다 크면 관련 로컬
+캐시를 비운다. 읽기 성능은 로컬 Caffeine으로 유지하면서 최대 1초의 명시적인
+최종 일관성 경계를 갖는다.
+
+## 배포와 롤백
+
+배포 파라미터는
+[production-rollout.env](../../../.github/deploy/production-rollout.env)에 버전
+관리한다.
+
+1. 전체 테스트와 `bootJar` 빌드
+2. 현재 100% 트래픽 리비전 기록
+3. 새 리비전을 `--no-traffic`과 고유 tag로 배포
+4. tag URL에서 health, 과목 수, CSRF, 관리자 로그인과 세션 검증
+5. 브리지 단계는 새 리비전으로 100% 원자 전환
+6. 정상 단계(`mode=off`, JDBC 유지)는 10% -> 50% -> 100% 카나리
+7. 어느 검증에서든 실패하면 기록해 둔 리비전으로 100% 롤백
+
+브리지 단계에서 구·신 리비전을 장시간 혼합하지 않는 이유는 메모리 세션과
+JDBC 세션이 서로의 쿠키를 읽을 수 없기 때문이다. Cloud Run session affinity는
+best effort이므로 정합성의 근거로 사용하지 않는다.
+
+참고:
+
+- [Cloud Run revision과 트래픽 전환](https://cloud.google.com/run/docs/rollouts-rollbacks-traffic-migration)
+- [Cloud Run session affinity의 best-effort 제한](https://cloud.google.com/run/docs/configuring/session-affinity)
+- [Spring Session JDBC](https://docs.spring.io/spring-session/reference/configuration/jdbc.html)
+
+## 검증
+
+### 자동 테스트
+
+2026-07-27 로컬 전체 테스트:
+
+- tests: 181
+- passed: 179
+- skipped: 2
+- failures: 0
+
+새로 추가한 핵심 시나리오:
+
+- issue 단계의 opaque 쿠키 발급과 hash-only 저장
+- user/admin 브리지 토큰의 JDBC 세션 전환
+- JDBC 세션으로 다음 요청 유지
+- 동일 브리지 토큰 재사용 거부
+- 세션 직렬화 principal에 비밀번호 해시가 없음을 역직렬화해 확인
+- 서로 다른 rate-limit store 인스턴스가 실패/해제 상태 공유
+- 다른 Caffeine 인스턴스가 DB 버전 변경을 반영
+- advisory lock 획득/해제가 같은 커넥션에서 수행됨을 확인
+
+### 확장값의 근거
+
+기존 [캐시·확장 벤치마크](../2026-07-25-cache-scaling/README.md)에서 1,000 VU 기준:
+
+| 구성 | 요청 수 | p95 | 클라이언트 실패 | 서버 5xx |
+|---|---:|---:|---:|---:|
+| max=1, concurrency=80 | 94,434 | 1,991.06ms | 0 | 0 |
+| max=3, concurrency=40, pool=10 | 172,792 | 793.54ms | 8 | 0 |
+
+요청 처리량은 83.0% 증가했고 p95는 60.1% 감소했다. 따라서 2단계 최종값은
+`max=3`, `concurrency=40`, 인스턴스당 DB pool `max=10/min=2`로 정했다.
+
+## 운영 증거
+
+| 단계 | 리비전 | 트래픽 | health | 세션 검증 | 시각 |
+|---|---|---:|---|---|---|
+| 1단계 issue | 배포 후 기록 | 100% | 배포 후 기록 | 브리지 쿠키 발급 | 배포 후 기록 |
+| 2단계 consume | 배포 후 기록 | 100% | 배포 후 기록 | 기존 브리지 쿠키로 JDBC 세션 생성 | 배포 후 기록 |
+
+이 표는 실제 운영 전환 후 Cloud Run 리비전, UTC/KST 시각, 세션 연속성 결과로
+갱신한다.

--- a/src/main/java/inu/timetable/TimeTableApplication.java
+++ b/src/main/java/inu/timetable/TimeTableApplication.java
@@ -2,8 +2,11 @@ package inu.timetable;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.session.SessionAutoConfiguration;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = SessionAutoConfiguration.class)
+@EnableScheduling
 public class TimeTableApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/inu/timetable/config/SecurityConfig.java
+++ b/src/main/java/inu/timetable/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package inu.timetable.config;
 
 import inu.timetable.security.LegacySha256DelegatingPasswordEncoder;
+import inu.timetable.security.SessionMigrationBridgeFilter;
 import inu.timetable.security.UserDetailsJpaService;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -22,6 +23,7 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.session.ChangeSessionIdAuthenticationStrategy;
 import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
 import org.springframework.security.web.context.HttpSessionSecurityContextRepository;
+import org.springframework.security.web.context.SecurityContextHolderFilter;
 import org.springframework.security.web.context.SecurityContextRepository;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 
@@ -62,7 +64,8 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(
             HttpSecurity http,
-            SecurityContextRepository securityContextRepository) throws Exception {
+            SecurityContextRepository securityContextRepository,
+            SessionMigrationBridgeFilter sessionMigrationBridgeFilter) throws Exception {
         http
                 .cors(Customizer.withDefaults())
                 .securityContext(context -> context.securityContextRepository(securityContextRepository))
@@ -102,7 +105,8 @@ public class SecurityConfig {
                                 response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "Login required")))
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .logout(AbstractHttpConfigurer::disable);
+                .logout(AbstractHttpConfigurer::disable)
+                .addFilterAfter(sessionMigrationBridgeFilter, SecurityContextHolderFilter.class);
 
         return http.build();
     }

--- a/src/main/java/inu/timetable/config/SharedJdbcSessionConfig.java
+++ b/src/main/java/inu/timetable/config/SharedJdbcSessionConfig.java
@@ -1,0 +1,42 @@
+package inu.timetable.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.jdbc.config.annotation.web.http.EnableJdbcHttpSession;
+import org.springframework.session.config.SessionRepositoryCustomizer;
+import org.springframework.session.jdbc.JdbcIndexedSessionRepository;
+import org.springframework.session.web.http.CookieSerializer;
+import org.springframework.session.web.http.DefaultCookieSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@ConditionalOnProperty(name = "session.shared.enabled", havingValue = "true")
+@EnableJdbcHttpSession(
+        maxInactiveIntervalInSeconds = 1800,
+        tableName = "SPRING_SESSION",
+        cleanupCron = "0 * * * * *")
+public class SharedJdbcSessionConfig {
+
+    @Bean
+    public CookieSerializer sessionCookieSerializer(
+            @Value("${server.servlet.session.cookie.path:/}") String cookiePath,
+            @Value("${server.servlet.session.cookie.secure:false}") boolean secure,
+            @Value("${server.servlet.session.cookie.same-site:lax}") String sameSite) {
+        DefaultCookieSerializer serializer = new DefaultCookieSerializer();
+        serializer.setCookieName("SESSION");
+        serializer.setCookiePath(cookiePath);
+        serializer.setUseHttpOnlyCookie(true);
+        serializer.setUseSecureCookie(secure);
+        serializer.setSameSite(sameSite);
+        return serializer;
+    }
+
+    @Bean
+    public SessionRepositoryCustomizer<JdbcIndexedSessionRepository> sessionTimeoutCustomizer(
+            @Value("${server.servlet.session.timeout:30m}") Duration timeout) {
+        return repository -> repository.setDefaultMaxInactiveInterval(timeout);
+    }
+}

--- a/src/main/java/inu/timetable/controller/AdminAuthController.java
+++ b/src/main/java/inu/timetable/controller/AdminAuthController.java
@@ -3,7 +3,9 @@ package inu.timetable.controller;
 import inu.timetable.dto.AdminAuthResponse;
 import inu.timetable.dto.AdminLoginRequest;
 import inu.timetable.service.AdminAuthService;
+import inu.timetable.service.SessionMigrationBridgeService;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -20,12 +22,18 @@ import java.util.Map;
 public class AdminAuthController {
 
     private final AdminAuthService adminAuthService;
+    private final SessionMigrationBridgeService sessionMigrationBridgeService;
 
     @PostMapping("/login")
     public AdminAuthResponse login(
             @Valid @RequestBody AdminLoginRequest request,
-            HttpServletRequest servletRequest) {
-        return adminAuthService.login(request.username(), request.password(), servletRequest);
+            HttpServletRequest servletRequest,
+            HttpServletResponse servletResponse) {
+        AdminAuthResponse response = adminAuthService.login(
+                request.username(), request.password(), servletRequest);
+        sessionMigrationBridgeService.rotateAdmin(
+                response.username(), servletRequest, servletResponse);
+        return response;
     }
 
     @GetMapping("/me")
@@ -34,7 +42,10 @@ public class AdminAuthController {
     }
 
     @PostMapping("/logout")
-    public Map<String, Object> logout(HttpServletRequest request) {
+    public Map<String, Object> logout(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        sessionMigrationBridgeService.revoke(request, response);
         adminAuthService.logout(request);
         return Map.of("loggedOut", true);
     }

--- a/src/main/java/inu/timetable/controller/AuthController.java
+++ b/src/main/java/inu/timetable/controller/AuthController.java
@@ -7,6 +7,7 @@ import inu.timetable.exception.ApiException;
 import inu.timetable.security.AuthenticatedUser;
 import inu.timetable.service.AuthService;
 import inu.timetable.service.LoginRateLimitService;
+import inu.timetable.service.SessionMigrationBridgeService;
 import inu.timetable.service.UserActivityService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -46,6 +47,7 @@ public class AuthController {
     private final SessionAuthenticationStrategy sessionAuthenticationStrategy;
     private final UserActivityService userActivityService;
     private final LoginRateLimitService loginRateLimitService;
+    private final SessionMigrationBridgeService sessionMigrationBridgeService;
 
     @PostMapping("/register")
     public ResponseEntity<?> register(
@@ -59,10 +61,11 @@ public class AuthController {
         List<AuthService.MajorSelection> majorSelections = parseMajorSelections(request.get("majors"));
 
         User user = authService.register(username, password, grade, major, majorSelections);
-        AuthenticatedUser principal = AuthenticatedUser.from(user);
+        AuthenticatedUser principal = AuthenticatedUser.forSession(user);
         Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(
                 principal, null, principal.getAuthorities());
         saveAuthentication(authentication, servletRequest, servletResponse);
+        sessionMigrationBridgeService.rotateUser(user.getId(), servletRequest, servletResponse);
         recordActivityQuietly(user.getId());
         return ResponseEntity.ok(UserResponse.from(user));
     }
@@ -87,10 +90,13 @@ public class AuthController {
         }
 
         loginRateLimitService.recordSuccess(username, servletRequest);
-        saveAuthentication(authentication, servletRequest, servletResponse);
-
-        AuthenticatedUser principal = (AuthenticatedUser) authentication.getPrincipal();
-        User user = authService.findById(principal.id());
+        AuthenticatedUser authenticatedPrincipal = (AuthenticatedUser) authentication.getPrincipal();
+        User user = authService.findById(authenticatedPrincipal.id());
+        AuthenticatedUser sessionPrincipal = AuthenticatedUser.forSession(user);
+        Authentication sessionAuthentication = UsernamePasswordAuthenticationToken.authenticated(
+                sessionPrincipal, null, sessionPrincipal.getAuthorities());
+        saveAuthentication(sessionAuthentication, servletRequest, servletResponse);
+        sessionMigrationBridgeService.rotateUser(user.getId(), servletRequest, servletResponse);
         recordActivityQuietly(user.getId());
         return ResponseEntity.ok(UserResponse.from(user));
     }
@@ -115,7 +121,7 @@ public class AuthController {
         List<AuthService.MajorSelection> majorSelections = parseMajorSelections(request.get("majors"));
 
         User user = authService.updateProfile(authenticatedUser.id(), grade, major, majorSelections);
-        AuthenticatedUser principal = AuthenticatedUser.from(user);
+        AuthenticatedUser principal = AuthenticatedUser.forSession(user);
         Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(
                 principal, null, principal.getAuthorities());
         replaceAuthentication(authentication, servletRequest, servletResponse);
@@ -129,6 +135,7 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        sessionMigrationBridgeService.revoke(request, response);
         new SecurityContextLogoutHandler().logout(
                 request,
                 response,
@@ -146,6 +153,7 @@ public class AuthController {
         }
 
         authService.withdraw(authenticatedUser.id());
+        sessionMigrationBridgeService.revoke(request, response);
         new SecurityContextLogoutHandler().logout(
                 request,
                 response,

--- a/src/main/java/inu/timetable/security/AuthenticatedUser.java
+++ b/src/main/java/inu/timetable/security/AuthenticatedUser.java
@@ -22,6 +22,14 @@ public record AuthenticatedUser(
                 List.of(new SimpleGrantedAuthority("ROLE_USER")));
     }
 
+    public static AuthenticatedUser forSession(User user) {
+        return new AuthenticatedUser(
+                user.getId(),
+                user.getUsername(),
+                null,
+                List.of(new SimpleGrantedAuthority("ROLE_USER")));
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return authorities;

--- a/src/main/java/inu/timetable/security/SessionMigrationBridgeFilter.java
+++ b/src/main/java/inu/timetable/security/SessionMigrationBridgeFilter.java
@@ -1,0 +1,128 @@
+package inu.timetable.security;
+
+import inu.timetable.entity.User;
+import inu.timetable.service.AdminAuthService;
+import inu.timetable.service.AuthService;
+import inu.timetable.service.SessionMigrationBridgeService;
+import inu.timetable.service.SessionMigrationPrincipal;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.context.SecurityContextRepository;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SessionMigrationBridgeFilter extends OncePerRequestFilter {
+
+    private final SessionMigrationBridgeService bridgeService;
+    private final AuthService authService;
+    private final SecurityContextRepository securityContextRepository;
+    private final SessionAuthenticationStrategy sessionAuthenticationStrategy;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain) throws ServletException, IOException {
+        if (bridgeService.isConsumeMode()) {
+            recoverSession(request, response);
+        } else if (bridgeService.isIssueMode() && !changesAuthentication(request)) {
+            bridgeService.issueForCurrentSession(request, response);
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean changesAuthentication(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        String method = request.getMethod();
+        return ("POST".equals(method)
+                    && ("/api/auth/login".equals(path)
+                        || "/api/auth/register".equals(path)
+                        || "/api/auth/logout".equals(path)
+                        || "/admin/api/auth/login".equals(path)
+                        || "/admin/api/auth/logout".equals(path)))
+                || ("DELETE".equals(method) && "/api/auth/me".equals(path));
+    }
+
+    private void recoverSession(HttpServletRequest request, HttpServletResponse response) {
+        if (alreadyAuthenticated(request) || !bridgeService.hasBridgeCookie(request)) {
+            return;
+        }
+
+        Optional<SessionMigrationPrincipal> migratedPrincipal;
+        try {
+            migratedPrincipal = bridgeService.consume(request);
+        } catch (RuntimeException exception) {
+            log.warn("Session migration token lookup failed", exception);
+            return;
+        }
+
+        if (migratedPrincipal.isEmpty()) {
+            bridgeService.clearCookie(response);
+            return;
+        }
+
+        try {
+            SessionMigrationPrincipal principal = migratedPrincipal.get();
+            if (principal.type() == SessionMigrationPrincipal.PrincipalType.USER) {
+                recoverUser(principal.userId(), request, response);
+            } else {
+                recoverAdmin(principal.adminUsername(), request);
+            }
+            bridgeService.clearCookie(response);
+        } catch (RuntimeException exception) {
+            bridgeService.clearCookie(response);
+            log.warn("Session migration principal recovery failed", exception);
+        }
+    }
+
+    private void recoverUser(
+            Long userId,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        User user = authService.findById(userId);
+        AuthenticatedUser principal = AuthenticatedUser.forSession(user);
+        Authentication authentication = UsernamePasswordAuthenticationToken.authenticated(
+                principal, null, principal.getAuthorities());
+
+        sessionAuthenticationStrategy.onAuthentication(authentication, request, response);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(authentication);
+        SecurityContextHolder.setContext(context);
+        securityContextRepository.saveContext(context, request, response);
+    }
+
+    private void recoverAdmin(String username, HttpServletRequest request) {
+        HttpSession session = request.getSession(true);
+        session.setAttribute(AdminAuthService.SESSION_AUTHENTICATED, true);
+        session.setAttribute(AdminAuthService.SESSION_USERNAME, username);
+    }
+
+    private boolean alreadyAuthenticated(HttpServletRequest request) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null
+                && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof AuthenticatedUser) {
+            return true;
+        }
+
+        HttpSession session = request.getSession(false);
+        return session != null
+                && Boolean.TRUE.equals(session.getAttribute(AdminAuthService.SESSION_AUTHENTICATED));
+    }
+}

--- a/src/main/java/inu/timetable/service/AdminAuthService.java
+++ b/src/main/java/inu/timetable/service/AdminAuthService.java
@@ -14,19 +14,16 @@ import org.springframework.web.server.ResponseStatusException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Service
 @RequiredArgsConstructor
 public class AdminAuthService {
 
     public static final String SESSION_AUTHENTICATED = "admin_authenticated";
     public static final String SESSION_USERNAME = "admin_username";
+    private static final String RATE_LIMIT_NAMESPACE = "ADMIN";
 
     private final BCryptPasswordEncoder passwordEncoder;
-    private final Map<String, LoginAttempt> loginAttempts = new ConcurrentHashMap<>();
+    private final LoginAttemptStore loginAttemptStore;
 
     @Value("${admin.username:}")
     private String adminUsername;
@@ -52,7 +49,7 @@ public class AdminAuthService {
             throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Invalid admin credentials");
         }
 
-        loginAttempts.remove(attemptKey);
+        loginAttemptStore.clear(RATE_LIMIT_NAMESPACE, attemptKey);
         HttpSession previousSession = request.getSession(false);
         if (previousSession != null) {
             previousSession.invalidate();
@@ -108,26 +105,18 @@ public class AdminAuthService {
     }
 
     private void rejectIfLocked(String attemptKey) {
-        LoginAttempt attempt = loginAttempts.get(attemptKey);
-        if (attempt == null || attempt.blockedUntil == null) {
-            return;
-        }
-        if (Instant.now().isBefore(attempt.blockedUntil)) {
+        if (loginAttemptStore.isBlocked(RATE_LIMIT_NAMESPACE, attemptKey)) {
             throw new ResponseStatusException(HttpStatus.TOO_MANY_REQUESTS,
                     "Too many failed admin login attempts. Try again later.");
         }
-        loginAttempts.remove(attemptKey);
     }
 
     private void recordFailure(String attemptKey) {
-        loginAttempts.compute(attemptKey, (key, current) -> {
-            LoginAttempt attempt = current == null ? new LoginAttempt() : current;
-            attempt.failedCount++;
-            if (attempt.failedCount >= maxFailures) {
-                attempt.blockedUntil = Instant.now().plus(Duration.ofMinutes(lockMinutes));
-            }
-            return attempt;
-        });
+        loginAttemptStore.recordFailure(
+                RATE_LIMIT_NAMESPACE,
+                attemptKey,
+                maxFailures,
+                Duration.ofMinutes(lockMinutes));
     }
 
     private String attemptKey(String username, HttpServletRequest request) {
@@ -137,10 +126,5 @@ public class AdminAuthService {
 
     private String clientIp(HttpServletRequest request) {
         return request.getRemoteAddr();
-    }
-
-    private static class LoginAttempt {
-        private int failedCount;
-        private Instant blockedUntil;
     }
 }

--- a/src/main/java/inu/timetable/service/AdminOperationLockService.java
+++ b/src/main/java/inu/timetable/service/AdminOperationLockService.java
@@ -5,23 +5,22 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.io.IOException;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Service
 public class AdminOperationLockService {
 
-    private final Set<String> runningOperations = ConcurrentHashMap.newKeySet();
+    private final DistributedOperationLockProvider lockProvider;
+
+    public AdminOperationLockService(DistributedOperationLockProvider lockProvider) {
+        this.lockProvider = lockProvider;
+    }
 
     public <T> T runExclusive(String operationKey, CheckedSupplier<T> supplier) throws IOException {
-        if (!runningOperations.add(operationKey)) {
-            throw new ResponseStatusException(HttpStatus.CONFLICT,
-                    "Same admin operation is already running");
-        }
-        try {
+        DistributedOperationLockProvider.LockHandle lockHandle =
+                lockProvider.tryAcquire(operationKey).orElseThrow(() ->
+                        new ResponseStatusException(HttpStatus.CONFLICT,
+                                "Same admin operation is already running"));
+        try (lockHandle) {
             return supplier.get();
-        } finally {
-            runningOperations.remove(operationKey);
         }
     }
 

--- a/src/main/java/inu/timetable/service/DistributedOperationLockProvider.java
+++ b/src/main/java/inu/timetable/service/DistributedOperationLockProvider.java
@@ -1,0 +1,14 @@
+package inu.timetable.service;
+
+import java.util.Optional;
+
+public interface DistributedOperationLockProvider {
+
+    Optional<LockHandle> tryAcquire(String operationKey);
+
+    @FunctionalInterface
+    interface LockHandle extends AutoCloseable {
+        @Override
+        void close();
+    }
+}

--- a/src/main/java/inu/timetable/service/JdbcLoginAttemptStore.java
+++ b/src/main/java/inu/timetable/service/JdbcLoginAttemptStore.java
@@ -1,0 +1,122 @@
+package inu.timetable.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DuplicateKeyException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Repository;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.HexFormat;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class JdbcLoginAttemptStore implements LoginAttemptStore {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    @Override
+    public boolean isBlocked(String namespace, String identity) {
+        String attemptKey = hash(namespace + ":" + identity);
+        List<OffsetDateTime> blockedUntilValues = jdbcTemplate.query("""
+                        SELECT blocked_until
+                        FROM login_rate_limits
+                        WHERE attempt_key = ?
+                        """,
+                (resultSet, rowNumber) ->
+                        resultSet.getObject("blocked_until", OffsetDateTime.class),
+                attemptKey);
+        if (blockedUntilValues.isEmpty() || blockedUntilValues.get(0) == null) {
+            return false;
+        }
+
+        OffsetDateTime blockedUntil = blockedUntilValues.get(0);
+        if (OffsetDateTime.now(ZoneOffset.UTC).isBefore(blockedUntil)) {
+            return true;
+        }
+        jdbcTemplate.update("DELETE FROM login_rate_limits WHERE attempt_key = ?", attemptKey);
+        return false;
+    }
+
+    @Override
+    public void recordFailure(
+            String namespace,
+            String identity,
+            int maxFailures,
+            Duration lockDuration) {
+        String attemptKey = hash(namespace + ":" + identity);
+        OffsetDateTime blockedUntil = OffsetDateTime.now(ZoneOffset.UTC).plus(lockDuration);
+        int updated = incrementExisting(attemptKey, maxFailures, blockedUntil);
+        if (updated > 0) {
+            return;
+        }
+
+        try {
+            jdbcTemplate.update("""
+                            INSERT INTO login_rate_limits (
+                                attempt_key,
+                                failed_count,
+                                blocked_until,
+                                updated_at
+                            ) VALUES (?, 1, ?, CURRENT_TIMESTAMP)
+                            """,
+                    attemptKey,
+                    maxFailures <= 1 ? blockedUntil : null);
+        } catch (DuplicateKeyException concurrentInsert) {
+            incrementExisting(attemptKey, maxFailures, blockedUntil);
+        }
+    }
+
+    @Override
+    public void clear(String namespace, String identity) {
+        jdbcTemplate.update("""
+                DELETE FROM login_rate_limits
+                WHERE attempt_key = ?
+                """, hash(namespace + ":" + identity));
+    }
+
+    @Override
+    @Scheduled(cron = "${login.rate-limit.cleanup-cron:0 17 * * * *}")
+    public int deleteStale() {
+        return jdbcTemplate.update("""
+                DELETE FROM login_rate_limits
+                WHERE updated_at < CURRENT_TIMESTAMP - INTERVAL '1 day'
+                  AND (blocked_until IS NULL OR blocked_until < CURRENT_TIMESTAMP)
+                """);
+    }
+
+    private int incrementExisting(
+            String attemptKey,
+            int maxFailures,
+            OffsetDateTime blockedUntil) {
+        return jdbcTemplate.update("""
+                        UPDATE login_rate_limits
+                        SET failed_count = failed_count + 1,
+                            blocked_until = CASE
+                                WHEN failed_count + 1 >= ? THEN ?
+                                ELSE blocked_until
+                            END,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE attempt_key = ?
+                        """,
+                maxFailures,
+                blockedUntil,
+                attemptKey);
+    }
+
+    static String hash(String value) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(value.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+}

--- a/src/main/java/inu/timetable/service/LocalOperationLockProvider.java
+++ b/src/main/java/inu/timetable/service/LocalOperationLockProvider.java
@@ -1,0 +1,23 @@
+package inu.timetable.service;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+@ConditionalOnProperty(name = "admin.operation-lock.provider", havingValue = "local")
+public class LocalOperationLockProvider implements DistributedOperationLockProvider {
+
+    private final Set<String> heldLocks = ConcurrentHashMap.newKeySet();
+
+    @Override
+    public Optional<LockHandle> tryAcquire(String operationKey) {
+        if (!heldLocks.add(operationKey)) {
+            return Optional.empty();
+        }
+        return Optional.of(() -> heldLocks.remove(operationKey));
+    }
+}

--- a/src/main/java/inu/timetable/service/LoginAttemptStore.java
+++ b/src/main/java/inu/timetable/service/LoginAttemptStore.java
@@ -1,0 +1,14 @@
+package inu.timetable.service;
+
+import java.time.Duration;
+
+public interface LoginAttemptStore {
+
+    boolean isBlocked(String namespace, String identity);
+
+    void recordFailure(String namespace, String identity, int maxFailures, Duration lockDuration);
+
+    void clear(String namespace, String identity);
+
+    int deleteStale();
+}

--- a/src/main/java/inu/timetable/service/LoginRateLimitService.java
+++ b/src/main/java/inu/timetable/service/LoginRateLimitService.java
@@ -8,14 +8,16 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.Duration;
-import java.time.Instant;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 @Service
 public class LoginRateLimitService {
 
-    private final Map<String, LoginAttempt> loginAttempts = new ConcurrentHashMap<>();
+    private static final String NAMESPACE = "USER";
+
+    private final LoginAttemptStore loginAttemptStore;
+
+    public LoginRateLimitService(LoginAttemptStore loginAttemptStore) {
+        this.loginAttemptStore = loginAttemptStore;
+    }
 
     @Value("${user.login.max-failures:5}")
     private int maxFailures;
@@ -25,34 +27,23 @@ public class LoginRateLimitService {
 
     public void rejectIfLocked(String username, HttpServletRequest request) {
         String attemptKey = attemptKey(username, request);
-        LoginAttempt attempt = loginAttempts.get(attemptKey);
-        if (attempt == null || attempt.blockedUntil == null) {
-            return;
-        }
-
-        if (Instant.now().isBefore(attempt.blockedUntil)) {
+        if (loginAttemptStore.isBlocked(NAMESPACE, attemptKey)) {
             throw new ResponseStatusException(
                     HttpStatus.TOO_MANY_REQUESTS,
                     "로그인 실패가 반복되었습니다. 잠시 후 다시 시도해주세요.");
         }
-
-        loginAttempts.remove(attemptKey);
     }
 
     public void recordFailure(String username, HttpServletRequest request) {
-        String attemptKey = attemptKey(username, request);
-        loginAttempts.compute(attemptKey, (key, current) -> {
-            LoginAttempt attempt = current == null ? new LoginAttempt() : current;
-            attempt.failedCount++;
-            if (attempt.failedCount >= maxFailures) {
-                attempt.blockedUntil = Instant.now().plus(Duration.ofMinutes(lockMinutes));
-            }
-            return attempt;
-        });
+        loginAttemptStore.recordFailure(
+                NAMESPACE,
+                attemptKey(username, request),
+                maxFailures,
+                Duration.ofMinutes(lockMinutes));
     }
 
     public void recordSuccess(String username, HttpServletRequest request) {
-        loginAttempts.remove(attemptKey(username, request));
+        loginAttemptStore.clear(NAMESPACE, attemptKey(username, request));
     }
 
     private String attemptKey(String username, HttpServletRequest request) {
@@ -66,10 +57,5 @@ public class LoginRateLimitService {
         // 신뢰된 프록시(nginx) 뒤의 실제 IP 보정은 server.forward-headers-strategy=framework
         // (운영 프로파일)가 처리하므로, 여기서는 컨테이너가 인지한 원격 주소만 사용한다.
         return request.getRemoteAddr();
-    }
-
-    private static class LoginAttempt {
-        private int failedCount;
-        private Instant blockedUntil;
     }
 }

--- a/src/main/java/inu/timetable/service/PostgresAdvisoryLockProvider.java
+++ b/src/main/java/inu/timetable/service/PostgresAdvisoryLockProvider.java
@@ -1,0 +1,89 @@
+package inu.timetable.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+import javax.sql.DataSource;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Optional;
+
+@Component
+@ConditionalOnProperty(
+        name = "admin.operation-lock.provider",
+        havingValue = "postgres",
+        matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class PostgresAdvisoryLockProvider implements DistributedOperationLockProvider {
+
+    private final DataSource dataSource;
+
+    @Override
+    public Optional<LockHandle> tryAcquire(String operationKey) {
+        long lockKey = stableLockKey(operationKey);
+        Connection connection = null;
+        try {
+            connection = dataSource.getConnection();
+            if (!tryLock(connection, lockKey)) {
+                connection.close();
+                return Optional.empty();
+            }
+            Connection lockConnection = connection;
+            return Optional.of(() -> unlockAndClose(lockConnection, lockKey));
+        } catch (SQLException exception) {
+            closeQuietly(connection);
+            throw new IllegalStateException("Failed to acquire PostgreSQL advisory lock", exception);
+        }
+    }
+
+    static long stableLockKey(String operationKey) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(operationKey.getBytes(StandardCharsets.UTF_8));
+            return ByteBuffer.wrap(digest).getLong();
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+
+    private boolean tryLock(Connection connection, long lockKey) throws SQLException {
+        try (PreparedStatement statement =
+                     connection.prepareStatement("SELECT pg_try_advisory_lock(?)")) {
+            statement.setLong(1, lockKey);
+            try (ResultSet resultSet = statement.executeQuery()) {
+                return resultSet.next() && resultSet.getBoolean(1);
+            }
+        }
+    }
+
+    private void unlockAndClose(Connection connection, long lockKey) {
+        try (connection;
+             PreparedStatement statement =
+                     connection.prepareStatement("SELECT pg_advisory_unlock(?)")) {
+            statement.setLong(1, lockKey);
+            statement.execute();
+        } catch (SQLException exception) {
+            log.error("Failed to release PostgreSQL advisory lock: key={}", lockKey, exception);
+        }
+    }
+
+    private void closeQuietly(Connection connection) {
+        if (connection == null) {
+            return;
+        }
+        try {
+            connection.close();
+        } catch (SQLException exception) {
+            log.warn("Failed to close advisory-lock connection", exception);
+        }
+    }
+}

--- a/src/main/java/inu/timetable/service/SessionMigrationBridgeService.java
+++ b/src/main/java/inu/timetable/service/SessionMigrationBridgeService.java
@@ -1,0 +1,158 @@
+package inu.timetable.service;
+
+import inu.timetable.security.AuthenticatedUser;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.Locale;
+import java.util.Optional;
+
+@Service
+public class SessionMigrationBridgeService {
+
+    private final SessionMigrationTokenService tokenService;
+    private final Mode mode;
+    private final String cookieName;
+    private final Duration ttl;
+    private final boolean cookieSecure;
+    private final String cookieSameSite;
+    private final String cookiePath;
+
+    public SessionMigrationBridgeService(
+            SessionMigrationTokenService tokenService,
+            @Value("${session.bridge.mode:off}") String mode,
+            @Value("${session.bridge.cookie-name:INU_SESSION_BRIDGE}") String cookieName,
+            @Value("${session.bridge.ttl:30m}") Duration ttl,
+            @Value("${server.servlet.session.cookie.secure:false}") boolean cookieSecure,
+            @Value("${server.servlet.session.cookie.same-site:lax}") String cookieSameSite,
+            @Value("${server.servlet.session.cookie.path:/}") String cookiePath) {
+        this.tokenService = tokenService;
+        this.mode = Mode.valueOf(mode.trim().toUpperCase(Locale.ROOT));
+        this.cookieName = cookieName;
+        this.ttl = ttl;
+        this.cookieSecure = cookieSecure;
+        this.cookieSameSite = cookieSameSite;
+        this.cookiePath = cookiePath;
+    }
+
+    public boolean isIssueMode() {
+        return mode == Mode.ISSUE;
+    }
+
+    public boolean isConsumeMode() {
+        return mode == Mode.CONSUME;
+    }
+
+    public void issueForCurrentSession(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        if (!isIssueMode() || findCookie(request).isPresent()) {
+            return;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication != null
+                && authentication.isAuthenticated()
+                && authentication.getPrincipal() instanceof AuthenticatedUser user) {
+            issueUser(user.id(), response);
+            return;
+        }
+
+        HttpSession session = request.getSession(false);
+        if (session != null
+                && Boolean.TRUE.equals(session.getAttribute(AdminAuthService.SESSION_AUTHENTICATED))) {
+            String username = (String) session.getAttribute(AdminAuthService.SESSION_USERNAME);
+            issueAdmin(username, response);
+        }
+    }
+
+    public void issueUser(Long userId, HttpServletResponse response) {
+        if (isIssueMode()) {
+            addCookie(response, tokenService.issue(SessionMigrationPrincipal.user(userId), ttl), ttl);
+        }
+    }
+
+    public void rotateUser(
+            Long userId,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        revoke(request, response);
+        issueUser(userId, response);
+    }
+
+    public void issueAdmin(String username, HttpServletResponse response) {
+        if (isIssueMode()) {
+            addCookie(response, tokenService.issue(SessionMigrationPrincipal.admin(username), ttl), ttl);
+        }
+    }
+
+    public void rotateAdmin(
+            String username,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        revoke(request, response);
+        issueAdmin(username, response);
+    }
+
+    public Optional<SessionMigrationPrincipal> consume(HttpServletRequest request) {
+        if (!isConsumeMode()) {
+            return Optional.empty();
+        }
+        return findCookie(request).flatMap(cookie -> tokenService.consume(cookie.getValue()));
+    }
+
+    public boolean hasBridgeCookie(HttpServletRequest request) {
+        return findCookie(request).isPresent();
+    }
+
+    public void clearCookie(HttpServletResponse response) {
+        addCookie(response, "", Duration.ZERO);
+    }
+
+    public void revoke(HttpServletRequest request, HttpServletResponse response) {
+        if (mode == Mode.OFF) {
+            return;
+        }
+        findCookie(request).ifPresent(cookie -> {
+            tokenService.revoke(cookie.getValue());
+            clearCookie(response);
+        });
+    }
+
+    private Optional<Cookie> findCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
+            return Optional.empty();
+        }
+        return Arrays.stream(cookies)
+                .filter(cookie -> cookieName.equals(cookie.getName()))
+                .findFirst();
+    }
+
+    private void addCookie(HttpServletResponse response, String value, Duration maxAge) {
+        ResponseCookie cookie = ResponseCookie.from(cookieName, value)
+                .httpOnly(true)
+                .secure(cookieSecure)
+                .sameSite(cookieSameSite)
+                .path(cookiePath)
+                .maxAge(maxAge)
+                .build();
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+
+    enum Mode {
+        OFF,
+        ISSUE,
+        CONSUME
+    }
+}

--- a/src/main/java/inu/timetable/service/SessionMigrationPrincipal.java
+++ b/src/main/java/inu/timetable/service/SessionMigrationPrincipal.java
@@ -1,0 +1,20 @@
+package inu.timetable.service;
+
+public record SessionMigrationPrincipal(
+        PrincipalType type,
+        Long userId,
+        String adminUsername) {
+
+    public static SessionMigrationPrincipal user(Long userId) {
+        return new SessionMigrationPrincipal(PrincipalType.USER, userId, null);
+    }
+
+    public static SessionMigrationPrincipal admin(String username) {
+        return new SessionMigrationPrincipal(PrincipalType.ADMIN, null, username);
+    }
+
+    public enum PrincipalType {
+        USER,
+        ADMIN
+    }
+}

--- a/src/main/java/inu/timetable/service/SessionMigrationTokenService.java
+++ b/src/main/java/inu/timetable/service/SessionMigrationTokenService.java
@@ -1,0 +1,156 @@
+package inu.timetable.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Slf4j
+public class SessionMigrationTokenService {
+
+    private static final int TOKEN_BYTES = 32;
+    private static final int MAX_ISSUE_ATTEMPTS = 3;
+
+    private final JdbcTemplate jdbcTemplate;
+    private final TransactionTemplate transactionTemplate;
+    private final SecureRandom secureRandom;
+
+    @Autowired
+    public SessionMigrationTokenService(
+            JdbcTemplate jdbcTemplate,
+            TransactionTemplate transactionTemplate) {
+        this(jdbcTemplate, transactionTemplate, new SecureRandom());
+    }
+
+    SessionMigrationTokenService(
+            JdbcTemplate jdbcTemplate,
+            TransactionTemplate transactionTemplate,
+            SecureRandom secureRandom) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.transactionTemplate = transactionTemplate;
+        this.secureRandom = secureRandom;
+    }
+
+    public String issue(SessionMigrationPrincipal principal, Duration ttl) {
+        OffsetDateTime expiresAt = OffsetDateTime.now(ZoneOffset.UTC).plus(ttl);
+        for (int attempt = 0; attempt < MAX_ISSUE_ATTEMPTS; attempt++) {
+            String rawToken = generateToken();
+            try {
+                jdbcTemplate.update("""
+                                INSERT INTO session_migration_tokens (
+                                    token_hash,
+                                    principal_type,
+                                    user_id,
+                                    admin_username,
+                                    expires_at
+                                ) VALUES (?, ?, ?, ?, ?)
+                                """,
+                        hash(rawToken),
+                        principal.type().name(),
+                        principal.userId(),
+                        principal.adminUsername(),
+                        expiresAt);
+                return rawToken;
+            } catch (org.springframework.dao.DuplicateKeyException collision) {
+                log.warn("Session migration token collision; retrying");
+            }
+        }
+        throw new IllegalStateException("Failed to issue a unique session migration token");
+    }
+
+    /**
+     * 토큰 조회와 삭제를 한 트랜잭션의 행 잠금 안에서 처리한다.
+     * 동시에 여러 인스턴스로 요청이 들어와도 한 요청만 principal 을 받는다.
+     */
+    public Optional<SessionMigrationPrincipal> consume(String rawToken) {
+        if (rawToken == null || rawToken.isBlank()) {
+            return Optional.empty();
+        }
+
+        Optional<SessionMigrationPrincipal> result = transactionTemplate.execute(status -> {
+            List<SessionMigrationPrincipal> principals = jdbcTemplate.query("""
+                            SELECT principal_type, user_id, admin_username
+                            FROM session_migration_tokens
+                            WHERE token_hash = ?
+                              AND expires_at > CURRENT_TIMESTAMP
+                            FOR UPDATE
+                            """,
+                    (resultSet, rowNumber) -> new SessionMigrationPrincipal(
+                            SessionMigrationPrincipal.PrincipalType.valueOf(
+                                    resultSet.getString("principal_type")),
+                            resultSet.getObject("user_id", Long.class),
+                            resultSet.getString("admin_username")),
+                    hash(rawToken));
+
+            if (principals.isEmpty()) {
+                jdbcTemplate.update("""
+                        DELETE FROM session_migration_tokens
+                        WHERE token_hash = ?
+                        """, hash(rawToken));
+                return Optional.empty();
+            }
+
+            jdbcTemplate.update("""
+                    DELETE FROM session_migration_tokens
+                    WHERE token_hash = ?
+                    """, hash(rawToken));
+            return Optional.of(principals.get(0));
+        });
+        return result == null ? Optional.empty() : result;
+    }
+
+    public int deleteExpired() {
+        return jdbcTemplate.update("""
+                DELETE FROM session_migration_tokens
+                WHERE expires_at <= CURRENT_TIMESTAMP
+                """);
+    }
+
+    public void revoke(String rawToken) {
+        if (rawToken == null || rawToken.isBlank()) {
+            return;
+        }
+        jdbcTemplate.update("""
+                DELETE FROM session_migration_tokens
+                WHERE token_hash = ?
+                """, hash(rawToken));
+    }
+
+    @Scheduled(cron = "${session.bridge.cleanup-cron:0 11 * * * *}")
+    public void cleanupExpired() {
+        int deleted = deleteExpired();
+        if (deleted > 0) {
+            log.info("Deleted {} expired session migration tokens", deleted);
+        }
+    }
+
+    static String hash(String rawToken) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256")
+                    .digest(rawToken.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is not available", impossible);
+        }
+    }
+
+    private String generateToken() {
+        byte[] token = new byte[TOKEN_BYTES];
+        secureRandom.nextBytes(token);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(token);
+    }
+}

--- a/src/main/java/inu/timetable/service/SharedSubjectCacheInvalidationService.java
+++ b/src/main/java/inu/timetable/service/SharedSubjectCacheInvalidationService.java
@@ -1,0 +1,84 @@
+package inu.timetable.service;
+
+import inu.timetable.event.SubjectDataChangedEvent;
+import inu.timetable.event.SubjectPopularityChangedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class SharedSubjectCacheInvalidationService {
+
+    static final String SCOPE_ALL = "subject-all";
+    static final String SCOPE_FILTERS = "subject-filters";
+
+    private final JdbcTemplate jdbcTemplate;
+    private final CacheManager cacheManager;
+    private final Map<String, Long> observedVersions = new ConcurrentHashMap<>();
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void publishSubjectDataChanged(SubjectDataChangedEvent event) {
+        incrementVersion(SCOPE_ALL);
+    }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
+    public void publishPopularityChanged(SubjectPopularityChangedEvent event) {
+        incrementVersion(SCOPE_FILTERS);
+    }
+
+    @Scheduled(fixedDelayString = "${subject.cache.invalidation.poll-interval-ms:1000}")
+    public void synchronizeLocalCaches() {
+        jdbcTemplate.query("""
+                        SELECT cache_scope, version
+                        FROM shared_cache_versions
+                        """,
+                resultSet -> {
+                    String scope = resultSet.getString("cache_scope");
+                    long currentVersion = resultSet.getLong("version");
+                    Long previousVersion = observedVersions.put(scope, currentVersion);
+                    if (previousVersion != null && currentVersion > previousVersion) {
+                        clearScope(scope);
+                        log.info(
+                                "Applied shared cache invalidation: scope={}, version={}",
+                                scope,
+                                currentVersion);
+                    }
+                });
+    }
+
+    private void incrementVersion(String scope) {
+        jdbcTemplate.update("""
+                        UPDATE shared_cache_versions
+                        SET version = version + 1,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE cache_scope = ?
+                        """,
+                scope);
+    }
+
+    private void clearScope(String scope) {
+        if (SCOPE_ALL.equals(scope)) {
+            SubjectCacheNames.ALL.forEach(this::clearCache);
+        } else if (SCOPE_FILTERS.equals(scope)) {
+            clearCache(SubjectCacheNames.SUBJECT_FILTERS);
+        }
+    }
+
+    private void clearCache(String cacheName) {
+        Cache cache = cacheManager.getCache(cacheName);
+        if (cache != null) {
+            cache.clear();
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,6 +45,16 @@ server:
         secure: ${SESSION_COOKIE_SECURE:false}
         same-site: ${SESSION_COOKIE_SAME_SITE:lax}
 
+session:
+  # Boot 3.5는 store-type 스위치를 제거했으므로 명시적인 조건부 설정으로 켠다.
+  # 1단계는 false, 2단계는 SHARED_SESSION_ENABLED=true.
+  shared:
+    enabled: ${SHARED_SESSION_ENABLED:false}
+  bridge:
+    mode: ${SESSION_BRIDGE_MODE:off}
+    cookie-name: ${SESSION_BRIDGE_COOKIE_NAME:INU_SESSION_BRIDGE}
+    ttl: ${SESSION_BRIDGE_TTL:30m}
+
 gemini:
   api:
     key: ${GEMINI_API_KEY}
@@ -72,6 +82,8 @@ subject:
       enabled: ${SUBJECT_CACHE_WARM_UP_ENABLED:true}
       concurrency: ${SUBJECT_CACHE_WARM_UP_CONCURRENCY:4}
       page-size: ${SUBJECT_CACHE_WARM_UP_PAGE_SIZE:20}
+    invalidation:
+      poll-interval-ms: ${SUBJECT_CACHE_INVALIDATION_POLL_INTERVAL_MS:1000}
 
 # Actuator 모니터링 설정
 management:

--- a/src/main/resources/db/migration/V20260727_01__create_shared_session_infrastructure.sql
+++ b/src/main/resources/db/migration/V20260727_01__create_shared_session_infrastructure.sql
@@ -1,0 +1,67 @@
+CREATE TABLE IF NOT EXISTS spring_session (
+    primary_id CHAR(36) NOT NULL,
+    session_id CHAR(36) NOT NULL,
+    creation_time BIGINT NOT NULL,
+    last_access_time BIGINT NOT NULL,
+    max_inactive_interval INT NOT NULL,
+    expiry_time BIGINT NOT NULL,
+    principal_name VARCHAR(100),
+    CONSTRAINT spring_session_pk PRIMARY KEY (primary_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS spring_session_ix1 ON spring_session (session_id);
+CREATE INDEX IF NOT EXISTS spring_session_ix2 ON spring_session (expiry_time);
+CREATE INDEX IF NOT EXISTS spring_session_ix3 ON spring_session (principal_name);
+
+CREATE TABLE IF NOT EXISTS spring_session_attributes (
+    session_primary_id CHAR(36) NOT NULL,
+    attribute_name VARCHAR(200) NOT NULL,
+    attribute_bytes BYTEA NOT NULL,
+    CONSTRAINT spring_session_attributes_pk PRIMARY KEY (session_primary_id, attribute_name),
+    CONSTRAINT spring_session_attributes_fk FOREIGN KEY (session_primary_id)
+        REFERENCES spring_session(primary_id) ON DELETE CASCADE
+);
+
+CREATE TABLE IF NOT EXISTS session_migration_tokens (
+    token_hash CHAR(64) NOT NULL,
+    principal_type VARCHAR(16) NOT NULL,
+    user_id BIGINT,
+    admin_username VARCHAR(100),
+    expires_at TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT session_migration_tokens_pk PRIMARY KEY (token_hash),
+    CONSTRAINT session_migration_tokens_principal_type_ck
+        CHECK (principal_type IN ('USER', 'ADMIN')),
+    CONSTRAINT session_migration_tokens_principal_ck
+        CHECK (
+            (principal_type = 'USER' AND user_id IS NOT NULL AND admin_username IS NULL)
+            OR
+            (principal_type = 'ADMIN' AND user_id IS NULL AND admin_username IS NOT NULL)
+        )
+);
+
+CREATE INDEX IF NOT EXISTS session_migration_tokens_expiry_ix
+    ON session_migration_tokens (expires_at);
+
+CREATE TABLE IF NOT EXISTS login_rate_limits (
+    attempt_key CHAR(64) NOT NULL,
+    failed_count INT NOT NULL,
+    blocked_until TIMESTAMP WITH TIME ZONE,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT login_rate_limits_pk PRIMARY KEY (attempt_key),
+    CONSTRAINT login_rate_limits_failed_count_ck CHECK (failed_count >= 0)
+);
+
+CREATE INDEX IF NOT EXISTS login_rate_limits_updated_at_ix
+    ON login_rate_limits (updated_at);
+
+CREATE TABLE IF NOT EXISTS shared_cache_versions (
+    cache_scope VARCHAR(100) NOT NULL,
+    version BIGINT NOT NULL DEFAULT 0,
+    updated_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT shared_cache_versions_pk PRIMARY KEY (cache_scope)
+);
+
+INSERT INTO shared_cache_versions (cache_scope, version)
+VALUES ('subject-all', 0), ('subject-filters', 0)
+ON CONFLICT (cache_scope) DO NOTHING;

--- a/src/test/java/inu/timetable/controller/SessionMigrationBridgeIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/SessionMigrationBridgeIntegrationTest.java
@@ -1,0 +1,128 @@
+package inu.timetable.controller;
+
+import inu.timetable.entity.User;
+import inu.timetable.repository.UserRepository;
+import inu.timetable.security.AuthenticatedUser;
+import inu.timetable.service.SessionMigrationPrincipal;
+import inu.timetable.service.SessionMigrationTokenService;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockCookie;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Duration;
+import java.io.ByteArrayInputStream;
+import java.io.ObjectInputStream;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "session.shared.enabled=true",
+        "session.bridge.mode=consume"
+})
+class SessionMigrationBridgeIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder userPasswordEncoder;
+
+    @Autowired
+    private SessionMigrationTokenService tokenService;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void oneTimeBridgeTokenCreatesReusableJdbcUserSession() throws Exception {
+        String username = "bridge-" + UUID.randomUUID();
+        User user = userRepository.save(User.builder()
+                .username(username)
+                .password(userPasswordEncoder.encode("password123"))
+                .grade(2)
+                .major("컴퓨터공학부")
+                .build());
+        String token = tokenService.issue(
+                SessionMigrationPrincipal.user(user.getId()),
+                Duration.ofMinutes(30));
+
+        var migrated = mockMvc.perform(get("/api/auth/me")
+                        .cookie(new MockCookie("INU_SESSION_BRIDGE", token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(username))
+                .andReturn();
+
+        Cookie sessionCookie = migrated.getResponse().getCookie("SESSION");
+        assertThat(sessionCookie).isNotNull();
+        assertThat(migrated.getResponse().getHeaders(HttpHeaders.SET_COOKIE))
+                .anyMatch(header -> header.startsWith("INU_SESSION_BRIDGE=")
+                        && header.contains("Max-Age=0"));
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM spring_session",
+                Integer.class)).isGreaterThanOrEqualTo(1);
+        byte[] serializedSecurityContext = jdbcTemplate.queryForObject("""
+                SELECT attribute_bytes
+                FROM spring_session_attributes
+                WHERE attribute_name = 'SPRING_SECURITY_CONTEXT'
+                ORDER BY session_primary_id DESC
+                LIMIT 1
+                """, byte[].class);
+        SecurityContext storedContext;
+        try (ObjectInputStream input =
+                     new ObjectInputStream(new ByteArrayInputStream(serializedSecurityContext))) {
+            storedContext = (SecurityContext) input.readObject();
+        }
+        AuthenticatedUser storedPrincipal =
+                (AuthenticatedUser) storedContext.getAuthentication().getPrincipal();
+        assertThat(storedPrincipal.password()).isNull();
+
+        mockMvc.perform(get("/api/auth/me").cookie(sessionCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.username").value(username));
+
+        mockMvc.perform(get("/api/auth/me")
+                        .cookie(new MockCookie("INU_SESSION_BRIDGE", token)))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void bridgeAlsoMigratesAdminSession() throws Exception {
+        String token = tokenService.issue(
+                SessionMigrationPrincipal.admin("admin"),
+                Duration.ofMinutes(30));
+
+        var migrated = mockMvc.perform(get("/admin/api/auth/me")
+                        .cookie(new MockCookie("INU_SESSION_BRIDGE", token)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true))
+                .andExpect(jsonPath("$.username").value("admin"))
+                .andReturn();
+
+        Cookie sessionCookie = migrated.getResponse().getCookie("SESSION");
+        assertThat(sessionCookie).isNotNull();
+
+        mockMvc.perform(get("/admin/api/auth/me").cookie(sessionCookie))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.authenticated").value(true));
+    }
+}

--- a/src/test/java/inu/timetable/controller/SessionMigrationBridgeIssueIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/SessionMigrationBridgeIssueIntegrationTest.java
@@ -1,0 +1,101 @@
+package inu.timetable.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@TestPropertySource(properties = {
+        "session.shared.enabled=false",
+        "session.bridge.mode=issue"
+})
+class SessionMigrationBridgeIssueIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    void loginIssuesOpaqueBridgeCookieAndStoresOnlyItsHash() throws Exception {
+        String username = "issue-" + UUID.randomUUID();
+        var register = mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(java.util.Map.of(
+                                "username", username,
+                                "password", "password123",
+                                "grade", 2,
+                                "major", "컴퓨터공학부"))))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        Cookie bridgeCookie = register.getResponse().getCookie("INU_SESSION_BRIDGE");
+        assertThat(bridgeCookie).isNotNull();
+        assertThat(bridgeCookie.isHttpOnly()).isTrue();
+        assertThat(bridgeCookie.getValue()).doesNotContain(username);
+
+        String storedHash = jdbcTemplate.queryForObject("""
+                SELECT token_hash
+                FROM session_migration_tokens
+                WHERE principal_type = 'USER'
+                ORDER BY created_at DESC
+                LIMIT 1
+                """, String.class);
+        assertThat(storedHash).isEqualTo(sha256(bridgeCookie.getValue()));
+        assertThat(storedHash).doesNotContain(bridgeCookie.getValue());
+
+        MockHttpSession session = (MockHttpSession) register.getRequest().getSession(false);
+        var csrf = mockMvc.perform(get("/api/auth/csrf")
+                        .session(session)
+                        .cookie(bridgeCookie))
+                .andExpect(status().isOk())
+                .andReturn();
+        String csrfToken = objectMapper.readTree(csrf.getResponse().getContentAsString())
+                .get("token")
+                .asText();
+
+        var logout = mockMvc.perform(post("/api/auth/logout")
+                        .session(session)
+                        .cookie(bridgeCookie, csrf.getResponse().getCookie("XSRF-TOKEN"))
+                        .header("X-XSRF-TOKEN", csrfToken))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertThat(jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM session_migration_tokens",
+                Integer.class)).isZero();
+        assertThat(logout.getResponse().getHeaders("Set-Cookie"))
+                .anyMatch(header -> header.startsWith("INU_SESSION_BRIDGE=")
+                        && header.contains("Max-Age=0"));
+    }
+
+    private String sha256(String value) throws Exception {
+        return HexFormat.of().formatHex(MessageDigest.getInstance("SHA-256")
+                .digest(value.getBytes(StandardCharsets.UTF_8)));
+    }
+}

--- a/src/test/java/inu/timetable/service/AdminAccessGuardTest.java
+++ b/src/test/java/inu/timetable/service/AdminAccessGuardTest.java
@@ -17,7 +17,9 @@ class AdminAccessGuardTest {
 
     @BeforeEach
     void setUp() {
-        adminAuthService = new AdminAuthService(new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder(4));
+        adminAuthService = new AdminAuthService(
+                new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder(4),
+                new InMemoryLoginAttemptStore());
         adminAccessGuard = new AdminAccessGuard(adminAuthService);
     }
 

--- a/src/test/java/inu/timetable/service/AdminAuthServiceTest.java
+++ b/src/test/java/inu/timetable/service/AdminAuthServiceTest.java
@@ -20,7 +20,7 @@ class AdminAuthServiceTest {
 
     @BeforeEach
     void setUp() {
-        adminAuthService = new AdminAuthService(passwordEncoder);
+        adminAuthService = new AdminAuthService(passwordEncoder, new InMemoryLoginAttemptStore());
         ReflectionTestUtils.setField(adminAuthService, "adminUsername", "admin");
         ReflectionTestUtils.setField(adminAuthService, "adminPasswordHash", passwordEncoder.encode("secret"));
         ReflectionTestUtils.setField(adminAuthService, "legacyAdminPassword", "");

--- a/src/test/java/inu/timetable/service/AdminOperationLockServiceTest.java
+++ b/src/test/java/inu/timetable/service/AdminOperationLockServiceTest.java
@@ -4,12 +4,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class AdminOperationLockServiceTest {
 
-    private final AdminOperationLockService adminOperationLockService = new AdminOperationLockService();
+    private final AdminOperationLockService adminOperationLockService =
+            new AdminOperationLockService(new InMemoryLockProvider());
 
     @Test
     void rejectsSameOperationWhileAlreadyRunning() {
@@ -27,5 +31,17 @@ class AdminOperationLockServiceTest {
 
         assertThat(first).isEqualTo("first");
         assertThat(second).isEqualTo("second");
+    }
+
+    private static class InMemoryLockProvider implements DistributedOperationLockProvider {
+        private final Set<String> heldLocks = ConcurrentHashMap.newKeySet();
+
+        @Override
+        public java.util.Optional<LockHandle> tryAcquire(String operationKey) {
+            if (!heldLocks.add(operationKey)) {
+                return java.util.Optional.empty();
+            }
+            return java.util.Optional.of(() -> heldLocks.remove(operationKey));
+        }
     }
 }

--- a/src/test/java/inu/timetable/service/InMemoryLoginAttemptStore.java
+++ b/src/test/java/inu/timetable/service/InMemoryLoginAttemptStore.java
@@ -1,0 +1,59 @@
+package inu.timetable.service;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+class InMemoryLoginAttemptStore implements LoginAttemptStore {
+
+    private final Map<String, Attempt> attempts = new ConcurrentHashMap<>();
+
+    @Override
+    public boolean isBlocked(String namespace, String identity) {
+        Attempt attempt = attempts.get(key(namespace, identity));
+        if (attempt == null || attempt.blockedUntil == null) {
+            return false;
+        }
+        if (Instant.now().isBefore(attempt.blockedUntil)) {
+            return true;
+        }
+        attempts.remove(key(namespace, identity));
+        return false;
+    }
+
+    @Override
+    public void recordFailure(
+            String namespace,
+            String identity,
+            int maxFailures,
+            Duration lockDuration) {
+        attempts.compute(key(namespace, identity), (key, current) -> {
+            Attempt attempt = current == null ? new Attempt() : current;
+            attempt.failedCount++;
+            if (attempt.failedCount >= maxFailures) {
+                attempt.blockedUntil = Instant.now().plus(lockDuration);
+            }
+            return attempt;
+        });
+    }
+
+    @Override
+    public void clear(String namespace, String identity) {
+        attempts.remove(key(namespace, identity));
+    }
+
+    @Override
+    public int deleteStale() {
+        return 0;
+    }
+
+    private String key(String namespace, String identity) {
+        return namespace + ":" + identity;
+    }
+
+    private static class Attempt {
+        private int failedCount;
+        private Instant blockedUntil;
+    }
+}

--- a/src/test/java/inu/timetable/service/JdbcLoginAttemptStoreTest.java
+++ b/src/test/java/inu/timetable/service/JdbcLoginAttemptStoreTest.java
@@ -1,0 +1,39 @@
+package inu.timetable.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JdbcTest
+@Import(JdbcLoginAttemptStore.class)
+class JdbcLoginAttemptStoreTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void separateStoreInstancesShareFailureAndUnlockState() {
+        LoginAttemptStore firstInstance = new JdbcLoginAttemptStore(jdbcTemplate);
+        LoginAttemptStore secondInstance = new JdbcLoginAttemptStore(jdbcTemplate);
+
+        firstInstance.recordFailure("USER", "student@127.0.0.1", 2, Duration.ofMinutes(10));
+        secondInstance.recordFailure("USER", "student@127.0.0.1", 2, Duration.ofMinutes(10));
+
+        assertThat(firstInstance.isBlocked("USER", "student@127.0.0.1")).isTrue();
+        assertThat(secondInstance.isBlocked("USER", "student@127.0.0.1")).isTrue();
+
+        secondInstance.clear("USER", "student@127.0.0.1");
+
+        assertThat(firstInstance.isBlocked("USER", "student@127.0.0.1")).isFalse();
+        String storedKey = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM login_rate_limits",
+                Integer.class).toString();
+        assertThat(storedKey).isEqualTo("0");
+    }
+}

--- a/src/test/java/inu/timetable/service/PostgresAdvisoryLockProviderTest.java
+++ b/src/test/java/inu/timetable/service/PostgresAdvisoryLockProviderTest.java
@@ -1,0 +1,76 @@
+package inu.timetable.service;
+
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class PostgresAdvisoryLockProviderTest {
+
+    @Test
+    void acquiredLockIsReleasedOnTheSameConnection() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement acquireStatement = mock(PreparedStatement.class);
+        PreparedStatement releaseStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement("SELECT pg_try_advisory_lock(?)"))
+                .thenReturn(acquireStatement);
+        when(connection.prepareStatement("SELECT pg_advisory_unlock(?)"))
+                .thenReturn(releaseStatement);
+        when(acquireStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(true);
+
+        var handle = new PostgresAdvisoryLockProvider(dataSource)
+                .tryAcquire("subject-import-apply");
+
+        assertThat(handle).isPresent();
+        handle.orElseThrow().close();
+
+        verify(acquireStatement).setLong(
+                1,
+                PostgresAdvisoryLockProvider.stableLockKey("subject-import-apply"));
+        verify(releaseStatement).setLong(
+                1,
+                PostgresAdvisoryLockProvider.stableLockKey("subject-import-apply"));
+        verify(connection).close();
+    }
+
+    @Test
+    void rejectedLockClosesConnectionWithoutRunningUnlock() throws Exception {
+        DataSource dataSource = mock(DataSource.class);
+        Connection connection = mock(Connection.class);
+        PreparedStatement acquireStatement = mock(PreparedStatement.class);
+        ResultSet resultSet = mock(ResultSet.class);
+        when(dataSource.getConnection()).thenReturn(connection);
+        when(connection.prepareStatement("SELECT pg_try_advisory_lock(?)"))
+                .thenReturn(acquireStatement);
+        when(acquireStatement.executeQuery()).thenReturn(resultSet);
+        when(resultSet.next()).thenReturn(true);
+        when(resultSet.getBoolean(1)).thenReturn(false);
+
+        var handle = new PostgresAdvisoryLockProvider(dataSource)
+                .tryAcquire("subject-import-apply");
+
+        assertThat(handle).isEmpty();
+        verify(connection).close();
+        verify(connection, never()).prepareStatement("SELECT pg_advisory_unlock(?)");
+    }
+
+    @Test
+    void stableLockKeyIsDeterministic() {
+        assertThat(PostgresAdvisoryLockProvider.stableLockKey("subject-import-apply"))
+                .isEqualTo(PostgresAdvisoryLockProvider.stableLockKey("subject-import-apply"))
+                .isNotEqualTo(PostgresAdvisoryLockProvider.stableLockKey("subject-delete"));
+    }
+}

--- a/src/test/java/inu/timetable/service/SharedSubjectCacheInvalidationServiceTest.java
+++ b/src/test/java/inu/timetable/service/SharedSubjectCacheInvalidationServiceTest.java
@@ -1,0 +1,45 @@
+package inu.timetable.service;
+
+import inu.timetable.event.SubjectDataChangedEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.JdbcTest;
+import org.springframework.cache.Cache;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@JdbcTest
+class SharedSubjectCacheInvalidationServiceTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Test
+    void databaseVersionInvalidatesAnotherInstancesLocalCache() {
+        CaffeineCacheManager firstManager = cacheManager();
+        CaffeineCacheManager secondManager = cacheManager();
+        SharedSubjectCacheInvalidationService firstInstance =
+                new SharedSubjectCacheInvalidationService(jdbcTemplate, firstManager);
+        SharedSubjectCacheInvalidationService secondInstance =
+                new SharedSubjectCacheInvalidationService(jdbcTemplate, secondManager);
+
+        firstInstance.synchronizeLocalCaches();
+        secondInstance.synchronizeLocalCaches();
+        Cache secondCache = secondManager.getCache(SubjectCacheNames.SUBJECT_NAME_SEARCH);
+        assertThat(secondCache).isNotNull();
+        secondCache.put("criteria", "cached-value");
+
+        firstInstance.publishSubjectDataChanged(new SubjectDataChangedEvent("test"));
+        secondInstance.synchronizeLocalCaches();
+
+        assertThat(secondCache.get("criteria")).isNull();
+    }
+
+    private CaffeineCacheManager cacheManager() {
+        CaffeineCacheManager manager = new CaffeineCacheManager();
+        manager.setCacheNames(SubjectCacheNames.ALL);
+        return manager;
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,6 +12,13 @@ spring:
         dialect: org.hibernate.dialect.H2Dialect
   flyway:
     enabled: false
+  sql:
+    init:
+      mode: always
+
+session:
+  shared:
+    enabled: false
 
 gemini:
   api:
@@ -21,3 +28,7 @@ subject:
   cache:
     warm-up:
       enabled: false
+
+admin:
+  operation-lock:
+    provider: local


### PR DESCRIPTION
## 변경 사항
- Spring Session JDBC와 1회용 opaque 세션 마이그레이션 토큰을 추가했습니다.
- 1단계 issue / 2단계 consume 전환을 통합 테스트로 검증했습니다.
- 관리자 작업 락을 PostgreSQL advisory lock으로 전환했습니다.
- 사용자·관리자 로그인 제한을 DB 공유 상태로 옮겼습니다.
- Caffeine 캐시 무효화를 DB 버전 기반으로 전 인스턴스에 전파합니다.
- Cloud Run을 0% 후보 검증, 자동 롤백, 정상 상태 카나리 방식으로 변경했습니다.
- 고정 과목 수 2894 smoke check를 양의 정수 검증으로 교체했습니다.

## 이번 PR의 운영 단계
- SESSION_BRIDGE_MODE=issue
- SHARED_SESSION_ENABLED=false
- max instances=1
- concurrency=80

이 PR 배포 뒤 브리지 쿠키 발급을 확인하고, 후속 PR에서 consume/JDBC/max=3/concurrency=40으로 전환합니다.

## 정확한 무중단 범위
도입 전에 이미 실행 중인 리비전의 메모리 세션은 외부로 추출할 수 없어 최초 1단계 배포 시 기존 로그인은 1회 갱신이 필요합니다. 1단계 이후 발급된 브리지 토큰부터 2단계 전환과 후속 배포에서 로그인 연속성을 유지합니다.

## 검증
- ./gradlew clean test bootJar
- 181 tests, 0 failures, 2 skipped
- workflow YAML parse
- git diff --check

## 문서
- reports/performance/2026-07-27-session-scaling-bridge/README.md