### PR TITLE
test: 세션 브리지 토큰 검증 격리

### DIFF
--- a/src/test/java/inu/timetable/controller/SessionMigrationBridgeIssueIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/SessionMigrationBridgeIssueIntegrationTest.java
@@ -87,8 +87,9 @@ class SessionMigrationBridgeIssueIntegrationTest {
                 .andReturn();
 
         assertThat(jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM session_migration_tokens",
-                Integer.class)).isZero();
+                "SELECT COUNT(*) FROM session_migration_tokens WHERE token_hash = ?",
+                Integer.class,
+                storedHash)).isZero();
         assertThat(logout.getResponse().getHeaders("Set-Cookie"))
                 .anyMatch(header -> header.startsWith("INU_SESSION_BRIDGE=")
                         && header.contains("Max-Age=0"));


### PR DESCRIPTION
## 변경 사항
- 로그아웃 테스트가 전체 마이그레이션 토큰 수를 검사하던 전역 상태 의존성을 제거했습니다.
- 테스트가 직접 발급한 토큰 해시의 삭제만 검증하도록 범위를 좁혔습니다.

## 원인
전체 테스트 실행 시 다른 브리지 테스트가 생성한 토큰이 남아 있어 기능은 정상이어도 CI가 실패했습니다.

## 검증
- `./gradlew test --tests inu.timetable.controller.SessionMigrationBridgeIssueIntegrationTest`
- `./gradlew clean test bootJar` (181 tests, 0 failed, 2 skipped)