### PR TITLE
ops: 세션 호환 브리지 종료

### DIFF
--- a/.github/deploy/production-rollout.env
+++ b/.github/deploy/production-rollout.env
@@ -1,6 +1,6 @@
-# Phase 2: consume phase-1 migration tokens into shared JDBC sessions.
-# Keep consume enabled for at least the bridge-token TTL before switching mode to off.
-SESSION_BRIDGE_MODE=consume
+# Phase 3: shared JDBC sessions only; the temporary migration bridge is disabled.
+# Phase 2 stayed active beyond the bridge-token TTL and no unexpired tokens remain.
+SESSION_BRIDGE_MODE=off
 SHARED_SESSION_ENABLED=true
 MAX_INSTANCES=3
 CONCURRENCY=40


### PR DESCRIPTION
## 변경 사항
- `SESSION_BRIDGE_MODE`를 `consume`에서 `off`로 전환했습니다.
- JDBC 공유 세션, `maxScale=3`, `concurrency=40`, DB pool `10/2` 설정은 유지합니다.

## 이유
- `issue` 단계 종료 후 브리지 토큰 TTL 30분을 충분히 초과했습니다.
- 전환 직전 운영 DB의 `session_migration_tokens`는 전체 0건, 유효 0건이었습니다.
- 임시 호환 브리지 경로를 종료해 JDBC 세션 경로로 단일화합니다.

## 검증
- `./gradlew test`: 181개 중 179개 성공, 2개 스킵, 실패 0개
- 롤아웃 환경값 및 diff 검사
- 전환 전 Cloud Run 상태·설정·ERROR 로그 확인