### PR TITLE
ops: 공유 세션 3인스턴스 2단계 전환

### DIFF
--- a/.github/deploy/production-rollout.env
+++ b/.github/deploy/production-rollout.env
@@ -1,8 +1,8 @@
-# Phase 1: issue opaque migration tokens while keeping the legacy in-memory session.
-# Change to consume/true/max=3/concurrency=40 only after the phase-1 revision is healthy.
-SESSION_BRIDGE_MODE=issue
-SHARED_SESSION_ENABLED=false
-MAX_INSTANCES=1
-CONCURRENCY=80
+# Phase 2: consume phase-1 migration tokens into shared JDBC sessions.
+# Keep consume enabled for at least the bridge-token TTL before switching mode to off.
+SESSION_BRIDGE_MODE=consume
+SHARED_SESSION_ENABLED=true
+MAX_INSTANCES=3
+CONCURRENCY=40
 DB_POOL_MAXIMUM_SIZE=10
 DB_POOL_MINIMUM_IDLE=2

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,9 @@ name: Deploy to GCP Cloud Run
 on:
   push:
     branches: ["main"]
+    paths-ignore:
+      - "reports/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/reports/performance/2026-07-27-session-scaling-bridge/README.md
+++ b/reports/performance/2026-07-27-session-scaling-bridge/README.md
@@ -160,8 +160,10 @@ best effort이므로 정합성의 근거로 사용하지 않는다.
 
 | 단계 | 리비전 | 트래픽 | health | 세션 검증 | 시각 |
 |---|---|---:|---|---|---|
-| 1단계 issue | 배포 후 기록 | 100% | 배포 후 기록 | 브리지 쿠키 발급 | 배포 후 기록 |
+| 1단계 issue | `inu-timetable-backend-00023-fam` | 100% | `UP` | 관리자 로그인/`me` 200, `INU_SESSION_BRIDGE` 발급 | 2026-07-27 14:48 KST |
 | 2단계 consume | 배포 후 기록 | 100% | 배포 후 기록 | 기존 브리지 쿠키로 JDBC 세션 생성 | 배포 후 기록 |
 
-이 표는 실제 운영 전환 후 Cloud Run 리비전, UTC/KST 시각, 세션 연속성 결과로
-갱신한다.
+1단계는 GitHub Actions run
+[`30240575690`](https://github.com/coldmans/inu_timetable/actions/runs/30240575690)에서
+후보 리비전을 0% 트래픽으로 검증한 뒤 원자 전환했다. 2단계 행은 실제 운영
+전환 후 Cloud Run 리비전과 세션 연속성 결과로 갱신한다.


### PR DESCRIPTION
## 변경 사항
- 세션 브리지를 `consume` 단계로 전환합니다.
- Spring Session JDBC를 활성화합니다.
- Cloud Run 최대 인스턴스를 1에서 3으로, 동시성을 80에서 40으로 조정합니다.
- 1단계 운영 리비전과 브리지 쿠키 발급 증거를 성능 보고서에 기록합니다.
- 보고서/Markdown만 바뀐 커밋은 운영 재배포를 생략합니다.

## 운영 전환 방식
- 후보 리비전은 0% 트래픽으로 배포합니다.
- health, 과목 수, CSRF, 관리자 로그인, JDBC `SESSION` 쿠키를 검증합니다.
- 브리지 호환 경계이므로 검증 후 100% 원자 전환합니다.
- 실패 시 기존 1단계 리비전으로 100% 롤백합니다.

## 검증
- `./gradlew clean test bootJar` (181 tests, 0 failed, 2 skipped)
- workflow YAML 파싱
- phase2 env 값 검증
- `git diff --check`