### PR TITLE
Redis two-level 공유 캐시 도입

### DIFF
--- a/.github/deploy/production-rollout.env
+++ b/.github/deploy/production-rollout.env
@@ -6,3 +6,13 @@ MAX_INSTANCES=3
 CONCURRENCY=40
 DB_POOL_MAXIMUM_SIZE=10
 DB_POOL_MINIMUM_IDLE=2
+
+# Caffeine L1 + Redis L2 shared cache. The DB version bridge remains active for
+# cross-instance L1 invalidation until a future Redis Pub/Sub rollout replaces it.
+SUBJECT_CACHE_PROVIDER=two-level
+SUBJECT_CACHE_REDIS_KEY_PREFIX=inu:timetable:prod
+SUBJECT_CACHE_DB_VERSION_POLL_ENABLED=true
+SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED=true
+REDIS_HEALTH_ENABLED=true
+REDIS_HOST=10.253.227.163
+REDIS_PORT=6379

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -44,9 +44,30 @@ jobs:
             true|false) ;;
             *) echo "Invalid SHARED_SESSION_ENABLED" >&2; exit 1 ;;
           esac
+          case "$SUBJECT_CACHE_PROVIDER" in
+            caffeine|redis|two-level) ;;
+            *) echo "Invalid SUBJECT_CACHE_PROVIDER" >&2; exit 1 ;;
+          esac
+          case "$SUBJECT_CACHE_DB_VERSION_POLL_ENABLED" in
+            true|false) ;;
+            *) echo "Invalid SUBJECT_CACHE_DB_VERSION_POLL_ENABLED" >&2; exit 1 ;;
+          esac
+          case "$SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED" in
+            true|false) ;;
+            *) echo "Invalid SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED" >&2; exit 1 ;;
+          esac
+          case "$REDIS_HEALTH_ENABLED" in
+            true|false) ;;
+            *) echo "Invalid REDIS_HEALTH_ENABLED" >&2; exit 1 ;;
+          esac
           test "$MAX_INSTANCES" -ge 1
           test "$CONCURRENCY" -ge 1
           test "$DB_POOL_MAXIMUM_SIZE" -ge "$DB_POOL_MINIMUM_IDLE"
+          if [ "$SUBJECT_CACHE_PROVIDER" != "caffeine" ]; then
+            test -n "$REDIS_HOST"
+            test "$REDIS_PORT" -ge 1
+            test "$REDIS_HEALTH_ENABLED" = "true"
+          fi
 
           {
             echo "SESSION_BRIDGE_MODE=$SESSION_BRIDGE_MODE"
@@ -55,6 +76,13 @@ jobs:
             echo "CONCURRENCY=$CONCURRENCY"
             echo "DB_POOL_MAXIMUM_SIZE=$DB_POOL_MAXIMUM_SIZE"
             echo "DB_POOL_MINIMUM_IDLE=$DB_POOL_MINIMUM_IDLE"
+            echo "SUBJECT_CACHE_PROVIDER=$SUBJECT_CACHE_PROVIDER"
+            echo "SUBJECT_CACHE_REDIS_KEY_PREFIX=$SUBJECT_CACHE_REDIS_KEY_PREFIX"
+            echo "SUBJECT_CACHE_DB_VERSION_POLL_ENABLED=$SUBJECT_CACHE_DB_VERSION_POLL_ENABLED"
+            echo "SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED=$SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED"
+            echo "REDIS_HEALTH_ENABLED=$REDIS_HEALTH_ENABLED"
+            echo "REDIS_HOST=$REDIS_HOST"
+            echo "REDIS_PORT=$REDIS_PORT"
           } >> "$GITHUB_ENV"
 
       - name: Set up JDK 17
@@ -108,8 +136,11 @@ jobs:
             --tag "$CANDIDATE_TAG" \
             --allow-unauthenticated \
             --service-account "$RUNTIME_SERVICE_ACCOUNT" \
-            --set-secrets DB_URL=DB_URL:latest,DB_USERNAME=DB_USERNAME:latest,DB_PASSWORD=DB_PASSWORD:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,ADMIN_PASSWORD=ADMIN_PASSWORD:latest \
-            --set-env-vars "^@^SPRING_PROFILES_ACTIVE=prod@ADMIN_USERNAME=admin@CORS_ALLOWED_ORIGINS=https://inu-timetable-front-git-main-jjhs-projects-4d22a2fd.vercel.app,https://inuu-timetable.vercel.app@SESSION_BRIDGE_MODE=$SESSION_BRIDGE_MODE@SHARED_SESSION_ENABLED=$SHARED_SESSION_ENABLED@DB_POOL_MAXIMUM_SIZE=$DB_POOL_MAXIMUM_SIZE@DB_POOL_MINIMUM_IDLE=$DB_POOL_MINIMUM_IDLE" \
+            --set-secrets DB_URL=DB_URL:latest,DB_USERNAME=DB_USERNAME:latest,DB_PASSWORD=DB_PASSWORD:latest,GEMINI_API_KEY=GEMINI_API_KEY:latest,ADMIN_PASSWORD=ADMIN_PASSWORD:latest,REDIS_PASSWORD=REDIS_PASSWORD:latest \
+            --set-env-vars "^@^SPRING_PROFILES_ACTIVE=prod@ADMIN_USERNAME=admin@CORS_ALLOWED_ORIGINS=https://inu-timetable-front-git-main-jjhs-projects-4d22a2fd.vercel.app,https://inuu-timetable.vercel.app@SESSION_BRIDGE_MODE=$SESSION_BRIDGE_MODE@SHARED_SESSION_ENABLED=$SHARED_SESSION_ENABLED@DB_POOL_MAXIMUM_SIZE=$DB_POOL_MAXIMUM_SIZE@DB_POOL_MINIMUM_IDLE=$DB_POOL_MINIMUM_IDLE@SUBJECT_CACHE_PROVIDER=$SUBJECT_CACHE_PROVIDER@SUBJECT_CACHE_REDIS_KEY_PREFIX=$SUBJECT_CACHE_REDIS_KEY_PREFIX@SUBJECT_CACHE_DB_VERSION_POLL_ENABLED=$SUBJECT_CACHE_DB_VERSION_POLL_ENABLED@SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED=$SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED@REDIS_HEALTH_ENABLED=$REDIS_HEALTH_ENABLED@REDIS_HOST=$REDIS_HOST@REDIS_PORT=$REDIS_PORT" \
+            --network default \
+            --subnet default \
+            --vpc-egress private-ranges-only \
             --port 8080 \
             --cpu 1 \
             --memory 1Gi \
@@ -150,6 +181,19 @@ jobs:
             "$CANDIDATE_URL/api/subjects/count")"
           [[ "$SUBJECT_COUNT" =~ ^[0-9]+$ ]]
           test "$SUBJECT_COUNT" -gt 0
+
+          for attempt in 1 2; do
+            curl --fail --show-error --silent \
+              "$CANDIDATE_URL/api/subjects/departments?semester=2026-2" >/dev/null
+            curl --fail --show-error --silent \
+              "$CANDIDATE_URL/api/subjects/filter?semester=2026-2&page=0&size=20" >/dev/null
+          done
+          curl --fail --show-error --silent "$CANDIDATE_URL/actuator/prometheus" |
+            grep --quiet 'subject_cache_requests_total'
+          if [ "$SUBJECT_CACHE_PROVIDER" = "two-level" ]; then
+            curl --fail --show-error --silent "$CANDIDATE_URL/actuator/prometheus" |
+              grep --quiet 'subject_cache_l1_requests_total'
+          fi
 
           COOKIE_JAR="$(mktemp)"
           CSRF_BODY="$(mktemp)"

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'org.springframework.session:spring-session-jdbc'
     implementation 'org.springframework.ai:spring-ai-pdf-document-reader'
     implementation 'org.springframework.boot:spring-boot-starter-webflux'

--- a/reports/performance/2026-07-27-redis-baseline/00-smoke-service-cap1-10vus.json
+++ b/reports/performance/2026-07-27-redis-baseline/00-smoke-service-cap1-10vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "current-caffeine-service-cap1-smoke",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "smoke",
+    "peakVus": 10,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T13:58:03.583Z"
+  },
+  "result": {
+    "options": {
+      "summaryTimeUnit": "",
+      "noColor": true,
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ]
+    },
+    "state": {
+      "isStdErrTTY": false,
+      "testRunDurationMs": 21541.965,
+      "isStdOutTTY": false
+    },
+    "metrics": {
+      "checks": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 1,
+          "passes": 349,
+          "fails": 0
+        }
+      },
+      "http_req_failed": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "passes": 0,
+          "fails": 349,
+          "rate": 0
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "subject_read_count_duration": {
+        "contains": "default",
+        "values": {
+          "avg": 22.55793506493506,
+          "min": 16.848,
+          "med": 20.001,
+          "max": 103.71,
+          "p(90)": 24.7222,
+          "p(95)": 34.49179999999996,
+          "p(99)": 67.02099999999997
+        },
+        "type": "trend"
+      },
+      "vus_max": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 10,
+          "min": 10,
+          "max": 10
+        }
+      },
+      "http_req_waiting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(99)": 121.57856,
+          "avg": 27.972770773638967,
+          "min": 15.992,
+          "med": 20.914,
+          "max": 344.426,
+          "p(90)": 34.01000000000001,
+          "p(95)": 76.85599999999991
+        }
+      },
+      "subject_read_grades_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "min": 17.178,
+          "med": 19.863,
+          "max": 37.973,
+          "p(90)": 24.5208,
+          "p(95)": 28.656499999999998,
+          "p(99)": 33.949839999999995,
+          "avg": 20.89168085106382
+        }
+      },
+      "subject_read_departments_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(90)": 24.134600000000002,
+          "p(95)": 29.58319999999999,
+          "p(99)": 53.72421999999999,
+          "avg": 22.060787234042557,
+          "min": 17.147,
+          "med": 20.287,
+          "max": 71.891
+        }
+      },
+      "data_received": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 6096485,
+          "rate": 283005.05548124324
+        }
+      },
+      "iterations": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 331,
+          "rate": 15.365357802781686
+        }
+      },
+      "iteration_duration": {
+        "contains": "time",
+        "values": {
+          "min": 221.689542,
+          "med": 468.250375,
+          "max": 751.851292,
+          "p(90)": 685.35225,
+          "p(95)": 696.7077499999999,
+          "p(99)": 722.371675,
+          "avg": 469.6177741873108
+        },
+        "type": "trend"
+      },
+      "http_req_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 29.489816618911185,
+          "min": 16.372,
+          "med": 21.479,
+          "max": 361.092,
+          "p(90)": 41.611399999999996,
+          "p(95)": 82.07279999999997,
+          "p(99)": 122.53368
+        },
+        "thresholds": {
+          "p(95)<500": {
+            "ok": true
+          },
+          "p(99)<1000": {
+            "ok": true
+          }
+        }
+      },
+      "subject_read_errors": {
+        "values": {
+          "rate": 0,
+          "passes": 0,
+          "fails": 349
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        },
+        "type": "rate",
+        "contains": "default"
+      },
+      "http_req_blocked": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 1.7848194842406784,
+          "min": 0,
+          "med": 0,
+          "max": 59.801,
+          "p(90)": 0.001,
+          "p(95)": 0.002,
+          "p(99)": 57.99644
+        }
+      },
+      "http_req_tls_handshaking": {
+        "values": {
+          "p(99)": 49.286199999999994,
+          "avg": 1.5296561604584529,
+          "min": 0,
+          "med": 0,
+          "max": 52.043,
+          "p(90)": 0,
+          "p(95)": 0
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "http_req_duration{expected_response:true}": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(90)": 41.611399999999996,
+          "p(95)": 82.07279999999997,
+          "p(99)": 122.53368,
+          "avg": 29.489816618911185,
+          "min": 16.372,
+          "med": 21.479,
+          "max": 361.092
+        }
+      },
+      "vus": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 2,
+          "min": 0,
+          "max": 10
+        }
+      },
+      "http_req_connecting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 7.8168,
+          "avg": 0.24213180515759308,
+          "min": 0,
+          "med": 0,
+          "max": 9.478
+        }
+      },
+      "http_req_receiving": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(90)": 2.7164000000000006,
+          "p(95)": 8.75259999999999,
+          "p(99)": 21.696319999999996,
+          "avg": 1.3674527220630366,
+          "min": 0.023,
+          "med": 0.094,
+          "max": 32.08
+        }
+      },
+      "subject_read_filter_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 43.41548148148148,
+          "min": 17.786,
+          "med": 25.481,
+          "max": 123.054,
+          "p(90)": 102.1635,
+          "p(95)": 109.67255,
+          "p(99)": 122.47948
+        }
+      },
+      "subject_read_professor_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(99)": 60.69651999999999,
+          "avg": 23.371185185185187,
+          "min": 16.372,
+          "med": 20.781,
+          "max": 65.634,
+          "p(90)": 30.573000000000008,
+          "p(95)": 42.151449999999954
+        }
+      },
+      "data_sent": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 76531,
+          "rate": 3552.647123881224
+        }
+      },
+      "http_req_sending": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 0.14959312320916923,
+          "min": 0.018,
+          "med": 0.082,
+          "max": 5.964,
+          "p(90)": 0.2174,
+          "p(95)": 0.2885999999999998,
+          "p(99)": 1.1063199999999975
+        }
+      },
+      "subject_read_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "min": 19.493,
+          "med": 28.1555,
+          "max": 361.092,
+          "p(90)": 57.17920000000002,
+          "p(95)": 82.48359999999998,
+          "p(99)": 258.4641599999999,
+          "avg": 41.85341428571428
+        }
+      },
+      "http_reqs": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 349,
+          "rate": 16.200936172721477
+        }
+      }
+    },
+    "root_group": {
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "groups": [
+        {
+          "groups": [],
+          "checks": [
+              {
+                "name": "count status 200",
+                "path": "::setup::count status 200",
+                "id": "373bc94804b8d5b7733e7b5c457e9a12",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "name": "departments status 200",
+                "path": "::setup::departments status 200",
+                "id": "d09fa4300114fed036f335660dddb271",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "path": "::setup::grades status 200",
+                "id": "af14747f4b0f176b2dce752b98debdff",
+                "passes": 3,
+                "fails": 0,
+                "name": "grades status 200"
+              },
+              {
+                "name": "subject search status 200",
+                "path": "::setup::subject search status 200",
+                "id": "c9fb74e122c66285735a0d5bc17e206c",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "name": "professor search status 200",
+                "path": "::setup::professor search status 200",
+                "id": "7ac220a4b0d54400a88825fbdc772aa0",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "passes": 3,
+                "fails": 0,
+                "name": "filter status 200",
+                "path": "::setup::filter status 200",
+                "id": "561cb701c0228225332599949cf1547c"
+              }
+            ],
+          "name": "setup",
+          "path": "::setup",
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a"
+        }
+      ],
+      "checks": [
+        {
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 44,
+          "fails": 0,
+          "name": "grades status 200",
+          "path": "::grades status 200"
+        },
+        {
+          "name": "subject search status 200",
+          "path": "::subject search status 200",
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 67,
+          "fails": 0
+        },
+        {
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 44,
+          "fails": 0,
+          "name": "departments status 200",
+          "path": "::departments status 200"
+        },
+        {
+          "name": "count status 200",
+          "path": "::count status 200",
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 74,
+          "fails": 0
+        },
+        {
+          "name": "filter status 200",
+          "path": "::filter status 200",
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 51,
+          "fails": 0
+        },
+        {
+          "name": "professor search status 200",
+          "path": "::professor search status 200",
+          "id": "bf145fc270dae668c75958348664d49c",
+          "passes": 51,
+          "fails": 0
+        }
+      ]
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-baseline/01-current-caffeine-service-cap1-200vus.json
+++ b/reports/performance/2026-07-27-redis-baseline/01-current-caffeine-service-cap1-200vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "current-caffeine-service-cap1-pool10-200vus",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "portfolio",
+    "peakVus": 200,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T14:01:52.584Z"
+  },
+  "result": {
+    "root_group": {
+      "groups": [
+        {
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a",
+          "groups": [],
+          "checks": [
+              {
+                "fails": 0,
+                "name": "count status 200",
+                "path": "::setup::count status 200",
+                "id": "373bc94804b8d5b7733e7b5c457e9a12",
+                "passes": 3
+              },
+              {
+                "name": "departments status 200",
+                "path": "::setup::departments status 200",
+                "id": "d09fa4300114fed036f335660dddb271",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "path": "::setup::grades status 200",
+                "id": "af14747f4b0f176b2dce752b98debdff",
+                "passes": 3,
+                "fails": 0,
+                "name": "grades status 200"
+              },
+              {
+                "name": "subject search status 200",
+                "path": "::setup::subject search status 200",
+                "id": "c9fb74e122c66285735a0d5bc17e206c",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "path": "::setup::professor search status 200",
+                "id": "7ac220a4b0d54400a88825fbdc772aa0",
+                "passes": 3,
+                "fails": 0,
+                "name": "professor search status 200"
+              },
+              {
+                "id": "561cb701c0228225332599949cf1547c",
+                "passes": 3,
+                "fails": 0,
+                "name": "filter status 200",
+                "path": "::setup::filter status 200"
+              }
+            ],
+          "name": "setup",
+          "path": "::setup"
+        }
+      ],
+      "checks": [
+        {
+          "name": "departments status 200",
+          "path": "::departments status 200",
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 7401,
+          "fails": 0
+        },
+        {
+          "name": "count status 200",
+          "path": "::count status 200",
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 9908,
+          "fails": 0
+        },
+        {
+          "name": "professor search status 200",
+          "path": "::professor search status 200",
+          "id": "bf145fc270dae668c75958348664d49c",
+          "passes": 7307,
+          "fails": 0
+        },
+        {
+          "path": "::subject search status 200",
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 9736,
+          "fails": 0,
+          "name": "subject search status 200"
+        },
+        {
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 7324,
+          "fails": 0,
+          "name": "grades status 200",
+          "path": "::grades status 200"
+        },
+        {
+          "name": "filter status 200",
+          "path": "::filter status 200",
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 7281,
+          "fails": 0
+        }
+      ],
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e"
+    },
+    "options": {
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ],
+      "summaryTimeUnit": "",
+      "noColor": true
+    },
+    "state": {
+      "isStdOutTTY": false,
+      "isStdErrTTY": false,
+      "testRunDurationMs": 221012.259
+    },
+    "metrics": {
+      "vus": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 1,
+          "min": 1,
+          "max": 200
+        }
+      },
+      "http_req_failed": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "passes": 0,
+          "fails": 48975,
+          "rate": 0
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "http_reqs": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 48975,
+          "rate": 221.59404288972044
+        }
+      },
+      "vus_max": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "max": 200,
+          "value": 200,
+          "min": 200
+        }
+      },
+      "subject_read_filter_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(90)": 34.116400000000006,
+          "p(95)": 51.185349999999936,
+          "p(99)": 93.16731999999999,
+          "avg": 23.494700164744614,
+          "min": 11.744,
+          "med": 18.415,
+          "max": 464.144
+        }
+      },
+      "subject_read_departments_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 21.14745326850351,
+          "min": 11.179,
+          "med": 17.5295,
+          "max": 517.386,
+          "p(90)": 30.472800000000003,
+          "p(95)": 40.84429999999999,
+          "p(99)": 74.66722999999999
+        }
+      },
+      "http_req_duration{expected_response:true}": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "min": 10.011,
+          "med": 18.246,
+          "max": 697.894,
+          "p(90)": 35.18860000000001,
+          "p(95)": 47.83319999999999,
+          "p(99)": 78.96826,
+          "avg": 23.095685880550985
+        }
+      },
+      "http_req_connecting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0,
+          "avg": 0.061116528841245604,
+          "min": 0,
+          "med": 0,
+          "max": 81.523
+        }
+      },
+      "subject_read_grades_duration": {
+        "values": {
+          "p(95)": 40.43339999999997,
+          "p(99)": 70.91661999999998,
+          "avg": 20.789386106182565,
+          "min": 10.936,
+          "med": 17.188,
+          "max": 498.514,
+          "p(90)": 29.4536
+        },
+        "type": "trend",
+        "contains": "default"
+      },
+      "subject_read_errors": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "fails": 48975,
+          "rate": 0,
+          "passes": 0
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "subject_read_professor_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 20.92037865937076,
+          "min": 10.011,
+          "med": 17.375500000000002,
+          "max": 358.697,
+          "p(90)": 29.7361,
+          "p(95)": 40.05204999999999,
+          "p(99)": 70.23966999999999
+        }
+      },
+      "data_sent": {
+        "contains": "data",
+        "values": {
+          "count": 6328842,
+          "rate": 28635.705678208556
+        },
+        "type": "counter"
+      },
+      "iterations": {
+        "contains": "default",
+        "values": {
+          "count": 48957,
+          "rate": 221.5125994436354
+        },
+        "type": "counter"
+      },
+      "checks": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "fails": 0,
+          "rate": 1,
+          "passes": 48975
+        }
+      },
+      "data_received": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 842392726,
+          "rate": 3811520.3645785097
+        }
+      },
+      "iteration_duration": {
+        "values": {
+          "p(95)": 699.1588327999999,
+          "p(99)": 722.21543348,
+          "avg": 474.37050681416713,
+          "min": 214.221,
+          "med": 474.973625,
+          "max": 1332.809292,
+          "p(90)": 674.6583168
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "http_req_waiting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(90)": 30.258400000000005,
+          "p(95)": 41.953299999999956,
+          "p(99)": 73.61986,
+          "avg": 21.218151240428504,
+          "min": 8.547,
+          "med": 17.455,
+          "max": 675.106
+        }
+      },
+      "http_req_receiving": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "max": 494.248,
+          "p(90)": 4.552600000000006,
+          "p(95)": 10.703899999999994,
+          "p(99)": 24.607339999999997,
+          "avg": 1.8045336396120046,
+          "min": 0.006,
+          "med": 0.06
+        }
+      },
+      "http_req_sending": {
+        "values": {
+          "med": 0.043,
+          "max": 8.043,
+          "p(90)": 0.112,
+          "p(95)": 0.15,
+          "p(99)": 0.38625999999999955,
+          "avg": 0.07300100051046136,
+          "min": 0.009
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "subject_read_count_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "med": 17.246,
+          "max": 423.894,
+          "p(90)": 30.02,
+          "p(95)": 40.5385,
+          "p(99)": 70.81929999999998,
+          "avg": 20.860889617596552,
+          "min": 10.179
+        }
+      },
+      "http_req_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "max": 697.894,
+          "p(90)": 35.18860000000001,
+          "p(95)": 47.83319999999999,
+          "p(99)": 78.96826,
+          "avg": 23.095685880550985,
+          "min": 10.011,
+          "med": 18.246
+        },
+        "thresholds": {
+          "p(95)<500": {
+            "ok": true
+          },
+          "p(99)<1000": {
+            "ok": true
+          }
+        }
+      },
+      "http_req_blocked": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 0.27886411434411745,
+          "min": 0,
+          "med": 0,
+          "max": 208.248,
+          "p(90)": 0.001,
+          "p(95)": 0.001,
+          "p(99)": 0.001
+        }
+      },
+      "http_req_tls_handshaking": {
+        "values": {
+          "min": 0,
+          "med": 0,
+          "max": 131.378,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0,
+          "avg": 0.21675469116896381
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "subject_read_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "min": 12.122,
+          "med": 23.692,
+          "max": 697.894,
+          "p(90)": 45.8346,
+          "p(95)": 60.0213,
+          "p(99)": 97.6534,
+          "avg": 29.920525618646693
+        }
+      }
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-baseline/02-current-caffeine-service-cap1-1000vus.json
+++ b/reports/performance/2026-07-27-redis-baseline/02-current-caffeine-service-cap1-1000vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "current-caffeine-service-cap1-pool10-1000vus",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "portfolio",
+    "peakVus": 1000,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T14:07:32.786Z"
+  },
+  "result": {
+    "state": {
+      "isStdOutTTY": false,
+      "isStdErrTTY": false,
+      "testRunDurationMs": 221199.151
+    },
+    "metrics": {
+      "vus_max": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "max": 1000,
+          "value": 1000,
+          "min": 1000
+        }
+      },
+      "checks": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 1,
+          "passes": 89889,
+          "fails": 0
+        }
+      },
+      "data_sent": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 14005795,
+          "rate": 63317.58027407619
+        }
+      },
+      "subject_read_errors": {
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        },
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0,
+          "passes": 0,
+          "fails": 89889
+        }
+      },
+      "http_req_tls_handshaking": {
+        "contains": "time",
+        "values": {
+          "avg": 0.5828248506491349,
+          "min": 0,
+          "med": 0,
+          "max": 473.337,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 43.80724
+        },
+        "type": "trend"
+      },
+      "iterations": {
+        "contains": "default",
+        "values": {
+          "count": 89871,
+          "rate": 406.28998616726153
+        },
+        "type": "counter"
+      },
+      "http_req_connecting": {
+        "contains": "time",
+        "values": {
+          "p(95)": 0,
+          "p(99)": 7.4,
+          "avg": 0.1656637964600786,
+          "min": 0,
+          "med": 0,
+          "max": 316.031,
+          "p(90)": 0
+        },
+        "type": "trend"
+      },
+      "subject_read_departments_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "min": 10.497,
+          "med": 709.752,
+          "max": 2684.161,
+          "p(90)": 2167.206,
+          "p(95)": 2286.4224,
+          "p(99)": 2600.55604,
+          "avg": 837.6212900141915
+        }
+      },
+      "vus": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 2,
+          "min": 2,
+          "max": 1000
+        }
+      },
+      "subject_read_count_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(95)": 2287.9878999999996,
+          "p(99)": 2604.6054299999996,
+          "avg": 843.5016219256632,
+          "min": 11.379,
+          "med": 713.2625,
+          "max": 2790.854,
+          "p(90)": 2163.5819
+        }
+      },
+      "http_reqs": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 89889,
+          "rate": 406.3713608014707
+        }
+      },
+      "http_req_sending": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "min": 0.009,
+          "med": 0.039,
+          "max": 8.363,
+          "p(90)": 0.096,
+          "p(95)": 0.13,
+          "p(99)": 0.3951199999999992,
+          "avg": 0.06731592297166458
+        }
+      },
+      "http_req_receiving": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 2.5772621677847636,
+          "min": 0.005,
+          "med": 0.06,
+          "max": 681.843,
+          "p(90)": 6.088,
+          "p(95)": 14.186599999999995,
+          "p(99)": 38.70724
+        }
+      },
+      "http_req_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 847.8665960684888,
+          "min": 10.497,
+          "med": 716.321,
+          "max": 2850.354,
+          "p(90)": 2169.8952,
+          "p(95)": 2302.4235999999996,
+          "p(99)": 2605.87684
+        },
+        "thresholds": {
+          "p(95)<500": {
+            "ok": false
+          },
+          "p(99)<1000": {
+            "ok": false
+          }
+        }
+      },
+      "http_req_blocked": {
+        "contains": "time",
+        "values": {
+          "med": 0,
+          "max": 484.458,
+          "p(90)": 0.001,
+          "p(95)": 0.001,
+          "p(99)": 53.043839999999996,
+          "avg": 0.7508401250430674,
+          "min": 0
+        },
+        "type": "trend"
+      },
+      "subject_read_filter_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 846.1233016504539,
+          "min": 11.396,
+          "med": 714.7345,
+          "max": 2684.546,
+          "p(90)": 2168.6071,
+          "p(95)": 2310.54345,
+          "p(99)": 2604.24293
+        }
+      },
+      "http_req_waiting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "min": 8.483,
+          "med": 714.53,
+          "max": 2790.694,
+          "p(90)": 2166.795,
+          "p(95)": 2295.4230000000002,
+          "p(99)": 2604.002,
+          "avg": 845.2220179777285
+        }
+      },
+      "http_req_duration{expected_response:true}": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 847.8665960684888,
+          "min": 10.497,
+          "med": 716.321,
+          "max": 2850.354,
+          "p(90)": 2169.8952,
+          "p(95)": 2302.4235999999996,
+          "p(99)": 2605.87684
+        }
+      },
+      "subject_read_grades_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(95)": 2294.1,
+          "p(99)": 2597.88416,
+          "avg": 848.3684086636082,
+          "min": 11.339,
+          "med": 717.219,
+          "max": 2667.621,
+          "p(90)": 2170.2896
+        }
+      },
+      "subject_read_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(95)": 2323.6956,
+          "p(99)": 2616.94312,
+          "avg": 864.9677288192325,
+          "min": 12.411,
+          "med": 725.042,
+          "max": 2850.354,
+          "p(90)": 2183.7316
+        }
+      },
+      "data_received": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 1585161287,
+          "rate": 7166217.771785209
+        }
+      },
+      "subject_read_professor_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "med": 714.7339999999999,
+          "max": 2677.448,
+          "p(90)": 2164.3612000000003,
+          "p(95)": 2304.1605999999997,
+          "p(99)": 2606.63554,
+          "avg": 842.46491745283,
+          "min": 11.142
+        }
+      },
+      "iteration_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "max": 3404.966917,
+          "p(90)": 2661.178708,
+          "p(95)": 2813.3220209999995,
+          "p(99)": 3094.0239962,
+          "avg": 1299.2551563637894,
+          "min": 213.893167,
+          "med": 1133.245958
+        }
+      },
+      "http_req_failed": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "fails": 89889,
+          "rate": 0,
+          "passes": 0
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      }
+    },
+    "root_group": {
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "groups": [
+        {
+          "checks": [
+            {
+              "passes": 3,
+              "fails": 0,
+              "name": "count status 200",
+              "path": "::setup::count status 200",
+              "id": "373bc94804b8d5b7733e7b5c457e9a12"
+            },
+            {
+              "fails": 0,
+              "name": "departments status 200",
+              "path": "::setup::departments status 200",
+              "id": "d09fa4300114fed036f335660dddb271",
+              "passes": 3
+            },
+            {
+              "path": "::setup::grades status 200",
+              "id": "af14747f4b0f176b2dce752b98debdff",
+              "passes": 3,
+              "fails": 0,
+              "name": "grades status 200"
+            },
+            {
+              "path": "::setup::subject search status 200",
+              "id": "c9fb74e122c66285735a0d5bc17e206c",
+              "passes": 3,
+              "fails": 0,
+              "name": "subject search status 200"
+            },
+            {
+              "passes": 3,
+              "fails": 0,
+              "name": "professor search status 200",
+              "path": "::setup::professor search status 200",
+              "id": "7ac220a4b0d54400a88825fbdc772aa0"
+            },
+            {
+              "name": "filter status 200",
+              "path": "::setup::filter status 200",
+              "id": "561cb701c0228225332599949cf1547c",
+              "passes": 3,
+              "fails": 0
+            }
+          ],
+          "name": "setup",
+          "path": "::setup",
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a",
+          "groups": []
+        }
+      ],
+      "checks": [
+        {
+          "name": "filter status 200",
+          "path": "::filter status 200",
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 13569,
+          "fails": 0
+        },
+        {
+          "name": "departments status 200",
+          "path": "::departments status 200",
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 13386,
+          "fails": 0
+        },
+        {
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 17926,
+          "fails": 0,
+          "name": "subject search status 200",
+          "path": "::subject search status 200"
+        },
+        {
+          "name": "grades status 200",
+          "path": "::grades status 200",
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 13294,
+          "fails": 0
+        },
+        {
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 18131,
+          "fails": 0,
+          "name": "count status 200",
+          "path": "::count status 200"
+        },
+        {
+          "name": "professor search status 200",
+          "path": "::professor search status 200",
+          "id": "bf145fc270dae668c75958348664d49c",
+          "passes": 13565,
+          "fails": 0
+        }
+      ]
+    },
+    "options": {
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ],
+      "summaryTimeUnit": "",
+      "noColor": true
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-baseline/03-current-caffeine-max3-1000vus.json
+++ b/reports/performance/2026-07-27-redis-baseline/03-current-caffeine-max3-1000vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "current-caffeine-max3-pool10-1000vus",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "portfolio",
+    "peakVus": 1000,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T14:14:02.479Z"
+  },
+  "result": {
+    "options": {
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ],
+      "summaryTimeUnit": "",
+      "noColor": true
+    },
+    "state": {
+      "testRunDurationMs": 238391.815,
+      "isStdOutTTY": false,
+      "isStdErrTTY": false
+    },
+    "metrics": {
+      "iterations": {
+        "contains": "default",
+        "values": {
+          "count": 126088,
+          "rate": 528.9107765717544
+        },
+        "type": "counter"
+      },
+      "subject_read_departments_duration": {
+        "values": {
+          "p(95)": 1082.8044999999993,
+          "p(99)": 3061.2933999999946,
+          "avg": 299.8449706209302,
+          "min": 0,
+          "med": 82.941,
+          "max": 37624.038,
+          "p(90)": 571.781
+        },
+        "type": "trend",
+        "contains": "default"
+      },
+      "data_sent": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "rate": 80845.41409276152,
+          "count": 19272885
+        }
+      },
+      "http_req_waiting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(95)": 507.19525,
+          "p(99)": 2086.2109499999997,
+          "avg": 182.54241281144337,
+          "min": 0,
+          "med": 77.58,
+          "max": 59999.601,
+          "p(90)": 301.7165
+        }
+      },
+      "http_reqs": {
+        "values": {
+          "count": 126106,
+          "rate": 528.9862825198088
+        },
+        "type": "counter",
+        "contains": "default"
+      },
+      "subject_read_count_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 228.2732789161123,
+          "min": 11.055,
+          "med": 78.393,
+          "max": 34937.345,
+          "p(90)": 496.38960000000003,
+          "p(95)": 631.2370999999998,
+          "p(99)": 2231.8101599999995
+        }
+      },
+      "subject_read_grades_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(95)": 592.5127499999998,
+          "p(99)": 2255.4065,
+          "avg": 240.8733827449746,
+          "min": 11.573,
+          "med": 78.329,
+          "max": 59999.401,
+          "p(90)": 496.28150000000005
+        }
+      },
+      "subject_read_filter_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(90)": 859.9013000000001,
+          "p(95)": 1396.9858999999988,
+          "p(99)": 4381.603889999998,
+          "avg": 420.24169198178134,
+          "min": 12.229,
+          "med": 143.983,
+          "max": 59999.428
+        }
+      },
+      "http_req_duration{expected_response:true}": {
+        "contains": "time",
+        "values": {
+          "max": 43453.071,
+          "p(90)": 1042.7820000000004,
+          "p(95)": 1959.8424999999995,
+          "p(99)": 6542.377959999998,
+          "avg": 471.5692127630877,
+          "min": 11.055,
+          "med": 82.804
+        },
+        "type": "trend"
+      },
+      "subject_read_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "med": 392.825,
+          "max": 60000.044,
+          "p(90)": 3086.3852000000006,
+          "p(95)": 5416.711399999994,
+          "p(99)": 10897.840119999999,
+          "avg": 1249.956285987342,
+          "min": 12.644
+        }
+      },
+      "http_req_failed": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.00006343869443166859,
+          "passes": 8,
+          "fails": 126098
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "checks": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.9999365613055683,
+          "passes": 126098,
+          "fails": 8
+        }
+      },
+      "http_req_blocked": {
+        "contains": "time",
+        "values": {
+          "p(90)": 0.001,
+          "p(95)": 0.001,
+          "p(99)": 0.003,
+          "avg": 4.42548157106282,
+          "min": 0,
+          "med": 0,
+          "max": 13270.108
+        },
+        "type": "trend"
+      },
+      "subject_read_errors": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.00006343869443166859,
+          "passes": 8,
+          "fails": 126098
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "vus_max": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 1000,
+          "min": 1000,
+          "max": 1000
+        }
+      },
+      "http_req_duration": {
+        "thresholds": {
+          "p(95)<500": {
+            "ok": false
+          },
+          "p(99)<1000": {
+            "ok": false
+          }
+        },
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 474.4781463213474,
+          "min": 0,
+          "med": 82.8055,
+          "max": 60000.044,
+          "p(90)": 1043.1735,
+          "p(95)": 1962.6212499999992,
+          "p(99)": 6560.435999999999
+        }
+      },
+      "http_req_sending": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(99)": 0.355,
+          "avg": 0.05833634402804259,
+          "min": 0,
+          "med": 0.033,
+          "max": 13.585,
+          "p(90)": 0.081,
+          "p(95)": 0.115
+        }
+      },
+      "data_received": {
+        "values": {
+          "count": 2213090137,
+          "rate": 9283414.940231903
+        },
+        "type": "counter",
+        "contains": "data"
+      },
+      "http_req_connecting": {
+        "values": {
+          "p(95)": 0,
+          "p(99)": 0,
+          "avg": 1.6579448083358426,
+          "min": 0,
+          "med": 0,
+          "max": 5080.55,
+          "p(90)": 0
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "http_req_receiving": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(95)": 1388.7692499999996,
+          "p(99)": 5465.96855,
+          "avg": 291.87739716587737,
+          "min": 0,
+          "med": 0.104,
+          "max": 59919.807,
+          "p(90)": 600.485
+        }
+      },
+      "http_req_tls_handshaking": {
+        "contains": "time",
+        "values": {
+          "p(99)": 0,
+          "avg": 2.766236412224638,
+          "min": 0,
+          "med": 0,
+          "max": 12196.361,
+          "p(90)": 0,
+          "p(95)": 0
+        },
+        "type": "trend"
+      },
+      "subject_read_professor_search_duration": {
+        "contains": "default",
+        "values": {
+          "p(90)": 494.3198,
+          "p(95)": 612.4912999999987,
+          "p(99)": 2222.48164,
+          "avg": 237.50444342820114,
+          "min": 11.175,
+          "med": 78.354,
+          "max": 59999.715
+        },
+        "type": "trend"
+      },
+      "iteration_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(95)": 2437.8351290499995,
+          "p(99)": 7017.232230579995,
+          "avg": 929.1572906326957,
+          "min": 213.965667,
+          "med": 633.4346665,
+          "max": 60646.835833,
+          "p(90)": 1483.4761462000001
+        }
+      },
+      "vus": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 1,
+          "min": 1,
+          "max": 1000
+        }
+      }
+    },
+    "root_group": {
+      "checks": [
+        {
+          "path": "::grades status 200",
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 19201,
+          "fails": 2,
+          "name": "grades status 200"
+        },
+        {
+          "fails": 1,
+          "name": "departments status 200",
+          "path": "::departments status 200",
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 18887
+        },
+        {
+          "path": "::count status 200",
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 25424,
+          "fails": 0,
+          "name": "count status 200"
+        },
+        {
+          "name": "filter status 200",
+          "path": "::filter status 200",
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 18878,
+          "fails": 1
+        },
+        {
+          "name": "subject search status 200",
+          "path": "::subject search status 200",
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 25107,
+          "fails": 3
+        },
+        {
+          "id": "bf145fc270dae668c75958348664d49c",
+          "passes": 18583,
+          "fails": 1,
+          "name": "professor search status 200",
+          "path": "::professor search status 200"
+        }
+      ],
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "groups": [
+        {
+          "path": "::setup",
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a",
+          "groups": [],
+          "checks": [
+              {
+                "name": "count status 200",
+                "path": "::setup::count status 200",
+                "id": "373bc94804b8d5b7733e7b5c457e9a12",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "name": "departments status 200",
+                "path": "::setup::departments status 200",
+                "id": "d09fa4300114fed036f335660dddb271",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "name": "grades status 200",
+                "path": "::setup::grades status 200",
+                "id": "af14747f4b0f176b2dce752b98debdff",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "name": "subject search status 200",
+                "path": "::setup::subject search status 200",
+                "id": "c9fb74e122c66285735a0d5bc17e206c",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "fails": 0,
+                "name": "professor search status 200",
+                "path": "::setup::professor search status 200",
+                "id": "7ac220a4b0d54400a88825fbdc772aa0",
+                "passes": 3
+              },
+              {
+                "name": "filter status 200",
+                "path": "::setup::filter status 200",
+                "id": "561cb701c0228225332599949cf1547c",
+                "passes": 3,
+                "fails": 0
+              }
+            ],
+          "name": "setup"
+        }
+      ]
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-baseline/README.md
+++ b/reports/performance/2026-07-27-redis-baseline/README.md
@@ -1,0 +1,241 @@
+# Redis 도입 전 현재 상태 기준선
+
+측정일: 2026-07-27 (KST)
+
+## 결론
+
+현재 구조는 `Cloud Run 최대 3대 + 인스턴스별 Caffeine + PostgreSQL 버전
+1초 폴링`이다. 200 VU에서는 단일 인스턴스만으로 48,975건을 실패 없이
+처리했고 p95는 47.83ms였다. 반면 1,000 VU에서 실제 3대로 확장했을 때는
+126,106건, 실패율 0.0063%, p95 1.96초, p99 6.56초였다.
+
+Redis 도입의 근거도 실제 부하 중 확인됐다.
+
+- 1,000 VU 측정 4분 동안 `subject-filters` 버전이 30번 증가했다.
+- 세 인스턴스가 이 변화를 각자 폴링해 로컬 캐시를 총 79번 비웠다.
+- 새 인스턴스 두 대는 각각 약 25초 동안 기동한 뒤 각자의 캐시를 다시
+  예열했다.
+- 서버 5xx와 Hikari connection timeout은 0이었다. 병목은 DB 연결 고갈보다
+  자동 확장 지연, 인스턴스별 캐시 중복, 전체 필터 캐시 무효화, CPU/응답
+  직렬화 대기가 합쳐진 결과로 보는 것이 타당하다.
+
+따라서 Redis는 단순 기술 추가가 아니라 다음 문제를 해결하는 후보가 된다.
+
+1. 인스턴스마다 같은 값을 중복 저장하고 예열하는 문제
+2. 캐시 변경 확인을 위해 인스턴스마다 매초 DB를 조회하는 문제
+3. 인기 순서가 한 번 바뀔 때 모든 인스턴스의 필터 캐시가 함께 사라지는 문제
+4. 무효화 직후 여러 인스턴스가 같은 키를 동시에 다시 계산하는 문제
+
+다만 Redis만 붙여도 Cloud Run 콜드 스타트와 JSON 직렬화/CPU 대기가
+사라지는 것은 아니다. 도입 후에는 같은 시나리오를 다시 실행해 효과를
+분리해서 증명해야 한다.
+
+## 측정 대상
+
+| 항목 | 값 |
+| --- | --- |
+| Git 커밋 | `b2800ba2797b15040066eecc8f71589fa3b0f65e` |
+| 애플리케이션 | Spring Boot 3.5.4, Java 17 |
+| Cloud Run 리전 | `asia-northeast3` |
+| 벤치 서비스 | `inu-timetable-backend-cache-bench` |
+| 벤치 리비전 | `inu-timetable-backend-cache-bench-redisbase` |
+| 접근 | Google IAM 인증이 필요한 비공개 서비스 |
+| 컨테이너 | 1 vCPU, 1 GiB |
+| 요청 동시성 | 인스턴스당 40 |
+| DB 풀 | 인스턴스당 maximum 10, minimum idle 2 |
+| 세션 | shared JDBC session 활성화, migration bridge `off` |
+| 현재 학기 | `2026-2` |
+| 활성 과목 수 | 5,280 |
+| 캐시 | 인스턴스별 Caffeine, maximum size 1,000, TTL 10분 |
+| 분산 무효화 | `shared_cache_versions`를 인스턴스마다 1초 간격으로 폴링 |
+| 부하 도구 | k6 1.4.2 |
+
+최신 main은 측정 전에 다음 검증을 통과했다.
+
+- `./gradlew clean assemble -x test`
+- `./gradlew test`
+- `./gradlew clean bootJar`
+
+## 중요한 데이터베이스 범위
+
+벤치 서비스는 `BENCH_DB_*` Secret을 사용하지만, Secret 값을 노출하지 않고
+지문을 비교한 결과 운영 Secret과 다음 항목이 같았다.
+
+- URL에서 연결 옵션을 제외한 DB endpoint와 database
+- DB username
+- DB password
+
+즉 Cloud Run 서비스는 별도지만 DB는 운영 DB와 같다. 이번 k6 시나리오는
+아래 읽기 API만 사용하며 사용자/과목 데이터를 쓰지 않았다.
+
+- `/api/subjects/count`
+- `/api/subjects/departments`
+- `/api/subjects/grades`
+- `/api/subjects/search`
+- `/api/subjects/search/professor`
+- `/api/subjects/filter`
+
+두 번의 1,000 VU 측정 동안 운영 서비스의 health와 과목 count를 10초
+간격으로 총 48회 확인했고 모두 HTTP 200이었다. 같은 시간대 운영 서비스의
+Cloud Run 5xx와 ERROR 로그도 0건이었다. 그래도 운영 DB와 완전히 격리된
+실험은 아니므로, Redis 전후 최종 비교는 DB clone에서 반복하는 편이 더
+엄밀하다.
+
+## 시나리오
+
+`portfolio` 프로필은 총 3분 40초다.
+
+1. 20초 동안 최대 VU의 15%까지 상승
+2. 60초 동안 50%까지 상승
+3. 60초 동안 50% 유지
+4. 20초 동안 최대 VU까지 상승
+5. 40초 동안 최대 VU 유지
+6. 20초 동안 0으로 하강
+
+각 VU는 요청 후 0.2~0.7초를 기다린다. 요청 비율은 count 20%,
+departments 15%, grades 15%, subject search 20%, professor search 15%,
+filter 15%다.
+
+## 결과
+
+| 조건 | 최대 VU | 실제 인스턴스 | 요청 수 | 실패 | 실패율 | 평균 | p95 | p99 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 스모크, service cap 1 | 10 | 1 | 349 | 0 | 0% | 29.49ms | 82.07ms | 122.53ms |
+| 현재 Caffeine, service cap 1 | 200 | 1 | 48,975 | 0 | 0% | 23.10ms | 47.83ms | 78.97ms |
+| 현재 Caffeine, 잘못 남은 service cap 1 | 1,000 | 1 | 89,889 | 0 | 0% | 847.87ms | 2,302.42ms | 2,605.88ms |
+| 현재 Caffeine, service/revision cap 3 | 1,000 | 3 | 126,106 | 8 | 0.0063% | 474.48ms | 1,962.62ms | 6,560.44ms |
+
+8건의 실패는 k6 쪽 HTTP/2 connection 수립 실패와 request timeout이었다.
+같은 시간대 벤치 리비전의 서버 5xx는 0건이었다. k6가 exit code 99로
+종료한 이유는 기능 오류율이 아니라 스크립트의 성능 임계값
+`p95 < 500ms`, `p99 < 1,000ms`를 넘었기 때문이다.
+
+### 수평 확장 효과
+
+현재 코드의 단일 인스턴스 1,000 VU와 3대 결과를 비교하면 다음과 같다.
+
+- 요청 수: 89,889 -> 126,106, **40.3% 증가**
+- 평균: 847.87ms -> 474.48ms, **44.0% 감소**
+- p95: 2,302.42ms -> 1,962.62ms, **14.8% 감소**
+- p99: 2,605.88ms -> 6,560.44ms, **151.8% 증가**
+
+처리량과 평균은 좋아졌지만 p99는 자동 확장과 client timeout의 영향을
+받아 크게 나빠졌다. 최대 인스턴스 수만 늘리는 것으로 스파이크의 tail
+latency가 해결되지는 않는다.
+
+### 발견된 Cloud Run 설정 함정
+
+처음 배포 후 리비전의 `max-instances`는 3이었지만 서비스 전체
+`max`가 과거 실험 값 1로 남아 있었다. 서비스 전체 cap이 우선 적용돼
+첫 1,000 VU 실험에서는 인스턴스가 한 대만 기동했다.
+
+다음 두 값을 모두 3으로 맞춘 뒤 재측정했다.
+
+- service-level maximum: 3
+- revision-level maximum: 3
+
+이 차이는 배포 설정에서 함께 검증해야 한다. 리비전 설정만 보고 “최대
+3대”라고 판단하면 실제 런타임과 어긋날 수 있다.
+
+## 자동 확장과 캐시 예열 증거
+
+3대 실험은 2026-07-27 23:10:02 KST 전후에 시작했다.
+
+| 이벤트 | 측정 시작 후 |
+| --- | ---: |
+| 두 번째 인스턴스 시작 요청 | 약 7초 |
+| 두 번째 인스턴스 애플리케이션 ready | 약 34초 |
+| 두 번째 인스턴스 캐시 warm-up 완료 | 약 35초 |
+| 세 번째 인스턴스 시작 요청 | 약 39초 |
+| 세 번째 인스턴스 애플리케이션 ready | 약 66초 |
+| 세 번째 인스턴스 캐시 warm-up 완료 | 약 68초 |
+
+두 새 인스턴스의 Spring Boot 기동 시간은 각각 25.09초와 25.29초였다.
+각 인스턴스는 7개 warm-up task를 별도로 수행했고 모두 성공했다.
+따라서 초기 1분 이상은 3대가 완전히 준비된 정상 상태가 아니었다.
+
+## 무효화 churn
+
+### 200 VU
+
+- 실제 인스턴스: 1
+- 서로 다른 `subject-filters` 버전 변경: 20회
+- 로컬 캐시 무효화 적용 로그: 20회
+
+### 1,000 VU, 3대
+
+- 실제 인스턴스: 3
+- 서로 다른 `subject-filters` 버전 변경: 30회 (`4139` -> `4168`)
+- 로컬 캐시 무효화 적용 로그: 79회
+- 벤치 종료 후 한 인스턴스에서 관측한 필터 캐시 hit/miss:
+  30,238 / 356, 적중률 98.84%
+- Hikari connection timeout: 0
+
+30번의 논리적 변경이 최대 90번의 로컬 clear가 될 수 있고, 이번에는
+인스턴스가 순차 기동해 총 79번이 관측됐다. 현재 구현은 시간표 추가/삭제로
+인기 카운트가 바뀔 때 `subjectFilters` 전체를 비운다. 사용량이 늘수록
+필터 캐시가 가장 자주 식는 구조다.
+
+또한 최대 3대가 모두 살아 있으면 `shared_cache_versions` 확인 쿼리가
+초당 약 3회, 분당 약 180회 발생한다. 지금 수치에서 DB 풀 고갈은
+없었지만, 캐시 일관성만을 위해 계속 발생하는 고정 DB 부하다.
+
+## 2026-07-25 기준선과 비교
+
+이전 보고서의 서울 DB/Caffeine 결과와 비교하면 다음과 같다.
+
+| 최대 VU / 인스턴스 | 2026-07-25 요청 수 | 현재 요청 수 | 요청 수 변화 | 이전 p95 | 현재 p95 |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1,000 / 1 | 94,434 | 89,889 | -4.8% | 1,991.06ms | 2,302.42ms |
+| 1,000 / 3 | 172,904 | 126,106 | -27.1% | 808.45ms | 1,962.62ms |
+
+현재는 활성 과목이 2,894개에서 5,280개로 늘었고, 공유 세션과 DB 버전
+폴링 기반 분산 무효화가 추가됐으며, 운영 사용자의 실제 시간표 변경으로
+필터 캐시가 계속 무효화됐다. 따라서 이 표를 특정 한 변경의 인과관계로
+해석하면 안 된다. “현재 운영 코드와 현재 데이터에서 다시 잰 출발점”으로
+사용해야 한다.
+
+## Redis 실험 설계
+
+첫 실험은 다음 범위가 적절하다.
+
+1. count/departments/grades/search/filter 결과를 Redis shared cache로 이동
+2. `shared_cache_versions` 1초 DB 폴링 제거
+3. 인기 순서에 영향받는 키와 영향받지 않는 필터 키를 분리
+4. 버전이 포함된 key namespace로 전체 삭제 비용 축소
+5. 동일 키 miss에 `SET NX PX` 기반 짧은 lock을 두어 cache stampede 방지
+6. 로컬 L1을 유지한다면 Redis Pub/Sub로 L1만 즉시 무효화하고, L1 없이
+   시작한다면 일관성 경로를 더 단순하게 유지
+
+Redis 전후 합격선은 다음처럼 잡는다.
+
+| 지표 | 현재 기준선 | 최소 목표 | 도전 목표 |
+| --- | ---: | ---: | ---: |
+| 200 VU p95 | 47.83ms | 55ms 이하, 실패 0 | 현재 이하 |
+| 1,000 VU 요청 수 | 126,106 | 151,000 이상 (+20%) | 172,904 이상 |
+| 1,000 VU p95 | 1,962.62ms | 1,374ms 이하 (-30%) | 1,000ms 이하 |
+| 1,000 VU p99 | 6,560.44ms | 4,592ms 이하 (-30%) | 2,500ms 이하 |
+| 무효화 확인 DB 쿼리 | 최대 약 3회/초 | 0 | 0 |
+| 동일 키 재계산 | 인스턴스별 발생 가능 | 변경당 최대 1회 | 변경당 최대 1회 |
+
+## 재현
+
+```bash
+BENCH_URL="https://<private-cloud-run-url>"
+ID_TOKEN="$(gcloud auth print-identity-token)"
+
+BASE_URL="$BENCH_URL" \
+BENCHMARK_NAME="current-caffeine-max3-pool10-1000vus" \
+RESULT_FILE="03-current-caffeine-max3-1000vus.json" \
+PROFILE="portfolio" \
+PEAK_VUS="1000" \
+ID_TOKEN="$ID_TOKEN" \
+k6 run scripts/k6/subject-read-benchmark.js
+```
+
+원본 결과:
+
+- `00-smoke-service-cap1-10vus.json`
+- `01-current-caffeine-service-cap1-200vus.json`
+- `02-current-caffeine-service-cap1-1000vus.json`
+- `03-current-caffeine-max3-1000vus.json`

--- a/reports/performance/2026-07-27-redis-shared-cache/00-smoke-10vus.json
+++ b/reports/performance/2026-07-27-redis-shared-cache/00-smoke-10vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "redis-shared-cache-smoke-10vus",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "smoke",
+    "peakVus": 10,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T14:56:25.811Z"
+  },
+  "result": {
+    "options": {
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ],
+      "summaryTimeUnit": "",
+      "noColor": true
+    },
+    "state": {
+      "isStdOutTTY": false,
+      "isStdErrTTY": false,
+      "testRunDurationMs": 22257.689
+    },
+    "metrics": {
+      "iterations": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 314,
+          "rate": 14.1074843843851
+        }
+      },
+      "http_req_tls_handshaking": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(95)": 0,
+          "p(99)": 49.105869999999996,
+          "avg": 1.598813253012048,
+          "min": 0,
+          "med": 0,
+          "max": 56.124,
+          "p(90)": 0
+        }
+      },
+      "subject_read_count_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "med": 20.782,
+          "max": 116.045,
+          "p(90)": 25.9375,
+          "p(95)": 56.358249999999934,
+          "p(99)": 87.47034999999998,
+          "avg": 24.77801515151516,
+          "min": 16.89
+        }
+      },
+      "checks": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "passes": 332,
+          "fails": 0,
+          "rate": 1
+        }
+      },
+      "data_received": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 5765237,
+          "rate": 259022.26417127135
+        }
+      },
+      "http_req_blocked": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 2.0436144578313136,
+          "min": 0,
+          "med": 0.001,
+          "max": 127.493,
+          "p(90)": 0.001,
+          "p(95)": 0.001,
+          "p(99)": 56.30062
+        }
+      },
+      "http_req_connecting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(99)": 7.85424,
+          "avg": 0.247316265060241,
+          "min": 0,
+          "med": 0,
+          "max": 8.629,
+          "p(90)": 0,
+          "p(95)": 0
+        }
+      },
+      "data_sent": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 73143,
+          "rate": 3286.1902239715905
+        }
+      },
+      "http_req_failed": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0,
+          "passes": 0,
+          "fails": 332
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "subject_read_departments_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 22.728777777777772,
+          "min": 15.088,
+          "med": 21.167,
+          "max": 76.211,
+          "p(90)": 26.3132,
+          "p(95)": 28.3094,
+          "p(99)": 51.93489999999998
+        }
+      },
+      "subject_read_errors": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "fails": 332,
+          "rate": 0,
+          "passes": 0
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "subject_read_professor_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(99)": 76.40599999999999,
+          "avg": 24.143097560975608,
+          "min": 15.864,
+          "med": 19.092,
+          "max": 83.23,
+          "p(90)": 28.474,
+          "p(95)": 59.952
+        }
+      },
+      "http_req_duration{expected_response:true}": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(95)": 84.40154999999999,
+          "p(99)": 260.15414999999985,
+          "avg": 34.480626506024066,
+          "min": 15.088,
+          "med": 22.1655,
+          "max": 352.816,
+          "p(90)": 68.73590000000002
+        }
+      },
+      "http_req_receiving": {
+        "values": {
+          "med": 0.1025,
+          "max": 55.604,
+          "p(90)": 3.9679,
+          "p(95)": 10.744299999999992,
+          "p(99)": 24.26865999999999,
+          "avg": 1.7317469879518068,
+          "min": 0.028
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "subject_read_grades_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(99)": 91.414,
+          "avg": 25.016775510204074,
+          "min": 16.567,
+          "med": 21.033,
+          "max": 98.302,
+          "p(90)": 26.958000000000002,
+          "p(95)": 55.22679999999992
+        }
+      },
+      "http_reqs": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 332,
+          "rate": 14.916193680305264
+        }
+      },
+      "subject_read_filter_duration": {
+        "values": {
+          "p(90)": 111.7272,
+          "p(95)": 126.77184999999996,
+          "p(99)": 157.49996,
+          "avg": 51.35687500000001,
+          "min": 19.268,
+          "med": 29.0125,
+          "max": 178.007
+        },
+        "type": "trend",
+        "contains": "default"
+      },
+      "vus": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 1,
+          "min": 0,
+          "max": 10
+        }
+      },
+      "iteration_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "min": 223.641875,
+          "med": 503.31379200000003,
+          "max": 902.13575,
+          "p(90)": 685.9606669,
+          "p(95)": 711.0243068,
+          "p(99)": 761.3989610799999,
+          "avg": 492.10684596815287
+        }
+      },
+      "http_req_waiting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 32.60150301204818,
+          "min": 14.908,
+          "med": 21.639499999999998,
+          "max": 336.781,
+          "p(90)": 62.0005,
+          "p(95)": 83.9748,
+          "p(99)": 251.60233999999986
+        }
+      },
+      "http_req_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 34.480626506024066,
+          "min": 15.088,
+          "med": 22.1655,
+          "max": 352.816,
+          "p(90)": 68.73590000000002,
+          "p(95)": 84.40154999999999,
+          "p(99)": 260.15414999999985
+        },
+        "thresholds": {
+          "p(95)<500": {
+            "ok": true
+          },
+          "p(99)<1000": {
+            "ok": true
+          }
+        }
+      },
+      "subject_read_search_duration": {
+        "values": {
+          "p(95)": 266.5819999999998,
+          "p(99)": 328.42303999999996,
+          "avg": 56.91518461538461,
+          "min": 20.604,
+          "med": 30.755,
+          "max": 352.816,
+          "p(90)": 85.4306
+        },
+        "type": "trend",
+        "contains": "default"
+      },
+      "vus_max": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "min": 10,
+          "max": 10,
+          "value": 10
+        }
+      },
+      "http_req_sending": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(99)": 1.1561299999999983,
+          "avg": 0.14737650602409633,
+          "min": 0.025,
+          "med": 0.117,
+          "max": 2.001,
+          "p(90)": 0.18980000000000002,
+          "p(95)": 0.30159999999999987
+        }
+      }
+    },
+    "root_group": {
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "groups": [
+        {
+          "checks": [
+            {
+              "fails": 0,
+              "name": "count status 200",
+              "path": "::setup::count status 200",
+              "id": "373bc94804b8d5b7733e7b5c457e9a12",
+              "passes": 3
+            },
+            {
+              "id": "d09fa4300114fed036f335660dddb271",
+              "passes": 3,
+              "fails": 0,
+              "name": "departments status 200",
+              "path": "::setup::departments status 200"
+            },
+            {
+              "passes": 3,
+              "fails": 0,
+              "name": "grades status 200",
+              "path": "::setup::grades status 200",
+              "id": "af14747f4b0f176b2dce752b98debdff"
+            },
+            {
+              "id": "c9fb74e122c66285735a0d5bc17e206c",
+              "passes": 3,
+              "fails": 0,
+              "name": "subject search status 200",
+              "path": "::setup::subject search status 200"
+            },
+            {
+              "fails": 0,
+              "name": "professor search status 200",
+              "path": "::setup::professor search status 200",
+              "id": "7ac220a4b0d54400a88825fbdc772aa0",
+              "passes": 3
+            },
+            {
+              "name": "filter status 200",
+              "path": "::setup::filter status 200",
+              "id": "561cb701c0228225332599949cf1547c",
+              "passes": 3,
+              "fails": 0
+            }
+          ],
+          "name": "setup",
+          "path": "::setup",
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a",
+          "groups": []
+        }
+      ],
+      "checks": [
+        {
+          "name": "departments status 200",
+          "path": "::departments status 200",
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 60,
+          "fails": 0
+        },
+        {
+          "name": "filter status 200",
+          "path": "::filter status 200",
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 45,
+          "fails": 0
+        },
+        {
+          "name": "subject search status 200",
+          "path": "::subject search status 200",
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 62,
+          "fails": 0
+        },
+        {
+          "name": "count status 200",
+          "path": "::count status 200",
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 63,
+          "fails": 0
+        },
+        {
+          "fails": 0,
+          "name": "grades status 200",
+          "path": "::grades status 200",
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 46
+        },
+        {
+          "passes": 38,
+          "fails": 0,
+          "name": "professor search status 200",
+          "path": "::professor search status 200",
+          "id": "bf145fc270dae668c75958348664d49c"
+        }
+      ]
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-shared-cache/01-redis-shared-cache-max3-1000vus.json
+++ b/reports/performance/2026-07-27-redis-shared-cache/01-redis-shared-cache-max3-1000vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "redis-shared-cache-max3-pool10-1000vus",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "portfolio",
+    "peakVus": 1000,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T15:00:33.657Z"
+  },
+  "result": {
+    "options": {
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ],
+      "summaryTimeUnit": "",
+      "noColor": true
+    },
+    "state": {
+      "isStdErrTTY": false,
+      "testRunDurationMs": 234648.81,
+      "isStdOutTTY": false
+    },
+    "metrics": {
+      "subject_read_filter_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 545.9619724941718,
+          "min": 14.026,
+          "med": 238.44299999999998,
+          "max": 60002.025,
+          "p(90)": 1181.2935000000002,
+          "p(95)": 1736.945149999999,
+          "p(99)": 4734.51506
+        }
+      },
+      "http_req_receiving": {
+        "values": {
+          "p(99)": 5335.359279999999,
+          "avg": 276.1100569451762,
+          "min": 0,
+          "med": 0.085,
+          "max": 59922.556,
+          "p(90)": 544.4804000000001,
+          "p(95)": 1302.0295999999985
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "subject_read_errors": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.00012924460834575518,
+          "passes": 15,
+          "fails": 116044
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "http_req_waiting": {
+        "values": {
+          "p(99)": 2199.17076,
+          "avg": 278.0325257756826,
+          "min": 0,
+          "med": 83.967,
+          "max": 60001.757,
+          "p(90)": 572.7904000000001,
+          "p(95)": 977.0885999999998
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "checks": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.9998707553916543,
+          "passes": 116044,
+          "fails": 15
+        }
+      },
+      "iterations": {
+        "contains": "default",
+        "values": {
+          "count": 116041,
+          "rate": 494.53052840966893
+        },
+        "type": "counter"
+      },
+      "subject_read_search_duration": {
+        "contains": "default",
+        "values": {
+          "p(90)": 2851.285900000001,
+          "p(95)": 5381.110149999999,
+          "p(99)": 11760.076969999996,
+          "avg": 1292.256890758482,
+          "min": 14.217,
+          "med": 465.6435,
+          "max": 60002.938
+        },
+        "type": "trend"
+      },
+      "data_received": {
+        "contains": "data",
+        "values": {
+          "count": 2030917577,
+          "rate": 8655136.912904011
+        },
+        "type": "counter"
+      },
+      "http_req_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "med": 153.024,
+          "max": 60002.938,
+          "p(90)": 1155.4948000000002,
+          "p(95)": 2064.0095999999976,
+          "p(99)": 6540.043519999989,
+          "avg": 554.2060235742124,
+          "min": 0
+        },
+        "thresholds": {
+          "p(99)<1000": {
+            "ok": false
+          },
+          "p(95)<500": {
+            "ok": false
+          }
+        }
+      },
+      "http_req_failed": {
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        },
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.00012924460834575518,
+          "passes": 15,
+          "fails": 116044
+        }
+      },
+      "http_req_sending": {
+        "values": {
+          "avg": 0.06344085335907015,
+          "min": 0,
+          "med": 0.038,
+          "max": 6.64,
+          "p(90)": 0.099,
+          "p(95)": 0.142,
+          "p(99)": 0.464419999999999
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "subject_read_professor_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(90)": 630.4430000000001,
+          "p(95)": 1072.7139999999997,
+          "p(99)": 2277.05996,
+          "avg": 324.3244903807725,
+          "min": 11.982,
+          "med": 83.757,
+          "max": 60000.768
+        }
+      },
+      "http_req_connecting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 1.504490233415763,
+          "min": 0,
+          "med": 0,
+          "max": 3079.082,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0
+        }
+      },
+      "http_req_tls_handshaking": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 2.625137490414358,
+          "min": 0,
+          "med": 0,
+          "max": 19162.663,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0
+        }
+      },
+      "subject_read_count_duration": {
+        "contains": "default",
+        "values": {
+          "p(95)": 1079.9177499999996,
+          "p(99)": 2305.4078299999996,
+          "avg": 320.60906660056764,
+          "min": 12.089,
+          "med": 84.858,
+          "max": 60001.797,
+          "p(90)": 635.9377000000001
+        },
+        "type": "trend"
+      },
+      "http_req_duration{expected_response:true}": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(90)": 1154.9238000000003,
+          "p(95)": 2060.532149999999,
+          "p(99)": 6495.376619999996,
+          "avg": 547.0389061390465,
+          "min": 11.982,
+          "med": 153.0115,
+          "max": 48343.423
+        }
+      },
+      "http_req_blocked": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 4.130986472396235,
+          "min": 0,
+          "med": 0,
+          "max": 19235.571,
+          "p(90)": 0.001,
+          "p(95)": 0.001,
+          "p(99)": 0.011
+        }
+      },
+      "subject_read_grades_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(99)": 2264.7230799999993,
+          "avg": 307.51422775332907,
+          "min": 0,
+          "med": 84.75,
+          "max": 36217.946,
+          "p(90)": 639.3228000000001,
+          "p(95)": 1070.2422
+        }
+      },
+      "data_sent": {
+        "values": {
+          "count": 17815486,
+          "rate": 75924.04154958212
+        },
+        "type": "counter",
+        "contains": "data"
+      },
+      "iteration_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "min": 217.01975,
+          "med": 686.790292,
+          "max": 60654.026459,
+          "p(90)": 1637.789666,
+          "p(95)": 2507.484292,
+          "p(99)": 7021.126275199999,
+          "avg": 1009.0873471209567
+        }
+      },
+      "vus_max": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "value": 1000,
+          "min": 1000,
+          "max": 1000
+        }
+      },
+      "http_reqs": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 116059,
+          "rate": 494.60723879230414
+        }
+      },
+      "subject_read_departments_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 371.27771774515963,
+          "min": 12.745,
+          "med": 110.019,
+          "max": 26573.482,
+          "p(90)": 859.4188,
+          "p(95)": 1216.8771999999997,
+          "p(99)": 2608.088879999998
+        }
+      },
+      "vus": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "max": 1000,
+          "value": 1,
+          "min": 1
+        }
+      }
+    },
+    "root_group": {
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "groups": [
+        {
+          "path": "::setup",
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a",
+          "groups": [],
+          "checks": [
+              {
+                "name": "count status 200",
+                "path": "::setup::count status 200",
+                "id": "373bc94804b8d5b7733e7b5c457e9a12",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "name": "departments status 200",
+                "path": "::setup::departments status 200",
+                "id": "d09fa4300114fed036f335660dddb271",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "passes": 3,
+                "fails": 0,
+                "name": "grades status 200",
+                "path": "::setup::grades status 200",
+                "id": "af14747f4b0f176b2dce752b98debdff"
+              },
+              {
+                "fails": 0,
+                "name": "subject search status 200",
+                "path": "::setup::subject search status 200",
+                "id": "c9fb74e122c66285735a0d5bc17e206c",
+                "passes": 3
+              },
+              {
+                "passes": 3,
+                "fails": 0,
+                "name": "professor search status 200",
+                "path": "::setup::professor search status 200",
+                "id": "7ac220a4b0d54400a88825fbdc772aa0"
+              },
+              {
+                "name": "filter status 200",
+                "path": "::setup::filter status 200",
+                "id": "561cb701c0228225332599949cf1547c",
+                "passes": 3,
+                "fails": 0
+              }
+            ],
+          "name": "setup"
+        }
+      ],
+      "checks": [
+        {
+          "name": "count status 200",
+          "path": "::count status 200",
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 23194,
+          "fails": 1
+        },
+        {
+          "passes": 17513,
+          "fails": 1,
+          "name": "professor search status 200",
+          "path": "::professor search status 200",
+          "id": "bf145fc270dae668c75958348664d49c"
+        },
+        {
+          "name": "departments status 200",
+          "path": "::departments status 200",
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 17506,
+          "fails": 0
+        },
+        {
+          "name": "subject search status 200",
+          "path": "::subject search status 200",
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 23164,
+          "fails": 11
+        },
+        {
+          "name": "grades status 200",
+          "path": "::grades status 200",
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 17493,
+          "fails": 1
+        },
+        {
+          "name": "filter status 200",
+          "path": "::filter status 200",
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 17156,
+          "fails": 1
+        }
+      ]
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-shared-cache/02-redis-shared-cache-nonlocking-max3-1000vus.json
+++ b/reports/performance/2026-07-27-redis-shared-cache/02-redis-shared-cache-nonlocking-max3-1000vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "redis-shared-cache-nonlocking-max3-1000vus",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "portfolio",
+    "peakVus": 1000,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T15:11:17.481Z"
+  },
+  "result": {
+    "root_group": {
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e",
+      "groups": [
+        {
+          "name": "setup",
+          "path": "::setup",
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a",
+          "groups": [],
+          "checks": [
+              {
+                "name": "count status 200",
+                "path": "::setup::count status 200",
+                "id": "373bc94804b8d5b7733e7b5c457e9a12",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "id": "d09fa4300114fed036f335660dddb271",
+                "passes": 3,
+                "fails": 0,
+                "name": "departments status 200",
+                "path": "::setup::departments status 200"
+              },
+              {
+                "fails": 0,
+                "name": "grades status 200",
+                "path": "::setup::grades status 200",
+                "id": "af14747f4b0f176b2dce752b98debdff",
+                "passes": 3
+              },
+              {
+                "name": "subject search status 200",
+                "path": "::setup::subject search status 200",
+                "id": "c9fb74e122c66285735a0d5bc17e206c",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "path": "::setup::professor search status 200",
+                "id": "7ac220a4b0d54400a88825fbdc772aa0",
+                "passes": 3,
+                "fails": 0,
+                "name": "professor search status 200"
+              },
+              {
+                "path": "::setup::filter status 200",
+                "id": "561cb701c0228225332599949cf1547c",
+                "passes": 3,
+                "fails": 0,
+                "name": "filter status 200"
+              }
+            ]
+        }
+      ],
+      "checks": [
+        {
+          "name": "subject search status 200",
+          "path": "::subject search status 200",
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 23465,
+          "fails": 5
+        },
+        {
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 23934,
+          "fails": 1,
+          "name": "count status 200",
+          "path": "::count status 200"
+        },
+        {
+          "id": "bf145fc270dae668c75958348664d49c",
+          "passes": 17707,
+          "fails": 0,
+          "name": "professor search status 200",
+          "path": "::professor search status 200"
+        },
+        {
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 17694,
+          "fails": 1,
+          "name": "grades status 200",
+          "path": "::grades status 200"
+        },
+        {
+          "name": "departments status 200",
+          "path": "::departments status 200",
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 17600,
+          "fails": 2
+        },
+        {
+          "name": "filter status 200",
+          "path": "::filter status 200",
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 17771,
+          "fails": 3
+        }
+      ]
+    },
+    "options": {
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ],
+      "summaryTimeUnit": "",
+      "noColor": true
+    },
+    "state": {
+      "testRunDurationMs": 237866.405,
+      "isStdOutTTY": false,
+      "isStdErrTTY": false
+    },
+    "metrics": {
+      "data_sent": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 18217783,
+          "rate": 76588.29753617372
+        }
+      },
+      "subject_read_professor_search_duration": {
+        "contains": "default",
+        "values": {
+          "avg": 281.59088085827267,
+          "min": 12.908,
+          "med": 83.412,
+          "max": 23100.826,
+          "p(90)": 566.3512999999999,
+          "p(95)": 762.2906999999998,
+          "p(99)": 2212.31946
+        },
+        "type": "trend"
+      },
+      "checks": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "passes": 118189,
+          "fails": 12,
+          "rate": 0.9998984780162604
+        }
+      },
+      "data_received": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 2067589122,
+          "rate": 8692228.404427268
+        }
+      },
+      "http_req_waiting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "med": 83.061,
+          "max": 60000.367,
+          "p(90)": 495.966,
+          "p(95)": 612.171,
+          "p(99)": 2091.916,
+          "avg": 241.45545088451334,
+          "min": 10.821
+        }
+      },
+      "http_req_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 533.8788169643205,
+          "min": 12.535,
+          "med": 148.962,
+          "max": 60001.112,
+          "p(90)": 1059.317,
+          "p(95)": 1979.128,
+          "p(99)": 6874.995
+        },
+        "thresholds": {
+          "p(95)<500": {
+            "ok": false
+          },
+          "p(99)<1000": {
+            "ok": false
+          }
+        }
+      },
+      "subject_read_count_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "min": 12.535,
+          "med": 84.2,
+          "max": 60000.4,
+          "p(90)": 563.567,
+          "p(95)": 769.4504499999997,
+          "p(99)": 2240.81122,
+          "avg": 296.637899365026
+        }
+      },
+      "subject_read_errors": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.00010152198373956227,
+          "passes": 12,
+          "fails": 118189
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "http_req_receiving": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 292.36392104973334,
+          "min": 0,
+          "med": 0.099,
+          "max": 59929.408,
+          "p(90)": 586.361,
+          "p(95)": 1391.212,
+          "p(99)": 5513.442
+        }
+      },
+      "http_req_failed": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.00010152198373956227,
+          "passes": 12,
+          "fails": 118189
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "http_req_sending": {
+        "values": {
+          "avg": 0.05944503007588908,
+          "min": 0.008,
+          "med": 0.035,
+          "max": 11.773,
+          "p(90)": 0.09,
+          "p(95)": 0.128,
+          "p(99)": 0.43
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "http_req_connecting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "max": 4074.329,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0,
+          "avg": 1.6396663987614317,
+          "min": 0,
+          "med": 0
+        }
+      },
+      "http_reqs": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 118201,
+          "rate": 496.9217910364434
+        }
+      },
+      "http_req_duration{expected_response:true}": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(90)": 1058.6078000000007,
+          "p(95)": 1975.8605999999963,
+          "p(99)": 6827.461079999993,
+          "avg": 528.3481662929686,
+          "min": 12.535,
+          "med": 148.944,
+          "max": 45114.108
+        }
+      },
+      "subject_read_departments_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "min": 13.687,
+          "med": 110.186,
+          "max": 60000.467,
+          "p(90)": 639.8706,
+          "p(95)": 1104.6257999999998,
+          "p(99)": 2670.3791999999994,
+          "avg": 359.51837051973735
+        }
+      },
+      "subject_read_grades_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "med": 84.215,
+          "max": 25538.297,
+          "p(90)": 565.1985,
+          "p(95)": 831.8772499999975,
+          "p(99)": 2247.66763,
+          "avg": 291.68297875466243,
+          "min": 13.072
+        }
+      },
+      "vus": {
+        "contains": "default",
+        "values": {
+          "min": 0,
+          "max": 1000,
+          "value": 2
+        },
+        "type": "gauge"
+      },
+      "iteration_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(95)": 2450.3061139499973,
+          "p(99)": 7389.042957519999,
+          "avg": 989.8290587352992,
+          "min": 218.195334,
+          "med": 680.814979,
+          "max": 60644.0305,
+          "p(90)": 1508.4221964
+        }
+      },
+      "http_req_blocked": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(99)": 0.008,
+          "avg": 5.131322230779341,
+          "min": 0,
+          "med": 0,
+          "max": 11739.903,
+          "p(90)": 0.001,
+          "p(95)": 0.001
+        }
+      },
+      "http_req_tls_handshaking": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "med": 0,
+          "max": 11571.342,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0,
+          "avg": 3.489711804468662,
+          "min": 0
+        }
+      },
+      "vus_max": {
+        "contains": "default",
+        "values": {
+          "value": 1000,
+          "min": 1000,
+          "max": 1000
+        },
+        "type": "gauge"
+      },
+      "subject_read_filter_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "med": 194.238,
+          "max": 60000.799,
+          "p(90)": 979.0706000000001,
+          "p(95)": 1433.9241999999988,
+          "p(99)": 4479.827399999999,
+          "avg": 480.6248356865591,
+          "min": 15.334
+        }
+      },
+      "iterations": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 118182,
+          "rate": 496.8419142669601
+        }
+      },
+      "subject_read_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(99)": 11582.839359999993,
+          "avg": 1319.8791604822616,
+          "min": 17.395,
+          "med": 486.821,
+          "max": 60001.112,
+          "p(90)": 2998.2102000000004,
+          "p(95)": 5485.9389999999985
+        }
+      }
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-shared-cache/03-two-level-caffeine-redis-max3-1000vus.json
+++ b/reports/performance/2026-07-27-redis-shared-cache/03-two-level-caffeine-redis-max3-1000vus.json
@@ -1,0 +1,423 @@
+{
+  "benchmark": {
+    "name": "two-level-caffeine-redis-max3-1000vus",
+    "baseUrl": "https://inu-timetable-backend-cache-bench-282216427513.asia-northeast3.run.app",
+    "profile": "portfolio",
+    "peakVus": 1000,
+    "warmupEnabled": true,
+    "completedAt": "2026-07-27T15:20:27.651Z"
+  },
+  "result": {
+    "options": {
+      "summaryTrendStats": [
+        "avg",
+        "min",
+        "med",
+        "max",
+        "p(90)",
+        "p(95)",
+        "p(99)"
+      ],
+      "summaryTimeUnit": "",
+      "noColor": true
+    },
+    "state": {
+      "isStdErrTTY": false,
+      "testRunDurationMs": 235871.226,
+      "isStdOutTTY": false
+    },
+    "metrics": {
+      "http_req_duration": {
+        "thresholds": {
+          "p(95)<500": {
+            "ok": false
+          },
+          "p(99)<1000": {
+            "ok": false
+          }
+        },
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 493.8181104287012,
+          "min": 0,
+          "med": 92.84649999999999,
+          "max": 60001.411,
+          "p(90)": 1035.689,
+          "p(95)": 1922.0859999999998,
+          "p(99)": 6465.628749999989
+        }
+      },
+      "http_req_sending": {
+        "values": {
+          "avg": 0.05608616213409743,
+          "min": 0,
+          "med": 0.033,
+          "max": 28.641,
+          "p(90)": 0.083,
+          "p(95)": 0.119,
+          "p(99)": 0.383
+        },
+        "type": "trend",
+        "contains": "time"
+      },
+      "iteration_duration": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "max": 60694.535125,
+          "p(90)": 1470.1903419,
+          "p(95)": 2403.3728902,
+          "p(99)": 6971.93028691,
+          "avg": 949.7531679832907,
+          "min": 214.687167,
+          "med": 652.55825
+        }
+      },
+      "http_req_tls_handshaking": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "min": 0,
+          "med": 0,
+          "max": 36737.771,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0,
+          "avg": 3.4077088255338484
+        }
+      },
+      "subject_read_grades_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(99)": 2155.84163,
+          "avg": 243.03621697397085,
+          "min": 0,
+          "med": 79.8625,
+          "max": 60000.279,
+          "p(90)": 496.3219,
+          "p(95)": 583.2038999999999
+        }
+      },
+      "vus_max": {
+        "values": {
+          "value": 1000,
+          "min": 1000,
+          "max": 1000
+        },
+        "type": "gauge",
+        "contains": "default"
+      },
+      "data_received": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "rate": 9171044.894640943,
+          "count": 2163185603
+        }
+      },
+      "subject_read_count_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "med": 79.982,
+          "max": 36422.677,
+          "p(90)": 495.8808,
+          "p(95)": 586.4409999999999,
+          "p(99)": 2168.0798799999993,
+          "avg": 243.53864678917736,
+          "min": 12.765
+        }
+      },
+      "http_req_connecting": {
+        "contains": "time",
+        "values": {
+          "med": 0,
+          "max": 4071.795,
+          "p(90)": 0,
+          "p(95)": 0,
+          "p(99)": 0,
+          "avg": 1.4112689037450508,
+          "min": 0
+        },
+        "type": "trend"
+      },
+      "iterations": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 123238,
+          "rate": 522.4800077988317
+        }
+      },
+      "http_req_duration{expected_response:true}": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 489.49198302526736,
+          "min": 12.284,
+          "med": 92.845,
+          "max": 39837.958,
+          "p(90)": 1035.1349,
+          "p(95)": 1918.2504499999995,
+          "p(99)": 6435.576789999999
+        }
+      },
+      "subject_read_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "avg": 1289.5087176030245,
+          "min": 13.761,
+          "med": 462.7735,
+          "max": 60001.411,
+          "p(90)": 3092.9192,
+          "p(95)": 5438.4369499999975,
+          "p(99)": 10938.417859999998
+        }
+      },
+      "data_sent": {
+        "type": "counter",
+        "contains": "data",
+        "values": {
+          "count": 18939633,
+          "rate": 80296.4961906799
+        }
+      },
+      "subject_read_errors": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "passes": 14,
+          "fails": 123242,
+          "rate": 0.00011358473421172194
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "http_reqs": {
+        "type": "counter",
+        "contains": "default",
+        "values": {
+          "count": 123256,
+          "rate": 522.5563206255603
+        }
+      },
+      "http_req_receiving": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "avg": 303.84668650613276,
+          "min": 0,
+          "med": 0.134,
+          "max": 59925.821,
+          "p(90)": 634.7230000000001,
+          "p(95)": 1461.0292499999994,
+          "p(99)": 5502.647349999995
+        }
+      },
+      "vus": {
+        "type": "gauge",
+        "contains": "default",
+        "values": {
+          "min": 0,
+          "max": 1000,
+          "value": 2
+        }
+      },
+      "subject_read_departments_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "max": 60000.554,
+          "p(90)": 566.296,
+          "p(95)": 1014.7139999999999,
+          "p(99)": 2395.0090999999993,
+          "avg": 297.5183504937682,
+          "min": 0,
+          "med": 91.269
+        }
+      },
+      "subject_read_professor_search_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "max": 60000.707,
+          "p(90)": 495.1834,
+          "p(95)": 583.3461999999998,
+          "p(99)": 2198.4112799999984,
+          "avg": 247.48508727564916,
+          "min": 0,
+          "med": 80.039
+        }
+      },
+      "subject_read_filter_duration": {
+        "type": "trend",
+        "contains": "default",
+        "values": {
+          "p(95)": 1366.9616999999998,
+          "p(99)": 4363.240339999999,
+          "avg": 450.39222961993727,
+          "min": 0,
+          "med": 167.392,
+          "max": 60001.333,
+          "p(90)": 852.3630000000002
+        }
+      },
+      "checks": {
+        "values": {
+          "rate": 0.9998864152657883,
+          "passes": 123242,
+          "fails": 14
+        },
+        "type": "rate",
+        "contains": "default"
+      },
+      "http_req_blocked": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(99)": 0.003,
+          "avg": 4.820245196990348,
+          "min": 0,
+          "med": 0,
+          "max": 36815.134,
+          "p(90)": 0.001,
+          "p(95)": 0.001
+        }
+      },
+      "http_req_failed": {
+        "type": "rate",
+        "contains": "default",
+        "values": {
+          "rate": 0.00011358473421172194,
+          "passes": 14,
+          "fails": 123242
+        },
+        "thresholds": {
+          "rate<0.01": {
+            "ok": true
+          }
+        }
+      },
+      "http_req_waiting": {
+        "type": "trend",
+        "contains": "time",
+        "values": {
+          "p(95)": 503.6982499999999,
+          "p(99)": 1153.4113499999999,
+          "avg": 189.91533776043215,
+          "min": 0,
+          "med": 78.901,
+          "max": 60000.677,
+          "p(90)": 302.45650000000006
+        }
+      }
+    },
+    "root_group": {
+      "groups": [
+        {
+          "path": "::setup",
+          "id": "5c0f8025f7e0b6654089e5b00e950f1a",
+          "groups": [],
+          "checks": [
+              {
+                "passes": 3,
+                "fails": 0,
+                "name": "count status 200",
+                "path": "::setup::count status 200",
+                "id": "373bc94804b8d5b7733e7b5c457e9a12"
+              },
+              {
+                "path": "::setup::departments status 200",
+                "id": "d09fa4300114fed036f335660dddb271",
+                "passes": 3,
+                "fails": 0,
+                "name": "departments status 200"
+              },
+              {
+                "name": "grades status 200",
+                "path": "::setup::grades status 200",
+                "id": "af14747f4b0f176b2dce752b98debdff",
+                "passes": 3,
+                "fails": 0
+              },
+              {
+                "id": "c9fb74e122c66285735a0d5bc17e206c",
+                "passes": 3,
+                "fails": 0,
+                "name": "subject search status 200",
+                "path": "::setup::subject search status 200"
+              },
+              {
+                "fails": 0,
+                "name": "professor search status 200",
+                "path": "::setup::professor search status 200",
+                "id": "7ac220a4b0d54400a88825fbdc772aa0",
+                "passes": 3
+              },
+              {
+                "path": "::setup::filter status 200",
+                "id": "561cb701c0228225332599949cf1547c",
+                "passes": 3,
+                "fails": 0,
+                "name": "filter status 200"
+              }
+            ],
+          "name": "setup"
+        }
+      ],
+      "checks": [
+        {
+          "name": "count status 200",
+          "path": "::count status 200",
+          "id": "75453c662b27cee5287ec70f7b17f543",
+          "passes": 24429,
+          "fails": 1
+        },
+        {
+          "path": "::subject search status 200",
+          "id": "cda8eb7d44570ff28b027dc767be03fa",
+          "passes": 24841,
+          "fails": 4,
+          "name": "subject search status 200"
+        },
+        {
+          "name": "departments status 200",
+          "path": "::departments status 200",
+          "id": "13ead444a17056b03ed45fd14d7bc319",
+          "passes": 18526,
+          "fails": 2
+        },
+        {
+          "name": "professor search status 200",
+          "path": "::professor search status 200",
+          "id": "bf145fc270dae668c75958348664d49c",
+          "passes": 18660,
+          "fails": 2
+        },
+        {
+          "fails": 2,
+          "name": "grades status 200",
+          "path": "::grades status 200",
+          "id": "cb7f7749617f8998c89bab82ac6c0964",
+          "passes": 18435
+        },
+        {
+          "id": "1b7b8b705cd437af404ac62612c991d6",
+          "passes": 18333,
+          "fails": 3,
+          "name": "filter status 200",
+          "path": "::filter status 200"
+        }
+      ],
+      "name": "",
+      "path": "",
+      "id": "d41d8cd98f00b204e9800998ecf8427e"
+    }
+  }
+}

--- a/reports/performance/2026-07-27-redis-shared-cache/README.md
+++ b/reports/performance/2026-07-27-redis-shared-cache/README.md
@@ -1,0 +1,245 @@
+# Redis 공유 캐시 도입 검증
+
+측정일: 2026-07-27~28 (KST)
+
+## 결론
+
+운영 후보는 Redis 단독 캐시가 아니라 `Caffeine L1 + Redis L2` 두 단계
+캐시로 결정했다. 뜨거운 조회는 인스턴스 메모리에서 처리하고, 새 Cloud Run
+인스턴스나 L1 miss만 Memorystore Redis를 조회한다.
+
+같은 1,000 VU/최대 3대 시나리오에서 최종 후보는 123,256건을 처리했다.
+현재 Caffeine 기준선과 비교하면 처리량은 2.3% 낮고 평균은 4.1% 높지만,
+p95는 2.1%, p99는 1.4% 낮았다. 서버 5xx, Redis 오류, 애플리케이션
+WARNING/ERROR는 모두 0이었다. 성능을 크게 높인 변경은 아니지만 현재
+처리 성능을 거의 유지하면서 다음 운영 안전장치를 추가했다.
+
+- 여러 인스턴스와 신규 인스턴스가 같은 L2 캐시를 재사용한다.
+- Redis 장애 시 5초 동안 Redis를 우회하고 PostgreSQL + Caffeine L1으로
+  계속 응답한다.
+- Redis 복구 전 공유 캐시를 비워 장애 중 오래된 값이 되살아나지 않게 한다.
+- Redis 직렬화 타입을 애플리케이션 DTO와 제한된 JDK 패키지로 제한한다.
+- 비밀번호는 Secret Manager에 두고 Cloud Run은 Direct VPC의 사설 IP로
+  Redis에 접근한다.
+- 캐시 전체 무효화는 `KEYS` 대신 `SCAN` batch를 사용한다.
+
+다만 이번 단계는 DB 버전 폴링을 제거하지 않는다. Caffeine L1의
+인스턴스 간 일관성을 유지하려면 현재 `shared_cache_versions` 브릿지가
+계속 필요하다. 이후 Redis Pub/Sub 기반 L1 무효화를 추가하고 혼합
+리비전이 모두 빠진 뒤에만 DB 폴링을 끌 수 있다.
+
+## 최종 구조
+
+```text
+요청
+  |
+  v
+Cloud Run 인스턴스별 Caffeine L1 (10분 TTL, 최대 1,000키)
+  | L1 miss
+  v
+Memorystore Redis L2 (공유, 10분 TTL)
+  | L2 miss 또는 Redis 장애
+  v
+PostgreSQL
+```
+
+쓰기 때문에 과목 캐시 버전이 바뀌면 기존 DB 버전 브릿지가 각 인스턴스의
+L1과 Redis L2를 함께 비운다. 따라서 구 Caffeine 리비전과 새 two-level
+리비전이 배포 중 함께 떠 있어도 동일한 무효화 계약을 사용한다.
+
+## 인프라
+
+| 항목 | 값 |
+| --- | --- |
+| GCP 프로젝트 | `project-53f7b99e-c306-49a7-a7b` |
+| 리전 | `asia-northeast3` |
+| Memorystore 인스턴스 | `inu-timetable-redis` |
+| Redis | 7.2, Basic 1 GiB, `allkeys-lru` |
+| 인증 | Redis AUTH 사용, 비밀번호는 Secret Manager |
+| 네트워크 | Cloud Run Direct VPC, `default/default`, private ranges only |
+| Redis endpoint | 사설 IP, 6379 |
+| 벤치 Cloud Run | 1 vCPU, 1 GiB, concurrency 40, 최대 3대 |
+| DB 풀 | 인스턴스당 maximum 10, minimum idle 2 |
+| 운영 서비스 영향 | 벤치 중 운영 서비스 트래픽/리비전 변경 없음 |
+
+Basic tier를 고른 이유는 과목 캐시가 PostgreSQL에서 완전히 재생성 가능하고,
+Redis 전체 손실 때도 fail-open으로 서비스할 수 있기 때문이다. 자동
+failover가 필요한 세션/원장 데이터는 이 Redis에 넣지 않는다.
+
+TLS는 이번 단계에서 사용하지 않는다. Redis는 외부 IP가 없고 Direct
+VPC 사설 경로와 AUTH를 사용한다. 향후 보안 요구가 올라가면 in-transit
+encryption을 별도 롤아웃한다.
+
+## 구현 범위
+
+### 두 단계 캐시
+
+- 기본/로컬 개발: 기존 Caffeine
+- 운영: Caffeine L1 + Redis L2
+- 비교 실험용: Redis L2-only
+- 캐시 대상: count, departments, grades, 과목명 검색, 교수 검색, 필터
+- TTL: L1/L2 모두 10분
+- Redis writer: non-locking
+- 전체 삭제: `SCAN 1,000`
+
+Redis locking writer는 hit에도 `EXISTS`를 추가해 왕복을 늘렸다. 이 데이터는
+DB에서 안전하게 다시 계산할 수 있으므로 rare miss의 중복 계산보다 모든
+hit의 추가 왕복 비용이 더 크다고 판단해 non-locking writer를 사용했다.
+
+### 장애 격리
+
+첫 Redis 예외가 발생하면 해당 인스턴스는 degraded 상태가 된다. 이후
+5초 동안 Redis를 호출하지 않고 loader를 실행한다. 재시도 시 Redis의
+모든 과목 캐시 namespace를 한 번 비운 뒤 정상 상태로 복귀한다.
+
+같은 최종 이미지의 비트래픽 Cloud Run 리비전에서 Redis port를 의도적으로
+6379가 아닌 6390으로 설정해 장애를 주입했다. Redis health contributor는
+이 실험에서만 꺼서 리비전을 기동하고 API fallback 자체를 확인했다.
+
+- 첫 count L1/L2 miss: HTTP 200, 6.06초 (Redis 연결 timeout 후 DB fallback)
+- departments/filter: 모두 HTTP 200
+- 이후 count L1 hit 3회: 72~79ms
+- `subject_cache_redis_failures_total`: 증가 확인
+- 각 캐시의 `result="bypass"`: 증가 확인
+
+즉 Redis 단절은 첫 miss의 지연을 늘리지만 API 기능 장애로 전파되지 않고,
+한번 적재된 값은 Caffeine L1에서 계속 응답했다.
+
+관측 지표:
+
+- `subject_cache_l1_requests_total{cache,result}`
+- `subject_cache_requests_total{cache,result}` (Redis L2)
+- `subject_cache_redis_failures_total`
+- `subject_cache_redis_recoveries_total`
+
+### 배포 안전장치
+
+GitHub Actions 후보 검증에 다음을 추가했다.
+
+- provider/boolean/Redis endpoint 설정 검증
+- Direct VPC network/subnet/egress 적용
+- `REDIS_PASSWORD` Secret 주입
+- health와 주요 과목 API 반복 호출
+- L2 메트릭 존재 확인
+- two-level이면 L1 메트릭 존재도 확인
+
+운영 설정은 DB 버전 poll/publish를 모두 `true`로 둔다. 이는 과거 리비전과
+혼재하는 배포 구간뿐 아니라 현재 Caffeine L1의 인스턴스 간 일관성에도
+필요하다.
+
+## 부하 시나리오
+
+기준선과 같은 k6 `portfolio` 프로필을 사용했다.
+
+1. 20초 동안 최대 VU의 15%까지 상승
+2. 60초 동안 50%까지 상승
+3. 60초 동안 50% 유지
+4. 20초 동안 100%까지 상승
+5. 40초 동안 100% 유지
+6. 20초 동안 0으로 하강
+
+요청은 읽기 전용 과목 API만 사용했다. 벤치 서비스는 IAM 인증이 필요한
+비공개 Cloud Run 서비스이며 운영과 같은 DB를 사용하므로 쓰기는 하지
+않았다.
+
+## 결과
+
+| 후보 | 실제 인스턴스 | 요청 수 | 실패 | 실패율 | 평균 | p95 | p99 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| 기존 Caffeine 기준선 | 3 | 126,106 | 8 | 0.0063% | 474.48ms | 1,962.62ms | 6,560.44ms |
+| Redis L2-only, locking | 3 | 116,059 | 15 | 0.0129% | 554.21ms | 2,064.01ms | 6,540.04ms |
+| Redis L2-only, non-locking | 3 | 118,201 | 12 | 0.0102% | 533.88ms | 1,979.13ms | 6,875.00ms |
+| **Caffeine L1 + Redis L2** | **3** | **123,256** | **14** | **0.0114%** | **493.82ms** | **1,922.09ms** | **6,465.63ms** |
+
+최종 후보와 기존 기준선의 차이:
+
+- 요청 수: 126,106 -> 123,256, **2.3% 감소**
+- 평균: 474.48ms -> 493.82ms, **4.1% 증가**
+- p95: 1,962.62ms -> 1,922.09ms, **2.1% 감소**
+- p99: 6,560.44ms -> 6,465.63ms, **1.4% 감소**
+
+Redis L2-only non-locking 후보와 비교하면 최종 후보는 요청 수가 4.3%
+늘었고 평균은 7.5%, p95는 2.9%, p99는 6.0% 낮았다. 모든 요청을
+네트워크 Redis에 보내는 설계가 현재 서비스에는 적합하지 않다는 것을
+실측으로 확인한 결과다.
+
+k6의 14건 실패는 1,000 VU 정점과 하강 구간의 HTTP/2 connection EOF,
+client connection 수립 실패, 60초 request timeout이었다. 같은 측정
+구간 Cloud Run request log의 서버 5xx는 0건이고 애플리케이션
+WARNING/ERROR도 0건이었다. k6 exit code 99는 기능 실패가 아니라 기존
+성능 임계값 `p95 < 500ms`, `p99 < 1,000ms` 초과 때문이다.
+
+## Redis 사용량
+
+최종 후보는 부하 중 실제 Cloud Run 인스턴스 3개로 확장했다. 측정 후
+한 인스턴스에서 본 누적 표본은 다음과 같다.
+
+| 계층 | 접근 수 |
+| --- | ---: |
+| Caffeine L1 | 26,483 |
+| Redis L2 | 129 |
+| Redis fallback 오류 | 0 |
+
+즉 이 표본에서는 L1 miss만 Redis로 내려가 Redis 접근이 L1 접근의 약
+0.49%였다. Memorystore의 분당 명령 지표에서도 부하 중 `GET`은
+32 -> 110 -> 176회로, 전체 HTTP 요청에 비해 매우 작았다.
+
+관측된 Redis 자원 최대치는 다음과 같다.
+
+- 연결 수: 14
+- 메모리 사용률: 0.54% 미만
+- main thread CPU: 관측된 1분 구간의 user+system 합 최대 약
+  0.20 CPU-second
+- Redis cache fallback: 0
+
+Redis가 병목이라는 증거는 없었다. 주요 tail latency는 기준선과 마찬가지로
+Cloud Run 확장/기동과 검색·필터 응답 경로의 영향을 더 크게 받는다.
+
+## 판정
+
+기준 보고서의 공격적인 목표인 요청 수 +20%, p95 -30%에는 도달하지
+못했다. 따라서 “Redis를 붙여 성능이 크게 향상됐다”고 주장하면 안 된다.
+
+이번 변경의 합격 근거는 다음처럼 제한한다.
+
+1. 현 처리량과 지연이 기준선과 대체로 동급이다.
+2. 3개 인스턴스에서 공유 L2가 실제 사용된다.
+3. Redis 장애가 요청 실패로 전파되지 않도록 fail-open 경로와 테스트가 있다.
+4. 후보에서 Redis 오류, 서버 5xx, 애플리케이션 오류가 0이다.
+5. 기존 DB 버전 브릿지를 유지해 혼합 리비전과 L1 일관성을 보존한다.
+
+다음 성능 개선은 Redis 자체보다 25초 수준의 Spring Boot 콜드 스타트,
+과목 검색/필터 쿼리, 캐시 무효화 범위 축소를 대상으로 하는 편이
+실측 근거에 맞다.
+
+## 후속 단계
+
+1. Redis Pub/Sub 채널로 과목 cache namespace/version 이벤트 발행
+2. 각 인스턴스가 이벤트를 받아 L1만 즉시 무효화
+3. 구 리비전이 모두 drain된 것을 확인
+4. DB version poll을 먼저 끄고 publish를 마지막에 끄는 단계 배포
+5. 이벤트 유실 복구를 위해 낮은 빈도의 DB reconciliation 또는 versioned
+   Redis key를 유지
+
+Pub/Sub 없이 poll을 끄면 인스턴스별 L1이 TTL 동안 서로 다른 값을
+제공할 수 있으므로 이번 PR에서는 하지 않는다.
+
+## 재현
+
+```bash
+ID_TOKEN="$(gcloud auth print-identity-token)" \
+BASE_URL="https://<private-benchmark-cloud-run-url>" \
+BENCHMARK_NAME="two-level-caffeine-redis-max3-1000vus" \
+RESULT_FILE="03-two-level-caffeine-redis-max3-1000vus.json" \
+PROFILE="portfolio" \
+PEAK_VUS="1000" \
+WARMUP="true" \
+k6 run scripts/k6/subject-read-benchmark.js
+```
+
+원본 결과:
+
+- `00-smoke-10vus.json`
+- `01-redis-shared-cache-max3-1000vus.json`
+- `02-redis-shared-cache-nonlocking-max3-1000vus.json`
+- `03-two-level-caffeine-redis-max3-1000vus.json`

--- a/src/main/java/inu/timetable/config/CacheConfig.java
+++ b/src/main/java/inu/timetable/config/CacheConfig.java
@@ -1,25 +1,48 @@
 package inu.timetable.config;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import inu.timetable.service.SubjectCacheNames;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.convert.DurationStyle;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.data.redis.cache.BatchStrategies;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.cache.RedisCacheWriter;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 import java.time.Duration;
+import java.util.Set;
 
 @Configuration
 @EnableCaching
 public class CacheConfig {
 
     @Bean
-    public CacheManager cacheManager(
+    @ConditionalOnProperty(name = "subject.cache.provider", havingValue = "caffeine", matchIfMissing = true)
+    public CacheManager caffeineCacheManager(
             @Value("${subject.cache.maximum-size:1000}") long maximumSize,
             @Value("${subject.cache.expire-after-write:10m}") String expireAfterWrite) {
+        return createCaffeineCacheManager(maximumSize, expireAfterWrite);
+    }
+
+    private CaffeineCacheManager createCaffeineCacheManager(
+            long maximumSize,
+            String expireAfterWrite) {
         CaffeineCacheManager cacheManager = new CaffeineCacheManager(SubjectCacheNames.ALL.toArray(String[]::new));
         cacheManager.setCaffeine(Caffeine.newBuilder()
                 .maximumSize(maximumSize)
@@ -28,7 +51,104 @@ public class CacheConfig {
         return cacheManager;
     }
 
+    @Bean
+    @ConditionalOnExpression(
+            "'${subject.cache.provider:caffeine}' == 'redis' or "
+                    + "'${subject.cache.provider:caffeine}' == 'two-level'")
+    public RedisSerializer<Object> subjectCacheValueSerializer(ObjectMapper objectMapper) {
+        ObjectMapper cacheObjectMapper = objectMapper.copy();
+        cacheObjectMapper.activateDefaultTyping(
+                BasicPolymorphicTypeValidator.builder()
+                        .allowIfSubType("inu.timetable.")
+                        .allowIfSubType("java.lang.")
+                        .allowIfSubType("java.util.")
+                        .build(),
+                ObjectMapper.DefaultTyping.EVERYTHING,
+                JsonTypeInfo.As.PROPERTY);
+        return new GenericJackson2JsonRedisSerializer(cacheObjectMapper);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "subject.cache.provider", havingValue = "redis")
+    public CacheManager redisCacheManager(
+            RedisConnectionFactory connectionFactory,
+            RedisSerializer<Object> subjectCacheValueSerializer,
+            MeterRegistry meterRegistry,
+            @Value("${subject.cache.expire-after-write:10m}") String expireAfterWrite,
+            @Value("${subject.cache.redis.key-prefix:inu:timetable:dev}") String keyPrefix,
+            @Value("${subject.cache.redis.retry-after:5s}") String retryAfter) {
+        return createRedisCacheManager(
+                connectionFactory,
+                subjectCacheValueSerializer,
+                meterRegistry,
+                expireAfterWrite,
+                keyPrefix,
+                retryAfter);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "subject.cache.provider", havingValue = "two-level")
+    public CacheManager twoLevelCacheManager(
+            RedisConnectionFactory connectionFactory,
+            RedisSerializer<Object> subjectCacheValueSerializer,
+            MeterRegistry meterRegistry,
+            @Value("${subject.cache.maximum-size:1000}") long maximumSize,
+            @Value("${subject.cache.expire-after-write:10m}") String expireAfterWrite,
+            @Value("${subject.cache.redis.key-prefix:inu:timetable:dev}") String keyPrefix,
+            @Value("${subject.cache.redis.retry-after:5s}") String retryAfter) {
+        CaffeineCacheManager local = createCaffeineCacheManager(maximumSize, expireAfterWrite);
+        CacheManager shared = createRedisCacheManager(
+                connectionFactory,
+                subjectCacheValueSerializer,
+                meterRegistry,
+                expireAfterWrite,
+                keyPrefix,
+                retryAfter);
+        return new TwoLevelCacheManager(local, shared, meterRegistry);
+    }
+
+    private CacheManager createRedisCacheManager(
+            RedisConnectionFactory connectionFactory,
+            RedisSerializer<Object> subjectCacheValueSerializer,
+            MeterRegistry meterRegistry,
+            String expireAfterWrite,
+            String keyPrefix,
+            String retryAfter) {
+        RedisCacheConfiguration cacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(parseDuration(expireAfterWrite))
+                .disableCachingNullValues()
+                .prefixCacheNameWith(normalizePrefix(keyPrefix))
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(
+                        subjectCacheValueSerializer));
+
+        // Cache values are safely reproducible from PostgreSQL. A cache-wide Redis lock would
+        // add an EXISTS round trip to every hit; duplicate computation on a rare miss is cheaper.
+        RedisCacheWriter cacheWriter = RedisCacheWriter.nonLockingRedisCacheWriter(
+                connectionFactory,
+                BatchStrategies.scan(1_000));
+        RedisCacheManager delegate = RedisCacheManager.builder(cacheWriter)
+                .cacheDefaults(cacheConfiguration)
+                .initialCacheNames(Set.copyOf(SubjectCacheNames.ALL))
+                .disableCreateOnMissingCache()
+                .enableStatistics()
+                .build();
+        // The delegate is wrapped below, so it is not a Spring bean and must be initialized here.
+        delegate.afterPropertiesSet();
+
+        return new ResilientRedisCacheManager(
+                delegate,
+                parseDuration(retryAfter),
+                meterRegistry);
+    }
+
     private Duration parseDuration(String value) {
         return DurationStyle.detectAndParse(value);
+    }
+
+    private String normalizePrefix(String prefix) {
+        String normalized = prefix == null ? "" : prefix.trim();
+        return normalized.endsWith(":") ? normalized : normalized + ":";
     }
 }

--- a/src/main/java/inu/timetable/config/ResilientRedisCacheManager.java
+++ b/src/main/java/inu/timetable/config/ResilientRedisCacheManager.java
@@ -1,0 +1,308 @@
+package inu.timetable.config;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.LongSupplier;
+
+/**
+ * Keeps read APIs available when Redis is temporarily unreachable.
+ *
+ * <p>While degraded, cache reads become misses and writes are skipped. Before Redis is used
+ * again, every subject cache is cleared once so values that became stale during the outage
+ * cannot be served after recovery.</p>
+ */
+@Slf4j
+public final class ResilientRedisCacheManager implements CacheManager {
+
+    private final CacheManager delegate;
+    private final MeterRegistry meterRegistry;
+    private final long retryAfterNanos;
+    private final LongSupplier nanoTime;
+    private final Counter failureCounter;
+    private final Counter recoveryCounter;
+    private final Map<String, Cache> caches = new ConcurrentHashMap<>();
+    private final AtomicBoolean degraded = new AtomicBoolean();
+    private final AtomicBoolean recoveryInProgress = new AtomicBoolean();
+
+    private volatile long retryAtNanos;
+
+    public ResilientRedisCacheManager(
+            CacheManager delegate,
+            Duration retryAfter,
+            MeterRegistry meterRegistry) {
+        this(delegate, retryAfter, meterRegistry, System::nanoTime);
+    }
+
+    ResilientRedisCacheManager(
+            CacheManager delegate,
+            Duration retryAfter,
+            MeterRegistry meterRegistry,
+            LongSupplier nanoTime) {
+        this.delegate = delegate;
+        this.meterRegistry = meterRegistry;
+        this.retryAfterNanos = Math.max(0, retryAfter.toNanos());
+        this.nanoTime = nanoTime;
+        this.failureCounter = Counter.builder("subject.cache.redis.failures")
+                .description("Redis cache operations that failed and fell back to the database")
+                .register(meterRegistry);
+        this.recoveryCounter = Counter.builder("subject.cache.redis.recoveries")
+                .description("Redis cache recoveries completed after flushing stale values")
+                .register(meterRegistry);
+    }
+
+    @Override
+    public Cache getCache(String name) {
+        Cache target = delegate.getCache(name);
+        if (target == null) {
+            return null;
+        }
+        return caches.computeIfAbsent(name, ignored -> new ResilientRedisCache(
+                target,
+                Counter.builder("subject.cache.requests")
+                        .tag("cache", name)
+                        .tag("result", "hit")
+                        .register(meterRegistry),
+                Counter.builder("subject.cache.requests")
+                        .tag("cache", name)
+                        .tag("result", "miss")
+                        .register(meterRegistry),
+                Counter.builder("subject.cache.requests")
+                        .tag("cache", name)
+                        .tag("result", "bypass")
+                        .register(meterRegistry)));
+    }
+
+    @Override
+    public Collection<String> getCacheNames() {
+        return delegate.getCacheNames();
+    }
+
+    private boolean redisAvailable() {
+        if (!degraded.get()) {
+            return true;
+        }
+        if (nanoTime.getAsLong() < retryAtNanos || !recoveryInProgress.compareAndSet(false, true)) {
+            return false;
+        }
+        try {
+            for (String cacheName : delegate.getCacheNames()) {
+                Cache cache = delegate.getCache(cacheName);
+                if (cache != null) {
+                    cache.clear();
+                }
+            }
+            degraded.set(false);
+            retryAtNanos = 0;
+            recoveryCounter.increment();
+            log.info("Redis subject cache recovered after clearing stale values");
+            return true;
+        } catch (RuntimeException exception) {
+            markFailure(exception);
+            return false;
+        } finally {
+            recoveryInProgress.set(false);
+        }
+    }
+
+    private void markFailure(RuntimeException exception) {
+        failureCounter.increment();
+        retryAtNanos = nanoTime.getAsLong() + retryAfterNanos;
+        if (degraded.compareAndSet(false, true)) {
+            log.warn(
+                    "Redis subject cache unavailable; using database fallback for {} ms: {}",
+                    Duration.ofNanos(retryAfterNanos).toMillis(),
+                    exception.getMessage());
+        }
+    }
+
+    private final class ResilientRedisCache implements Cache {
+
+        private final Cache target;
+        private final Counter hitCounter;
+        private final Counter missCounter;
+        private final Counter bypassCounter;
+
+        private ResilientRedisCache(
+                Cache target,
+                Counter hitCounter,
+                Counter missCounter,
+                Counter bypassCounter) {
+            this.target = target;
+            this.hitCounter = hitCounter;
+            this.missCounter = missCounter;
+            this.bypassCounter = bypassCounter;
+        }
+
+        @Override
+        public String getName() {
+            return target.getName();
+        }
+
+        @Override
+        public Object getNativeCache() {
+            return target.getNativeCache();
+        }
+
+        @Override
+        public ValueWrapper get(Object key) {
+            if (!redisAvailable()) {
+                bypassCounter.increment();
+                return null;
+            }
+            try {
+                ValueWrapper value = target.get(key);
+                counterFor(value != null).increment();
+                return value;
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+                bypassCounter.increment();
+                return null;
+            }
+        }
+
+        @Override
+        public <T> T get(Object key, Class<T> type) {
+            if (!redisAvailable()) {
+                bypassCounter.increment();
+                return null;
+            }
+            try {
+                T value = target.get(key, type);
+                counterFor(value != null).increment();
+                return value;
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+                bypassCounter.increment();
+                return null;
+            }
+        }
+
+        @Override
+        public <T> T get(Object key, Callable<T> valueLoader) {
+            if (!redisAvailable()) {
+                bypassCounter.increment();
+                return callLoader(key, valueLoader);
+            }
+
+            AtomicBoolean loaded = new AtomicBoolean();
+            AtomicReference<T> loadedValue = new AtomicReference<>();
+            try {
+                T value = target.get(key, () -> {
+                    T result = valueLoader.call();
+                    loadedValue.set(result);
+                    loaded.set(true);
+                    return result;
+                });
+                counterFor(!loaded.get()).increment();
+                return value;
+            } catch (ValueRetrievalException exception) {
+                throw exception;
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+                bypassCounter.increment();
+                if (loaded.get()) {
+                    return loadedValue.get();
+                }
+                return callLoader(key, valueLoader);
+            }
+        }
+
+        @Override
+        public void put(Object key, Object value) {
+            if (!redisAvailable()) {
+                return;
+            }
+            try {
+                target.put(key, value);
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+            }
+        }
+
+        @Override
+        public ValueWrapper putIfAbsent(Object key, Object value) {
+            if (!redisAvailable()) {
+                return null;
+            }
+            try {
+                return target.putIfAbsent(key, value);
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+                return null;
+            }
+        }
+
+        @Override
+        public void evict(Object key) {
+            if (!redisAvailable()) {
+                return;
+            }
+            try {
+                target.evict(key);
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+            }
+        }
+
+        @Override
+        public boolean evictIfPresent(Object key) {
+            if (!redisAvailable()) {
+                return false;
+            }
+            try {
+                return target.evictIfPresent(key);
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+                return false;
+            }
+        }
+
+        @Override
+        public void clear() {
+            if (!redisAvailable()) {
+                return;
+            }
+            try {
+                target.clear();
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+            }
+        }
+
+        @Override
+        public boolean invalidate() {
+            if (!redisAvailable()) {
+                return false;
+            }
+            try {
+                return target.invalidate();
+            } catch (RuntimeException exception) {
+                markFailure(exception);
+                return false;
+            }
+        }
+
+        private Counter counterFor(boolean hit) {
+            return hit ? hitCounter : missCounter;
+        }
+
+        private <T> T callLoader(Object key, Callable<T> valueLoader) {
+            try {
+                return valueLoader.call();
+            } catch (Exception exception) {
+                throw new ValueRetrievalException(key, valueLoader, exception);
+            }
+        }
+    }
+}

--- a/src/main/java/inu/timetable/config/TwoLevelCacheManager.java
+++ b/src/main/java/inu/timetable/config/TwoLevelCacheManager.java
@@ -1,0 +1,176 @@
+package inu.timetable.config;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Combines a per-instance Caffeine L1 with a shared, resilient Redis L2.
+ *
+ * <p>Hot reads remain in-process. New Cloud Run instances can reuse values already loaded by
+ * another instance, while a Redis outage still falls through to PostgreSQL and keeps L1 useful.</p>
+ */
+public final class TwoLevelCacheManager implements CacheManager {
+
+    private final CacheManager local;
+    private final CacheManager shared;
+    private final MeterRegistry meterRegistry;
+    private final Map<String, Cache> caches = new ConcurrentHashMap<>();
+
+    public TwoLevelCacheManager(
+            CacheManager local,
+            CacheManager shared,
+            MeterRegistry meterRegistry) {
+        this.local = local;
+        this.shared = shared;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public Cache getCache(String name) {
+        Cache localCache = local.getCache(name);
+        Cache sharedCache = shared.getCache(name);
+        if (localCache == null || sharedCache == null) {
+            return null;
+        }
+        return caches.computeIfAbsent(name, ignored -> new TwoLevelCache(
+                localCache,
+                sharedCache,
+                Counter.builder("subject.cache.l1.requests")
+                        .tag("cache", name)
+                        .tag("result", "hit")
+                        .register(meterRegistry),
+                Counter.builder("subject.cache.l1.requests")
+                        .tag("cache", name)
+                        .tag("result", "miss")
+                        .register(meterRegistry)));
+    }
+
+    @Override
+    public Collection<String> getCacheNames() {
+        return local.getCacheNames();
+    }
+
+    private static final class TwoLevelCache implements Cache {
+
+        private final Cache local;
+        private final Cache shared;
+        private final Counter localHitCounter;
+        private final Counter localMissCounter;
+
+        private TwoLevelCache(
+                Cache local,
+                Cache shared,
+                Counter localHitCounter,
+                Counter localMissCounter) {
+            this.local = local;
+            this.shared = shared;
+            this.localHitCounter = localHitCounter;
+            this.localMissCounter = localMissCounter;
+        }
+
+        @Override
+        public String getName() {
+            return local.getName();
+        }
+
+        @Override
+        public Object getNativeCache() {
+            return local.getNativeCache();
+        }
+
+        @Override
+        public ValueWrapper get(Object key) {
+            ValueWrapper localValue = local.get(key);
+            if (localValue != null) {
+                localHitCounter.increment();
+                return localValue;
+            }
+            localMissCounter.increment();
+            ValueWrapper sharedValue = shared.get(key);
+            if (sharedValue != null) {
+                local.put(key, sharedValue.get());
+            }
+            return sharedValue;
+        }
+
+        @Override
+        public <T> T get(Object key, Class<T> type) {
+            T localValue = local.get(key, type);
+            if (localValue != null) {
+                localHitCounter.increment();
+                return localValue;
+            }
+            localMissCounter.increment();
+            T sharedValue = shared.get(key, type);
+            if (sharedValue != null) {
+                local.put(key, sharedValue);
+            }
+            return sharedValue;
+        }
+
+        @Override
+        public <T> T get(Object key, Callable<T> valueLoader) {
+            AtomicBoolean localMiss = new AtomicBoolean();
+            T value = local.get(key, () -> {
+                localMiss.set(true);
+                return shared.get(key, valueLoader);
+            });
+            if (localMiss.get()) {
+                localMissCounter.increment();
+            } else {
+                localHitCounter.increment();
+            }
+            return value;
+        }
+
+        @Override
+        public void put(Object key, Object value) {
+            shared.put(key, value);
+            local.put(key, value);
+        }
+
+        @Override
+        public ValueWrapper putIfAbsent(Object key, Object value) {
+            ValueWrapper existing = get(key);
+            if (existing != null) {
+                return existing;
+            }
+            put(key, value);
+            return null;
+        }
+
+        @Override
+        public void evict(Object key) {
+            shared.evict(key);
+            local.evict(key);
+        }
+
+        @Override
+        public boolean evictIfPresent(Object key) {
+            boolean sharedEvicted = shared.evictIfPresent(key);
+            boolean localEvicted = local.evictIfPresent(key);
+            return sharedEvicted || localEvicted;
+        }
+
+        @Override
+        public void clear() {
+            shared.clear();
+            local.clear();
+        }
+
+        @Override
+        public boolean invalidate() {
+            boolean sharedInvalidated = shared.invalidate();
+            boolean localInvalidated = local.invalidate();
+            return sharedInvalidated || localInvalidated;
+        }
+    }
+}

--- a/src/main/java/inu/timetable/dto/SubjectPageCacheValue.java
+++ b/src/main/java/inu/timetable/dto/SubjectPageCacheValue.java
@@ -1,0 +1,32 @@
+package inu.timetable.dto;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Redis-safe representation of a subject page.
+ *
+ * <p>Spring Data's {@code PageImpl} is an API model rather than a stable serialization
+ * contract, so only the values needed to reconstruct it are cached.</p>
+ */
+public record SubjectPageCacheValue(
+        List<SubjectDto> content,
+        int page,
+        int size,
+        long totalElements) {
+
+    public SubjectPageCacheValue {
+        content = new ArrayList<>(content);
+    }
+
+    public Page<SubjectDto> toPage() {
+        return new PageImpl<>(
+                new ArrayList<>(content),
+                PageRequest.of(page, size),
+                totalElements);
+    }
+}

--- a/src/main/java/inu/timetable/service/SharedSubjectCacheInvalidationService.java
+++ b/src/main/java/inu/timetable/service/SharedSubjectCacheInvalidationService.java
@@ -2,8 +2,8 @@ package inu.timetable.service;
 
 import inu.timetable.event.SubjectDataChangedEvent;
 import inu.timetable.event.SubjectPopularityChangedEvent;
-import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.Cache;
 import org.springframework.cache.CacheManager;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -16,7 +16,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
 @Service
-@RequiredArgsConstructor
 @Slf4j
 public class SharedSubjectCacheInvalidationService {
 
@@ -25,7 +24,20 @@ public class SharedSubjectCacheInvalidationService {
 
     private final JdbcTemplate jdbcTemplate;
     private final CacheManager cacheManager;
+    private final boolean pollEnabled;
+    private final boolean publishEnabled;
     private final Map<String, Long> observedVersions = new ConcurrentHashMap<>();
+
+    public SharedSubjectCacheInvalidationService(
+            JdbcTemplate jdbcTemplate,
+            CacheManager cacheManager,
+            @Value("${subject.cache.compatibility.poll-enabled:true}") boolean pollEnabled,
+            @Value("${subject.cache.compatibility.publish-enabled:true}") boolean publishEnabled) {
+        this.jdbcTemplate = jdbcTemplate;
+        this.cacheManager = cacheManager;
+        this.pollEnabled = pollEnabled;
+        this.publishEnabled = publishEnabled;
+    }
 
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT, fallbackExecution = true)
     public void publishSubjectDataChanged(SubjectDataChangedEvent event) {
@@ -39,6 +51,9 @@ public class SharedSubjectCacheInvalidationService {
 
     @Scheduled(fixedDelayString = "${subject.cache.invalidation.poll-interval-ms:1000}")
     public void synchronizeLocalCaches() {
+        if (!pollEnabled) {
+            return;
+        }
         jdbcTemplate.query("""
                         SELECT cache_scope, version
                         FROM shared_cache_versions
@@ -58,6 +73,9 @@ public class SharedSubjectCacheInvalidationService {
     }
 
     private void incrementVersion(String scope) {
+        if (!publishEnabled) {
+            return;
+        }
         jdbcTemplate.update("""
                         UPDATE shared_cache_versions
                         SET version = version + 1,

--- a/src/main/java/inu/timetable/service/SubjectFilterCacheService.java
+++ b/src/main/java/inu/timetable/service/SubjectFilterCacheService.java
@@ -2,6 +2,7 @@ package inu.timetable.service;
 
 import inu.timetable.dto.SubjectDto;
 import inu.timetable.dto.SubjectFilterCriteria;
+import inu.timetable.dto.SubjectPageCacheValue;
 import inu.timetable.entity.Subject;
 import inu.timetable.enums.ClassMethod;
 import inu.timetable.repository.SubjectRepository;
@@ -9,7 +10,6 @@ import inu.timetable.repository.UserTimetableRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -37,7 +37,7 @@ public class SubjectFilterCacheService {
             key = "#criteria",
             condition = "#criteria.size() <= " + MAX_CACHEABLE_PAGE_SIZE,
             sync = true)
-    public Page<SubjectDto> filterSubjects(SubjectFilterCriteria criteria) {
+    public SubjectPageCacheValue filterSubjects(SubjectFilterCriteria criteria) {
         Pageable pageable = PageRequest.of(criteria.page(), criteria.size());
         List<String> departments = criteria.departments();
         List<String> departmentListParam = departments.isEmpty()
@@ -78,7 +78,11 @@ public class SubjectFilterCacheService {
 
         List<Long> subjectIds = subjectIdPage.getContent();
         if (subjectIds.isEmpty()) {
-            return new PageImpl<>(List.of(), pageable, subjectIdPage.getTotalElements());
+            return new SubjectPageCacheValue(
+                    List.of(),
+                    criteria.page(),
+                    criteria.size(),
+                    subjectIdPage.getTotalElements());
         }
 
         List<Subject> subjects = new ArrayList<>(subjectRepository.findWithSchedulesByIds(subjectIds));
@@ -95,7 +99,11 @@ public class SubjectFilterCacheService {
 
         List<SubjectDto> subjectDtos = subjects.stream()
                 .map(subject -> SubjectDto.from(subject, timetableAddCounts.getOrDefault(subject.getId(), 0L)))
-                .toList();
-        return new PageImpl<>(subjectDtos, pageable, subjectIdPage.getTotalElements());
+                .collect(Collectors.toCollection(ArrayList::new));
+        return new SubjectPageCacheValue(
+                subjectDtos,
+                criteria.page(),
+                criteria.size(),
+                subjectIdPage.getTotalElements());
     }
 }

--- a/src/main/java/inu/timetable/service/SubjectQueryService.java
+++ b/src/main/java/inu/timetable/service/SubjectQueryService.java
@@ -55,6 +55,6 @@ public class SubjectQueryService {
     }
 
     public Page<SubjectDto> filterSubjects(SubjectFilterCriteria criteria) {
-        return subjectFilterCacheService.filterSubjects(criteria);
+        return subjectFilterCacheService.filterSubjects(criteria).toPage();
     }
 }

--- a/src/main/java/inu/timetable/service/SubjectSearchCacheService.java
+++ b/src/main/java/inu/timetable/service/SubjectSearchCacheService.java
@@ -9,7 +9,9 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -29,7 +31,7 @@ public class SubjectSearchCacheService {
                 : subjectRepository.findBySubjectNameContainingAndGradeAndActiveTrue(criteria.keyword(), criteria.grade());
         return subjects.stream()
                 .map(SubjectDto::from)
-                .toList();
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 
     @Cacheable(
@@ -43,6 +45,6 @@ public class SubjectSearchCacheService {
                 : subjectRepository.findByProfessorContainingAndGradeAndActiveTrue(criteria.keyword(), criteria.grade());
         return subjects.stream()
                 .map(SubjectDto::from)
-                .toList();
+                .collect(Collectors.toCollection(ArrayList::new));
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -22,6 +22,10 @@ management:
     health:
       show-details: always
       show-components: always
+  health:
+    # Local development uses Caffeine and does not require a local Redis process.
+    redis:
+      enabled: false
 
 logging:
   level:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -23,6 +23,10 @@ management:
     health:
       show-details: never
       show-components: never
+  health:
+    # Enabled only in revisions that explicitly select the Redis cache provider.
+    redis:
+      enabled: ${REDIS_HEALTH_ENABLED:false}
   # /actuator/info 가 환경변수/프로퍼티를 노출하지 않도록 비활성화.
   info:
     env:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,9 @@
 spring:
   application:
     name: timeTable
+  autoconfigure:
+    # Redis backs Spring Cache only; no Redis entity repositories exist.
+    exclude: org.springframework.boot.autoconfigure.data.redis.RedisRepositoriesAutoConfiguration
   profiles:
     # 배포 스크립트(deploy-blue-green.sh)와 동일한 표준 변수명으로 통일.
     # 운영 배포 시 SPRING_PROFILES_ACTIVE=prod 가 주입되며, 미설정 시 로컬 개발용 dev 로 동작한다.
@@ -34,6 +37,15 @@ spring:
     enabled: true
     baseline-on-migrate: true
     locations: classpath:db/migration
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+      connect-timeout: ${REDIS_CONNECT_TIMEOUT:2s}
+      timeout: ${REDIS_COMMAND_TIMEOUT:2s}
+      repositories:
+        enabled: false
 
 server:
   servlet:
@@ -76,8 +88,19 @@ user:
 
 subject:
   cache:
+    # Local development/tests use Caffeine. Cloud Run uses Caffeine L1 + Redis L2.
+    provider: ${SUBJECT_CACHE_PROVIDER:caffeine}
     maximum-size: ${SUBJECT_CACHE_MAXIMUM_SIZE:1000}
     expire-after-write: ${SUBJECT_CACHE_EXPIRE_AFTER_WRITE:10m}
+    redis:
+      key-prefix: ${SUBJECT_CACHE_REDIS_KEY_PREFIX:inu:timetable:dev}
+      # After a Redis error, bypass it briefly, then flush stale values before reuse.
+      retry-after: ${SUBJECT_CACHE_REDIS_RETRY_AFTER:5s}
+    compatibility:
+      # Keep both true while Caffeine L1 is used. A future Redis Pub/Sub invalidation
+      # rollout may replace this DB version bridge after mixed revisions have drained.
+      poll-enabled: ${SUBJECT_CACHE_DB_VERSION_POLL_ENABLED:true}
+      publish-enabled: ${SUBJECT_CACHE_DB_VERSION_PUBLISH_ENABLED:true}
     warm-up:
       enabled: ${SUBJECT_CACHE_WARM_UP_ENABLED:true}
       concurrency: ${SUBJECT_CACHE_WARM_UP_CONCURRENCY:4}

--- a/src/test/java/inu/timetable/config/CacheConfigTest.java
+++ b/src/test/java/inu/timetable/config/CacheConfigTest.java
@@ -1,11 +1,24 @@
 package inu.timetable.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inu.timetable.dto.SubjectDto;
+import inu.timetable.dto.SubjectPageCacheValue;
+import inu.timetable.enums.ClassMethod;
+import inu.timetable.enums.SubjectType;
+import inu.timetable.service.SubjectCacheNames;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.RedisSerializer;
+
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 class CacheConfigTest {
 
@@ -20,5 +33,82 @@ class CacheConfigTest {
 
             assertThat(cacheManager).isInstanceOf(CaffeineCacheManager.class);
         });
+    }
+
+    @Test
+    void buildsResilientRedisCacheManagerWhenSelected() {
+        contextRunner
+                .withPropertyValues(
+                        "subject.cache.provider=redis",
+                        "subject.cache.redis.key-prefix=inu:timetable:test")
+                .withBean(RedisConnectionFactory.class, () -> mock(RedisConnectionFactory.class))
+                .withBean(ObjectMapper.class, ObjectMapper::new)
+                .withBean(SimpleMeterRegistry.class, SimpleMeterRegistry::new)
+                .run(context -> {
+                    CacheManager cacheManager = context.getBean(CacheManager.class);
+
+                    assertThat(cacheManager).isInstanceOf(ResilientRedisCacheManager.class);
+                    assertThat(SubjectCacheNames.ALL)
+                            .allSatisfy(name -> assertThat(cacheManager.getCache(name)).isNotNull());
+                });
+    }
+
+    @Test
+    void buildsTwoLevelCacheManagerWithEveryNamedCacheWhenSelected() {
+        contextRunner
+                .withPropertyValues(
+                        "subject.cache.provider=two-level",
+                        "subject.cache.redis.key-prefix=inu:timetable:test:two-level")
+                .withBean(RedisConnectionFactory.class, () -> mock(RedisConnectionFactory.class))
+                .withBean(ObjectMapper.class, ObjectMapper::new)
+                .withBean(SimpleMeterRegistry.class, SimpleMeterRegistry::new)
+                .run(context -> {
+                    CacheManager cacheManager = context.getBean(CacheManager.class);
+
+                    assertThat(cacheManager).isInstanceOf(TwoLevelCacheManager.class);
+                    assertThat(SubjectCacheNames.ALL)
+                            .allSatisfy(name -> assertThat(cacheManager.getCache(name)).isNotNull());
+                });
+    }
+
+    @Test
+    void redisSerializerRoundTripsEveryCachedValueShape() {
+        contextRunner
+                .withPropertyValues("subject.cache.provider=redis")
+                .withBean(RedisConnectionFactory.class, () -> mock(RedisConnectionFactory.class))
+                .withBean(ObjectMapper.class, ObjectMapper::new)
+                .withBean(SimpleMeterRegistry.class, SimpleMeterRegistry::new)
+                .run(context -> {
+                    @SuppressWarnings("unchecked")
+                    RedisSerializer<Object> serializer =
+                            (RedisSerializer<Object>) context.getBean("subjectCacheValueSerializer");
+                    SubjectDto subject = SubjectDto.builder()
+                            .id(1L)
+                            .subjectName("자료구조")
+                            .credits(3)
+                            .department("컴퓨터공학부")
+                            .grade(2)
+                            .subjectType(SubjectType.전심)
+                            .classMethod(ClassMethod.OFFLINE)
+                            .schedules(new ArrayList<>())
+                            .timetableAddCount(7L)
+                            .build();
+
+                    Object count = serializer.deserialize(serializer.serialize(2894L));
+                    Object subjects = serializer.deserialize(serializer.serialize(
+                            new ArrayList<>(List.of(subject))));
+                    Object page = serializer.deserialize(serializer.serialize(
+                            new SubjectPageCacheValue(List.of(subject), 0, 20, 1)));
+
+                    assertThat(count).isEqualTo(2894L);
+                    assertThat(subjects).isInstanceOf(ArrayList.class);
+                    assertThat((List<?>) subjects)
+                            .singleElement()
+                            .isInstanceOf(SubjectDto.class);
+                    assertThat(page).isInstanceOf(SubjectPageCacheValue.class);
+                    assertThat(((SubjectPageCacheValue) page).toPage().getContent())
+                            .extracting(SubjectDto::getSubjectName)
+                            .containsExactly("자료구조");
+                });
     }
 }

--- a/src/test/java/inu/timetable/config/ResilientRedisCacheManagerTest.java
+++ b/src/test/java/inu/timetable/config/ResilientRedisCacheManagerTest.java
@@ -1,0 +1,189 @@
+package inu.timetable.config;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.support.SimpleValueWrapper;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ResilientRedisCacheManagerTest {
+
+    @Test
+    void fallsBackToLoaderAndBypassesRedisDuringCooldown() {
+        AtomicLong nanoTime = new AtomicLong();
+        TestCache target = new TestCache();
+        target.failReads = true;
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Cache cache = manager(target, nanoTime, meterRegistry).getCache("subjectFilters");
+        AtomicInteger loads = new AtomicInteger();
+
+        assertThat(cache).isNotNull();
+        assertThat(cache.get("criteria", () -> {
+            loads.incrementAndGet();
+            return "database-value";
+        })).isEqualTo("database-value");
+        assertThat(cache.get("criteria", () -> {
+            loads.incrementAndGet();
+            return "database-value-2";
+        })).isEqualTo("database-value-2");
+
+        assertThat(loads).hasValue(2);
+        assertThat(target.readAttempts).hasValue(1);
+        assertThat(meterRegistry.counter("subject.cache.redis.failures").count()).isEqualTo(1);
+        assertThat(meterRegistry.counter(
+                "subject.cache.requests",
+                "cache", "subjectFilters",
+                "result", "bypass").count()).isEqualTo(2);
+    }
+
+    @Test
+    void flushesPotentiallyStaleValuesBeforeUsingRedisAgain() {
+        AtomicLong nanoTime = new AtomicLong();
+        TestCache target = new TestCache();
+        target.failReads = true;
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Cache cache = manager(target, nanoTime, meterRegistry).getCache("subjectFilters");
+
+        assertThat(cache).isNotNull();
+        assertThat(cache.get("criteria", () -> "database-value")).isEqualTo("database-value");
+
+        target.failReads = false;
+        target.cachedValue = "fresh-redis-value";
+        nanoTime.set(Duration.ofSeconds(6).toNanos());
+
+        assertThat(cache.get("criteria", String.class)).isNull();
+        assertThat(target.clears).hasValue(1);
+        assertThat(meterRegistry.counter("subject.cache.redis.recoveries").count()).isEqualTo(1);
+    }
+
+    @Test
+    void doesNotExecuteLoaderTwiceWhenRedisPutFailsAfterLoading() {
+        AtomicLong nanoTime = new AtomicLong();
+        TestCache target = new TestCache();
+        target.failAfterLoading = true;
+        Cache cache = manager(target, nanoTime, new SimpleMeterRegistry()).getCache("subjectFilters");
+        AtomicInteger loads = new AtomicInteger();
+
+        assertThat(cache).isNotNull();
+        String value = cache.get("criteria", () -> {
+            loads.incrementAndGet();
+            return "database-value";
+        });
+
+        assertThat(value).isEqualTo("database-value");
+        assertThat(loads).hasValue(1);
+    }
+
+    private ResilientRedisCacheManager manager(
+            TestCache target,
+            AtomicLong nanoTime,
+            SimpleMeterRegistry meterRegistry) {
+        CacheManager delegate = new CacheManager() {
+            @Override
+            public Cache getCache(String name) {
+                return target;
+            }
+
+            @Override
+            public Collection<String> getCacheNames() {
+                return List.of(target.getName());
+            }
+        };
+        return new ResilientRedisCacheManager(
+                delegate,
+                Duration.ofSeconds(5),
+                meterRegistry,
+                nanoTime::get);
+    }
+
+    private static final class TestCache implements Cache {
+
+        private final AtomicInteger readAttempts = new AtomicInteger();
+        private final AtomicInteger clears = new AtomicInteger();
+        private boolean failReads;
+        private boolean failAfterLoading;
+        private Object cachedValue;
+
+        @Override
+        public String getName() {
+            return "subjectFilters";
+        }
+
+        @Override
+        public Object getNativeCache() {
+            return this;
+        }
+
+        @Override
+        public ValueWrapper get(Object key) {
+            readAttempts.incrementAndGet();
+            failIfNeeded();
+            return cachedValue == null ? null : new SimpleValueWrapper(cachedValue);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> T get(Object key, Class<T> type) {
+            readAttempts.incrementAndGet();
+            failIfNeeded();
+            return (T) cachedValue;
+        }
+
+        @Override
+        public <T> T get(Object key, Callable<T> valueLoader) {
+            readAttempts.incrementAndGet();
+            failIfNeeded();
+            try {
+                if (cachedValue != null) {
+                    @SuppressWarnings("unchecked")
+                    T value = (T) cachedValue;
+                    return value;
+                }
+                T value = valueLoader.call();
+                if (failAfterLoading) {
+                    throw new IllegalStateException("redis put failed");
+                }
+                cachedValue = value;
+                return value;
+            } catch (Cache.ValueRetrievalException exception) {
+                throw exception;
+            } catch (Exception exception) {
+                if (exception instanceof RuntimeException runtimeException) {
+                    throw runtimeException;
+                }
+                throw new Cache.ValueRetrievalException(key, valueLoader, exception);
+            }
+        }
+
+        @Override
+        public void put(Object key, Object value) {
+            cachedValue = value;
+        }
+
+        @Override
+        public void evict(Object key) {
+            cachedValue = null;
+        }
+
+        @Override
+        public void clear() {
+            clears.incrementAndGet();
+            cachedValue = null;
+        }
+
+        private void failIfNeeded() {
+            if (failReads) {
+                throw new IllegalStateException("redis unavailable");
+            }
+        }
+    }
+}

--- a/src/test/java/inu/timetable/config/TwoLevelCacheManagerTest.java
+++ b/src/test/java/inu/timetable/config/TwoLevelCacheManagerTest.java
@@ -1,0 +1,80 @@
+package inu.timetable.config;
+
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.Test;
+import org.springframework.cache.Cache;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TwoLevelCacheManagerTest {
+
+    @Test
+    void promotesSharedValueToLocalCacheAndUsesLocalOnNextRead() {
+        ConcurrentMapCacheManager local = new ConcurrentMapCacheManager("subjects");
+        ConcurrentMapCacheManager shared = new ConcurrentMapCacheManager("subjects");
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        Cache sharedCache = shared.getCache("subjects");
+        assertThat(sharedCache).isNotNull();
+        sharedCache.put("key", "shared-value");
+        Cache cache = new TwoLevelCacheManager(local, shared, meterRegistry).getCache("subjects");
+
+        assertThat(cache).isNotNull();
+        assertThat(cache.get("key", String.class)).isEqualTo("shared-value");
+        sharedCache.put("key", "changed-after-promotion");
+        assertThat(cache.get("key", String.class)).isEqualTo("shared-value");
+
+        assertThat(meterRegistry.counter(
+                "subject.cache.l1.requests",
+                "cache", "subjects",
+                "result", "miss").count()).isEqualTo(1);
+        assertThat(meterRegistry.counter(
+                "subject.cache.l1.requests",
+                "cache", "subjects",
+                "result", "hit").count()).isEqualTo(1);
+    }
+
+    @Test
+    void loadsDatabaseOnceAndPopulatesBothLevels() {
+        ConcurrentMapCacheManager local = new ConcurrentMapCacheManager("subjects");
+        ConcurrentMapCacheManager shared = new ConcurrentMapCacheManager("subjects");
+        Cache cache = new TwoLevelCacheManager(
+                local,
+                shared,
+                new SimpleMeterRegistry()).getCache("subjects");
+        AtomicInteger loads = new AtomicInteger();
+
+        assertThat(cache).isNotNull();
+        assertThat(cache.get("key", () -> {
+            loads.incrementAndGet();
+            return "database-value";
+        })).isEqualTo("database-value");
+        assertThat(cache.get("key", () -> {
+            loads.incrementAndGet();
+            return "unexpected";
+        })).isEqualTo("database-value");
+
+        assertThat(loads).hasValue(1);
+        assertThat(shared.getCache("subjects").get("key", String.class))
+                .isEqualTo("database-value");
+    }
+
+    @Test
+    void clearInvalidatesLocalAndSharedLevels() {
+        ConcurrentMapCacheManager local = new ConcurrentMapCacheManager("subjects");
+        ConcurrentMapCacheManager shared = new ConcurrentMapCacheManager("subjects");
+        Cache cache = new TwoLevelCacheManager(
+                local,
+                shared,
+                new SimpleMeterRegistry()).getCache("subjects");
+
+        assertThat(cache).isNotNull();
+        cache.put("key", "value");
+        cache.clear();
+
+        assertThat(local.getCache("subjects").get("key")).isNull();
+        assertThat(shared.getCache("subjects").get("key")).isNull();
+    }
+}

--- a/src/test/java/inu/timetable/service/SharedSubjectCacheInvalidationServiceTest.java
+++ b/src/test/java/inu/timetable/service/SharedSubjectCacheInvalidationServiceTest.java
@@ -21,9 +21,9 @@ class SharedSubjectCacheInvalidationServiceTest {
         CaffeineCacheManager firstManager = cacheManager();
         CaffeineCacheManager secondManager = cacheManager();
         SharedSubjectCacheInvalidationService firstInstance =
-                new SharedSubjectCacheInvalidationService(jdbcTemplate, firstManager);
+                new SharedSubjectCacheInvalidationService(jdbcTemplate, firstManager, true, true);
         SharedSubjectCacheInvalidationService secondInstance =
-                new SharedSubjectCacheInvalidationService(jdbcTemplate, secondManager);
+                new SharedSubjectCacheInvalidationService(jdbcTemplate, secondManager, true, true);
 
         firstInstance.synchronizeLocalCaches();
         secondInstance.synchronizeLocalCaches();
@@ -35,6 +35,35 @@ class SharedSubjectCacheInvalidationServiceTest {
         secondInstance.synchronizeLocalCaches();
 
         assertThat(secondCache.get("criteria")).isNull();
+    }
+
+    @Test
+    void disabledCompatibilityBridgeDoesNotPollOrPublishDatabaseVersions() {
+        CaffeineCacheManager manager = cacheManager();
+        SharedSubjectCacheInvalidationService service =
+                new SharedSubjectCacheInvalidationService(jdbcTemplate, manager, false, false);
+
+        Long initialVersion = versionOf(SharedSubjectCacheInvalidationService.SCOPE_ALL);
+        Cache cache = manager.getCache(SubjectCacheNames.SUBJECT_NAME_SEARCH);
+        assertThat(cache).isNotNull();
+        cache.put("criteria", "cached-value");
+
+        service.publishSubjectDataChanged(new SubjectDataChangedEvent("test"));
+        jdbcTemplate.update(
+                "UPDATE shared_cache_versions SET version = version + 1 WHERE cache_scope = ?",
+                SharedSubjectCacheInvalidationService.SCOPE_ALL);
+        service.synchronizeLocalCaches();
+
+        assertThat(versionOf(SharedSubjectCacheInvalidationService.SCOPE_ALL))
+                .isEqualTo(initialVersion + 1);
+        assertThat(cache.get("criteria", String.class)).isEqualTo("cached-value");
+    }
+
+    private Long versionOf(String scope) {
+        return jdbcTemplate.queryForObject(
+                "SELECT version FROM shared_cache_versions WHERE cache_scope = ?",
+                Long.class,
+                scope);
     }
 
     private CaffeineCacheManager cacheManager() {


### PR DESCRIPTION
## 요약

- 과목 조회 캐시를 운영에서 Caffeine L1 + Memorystore Redis L2로 구성합니다.
- Redis 장애 시 PostgreSQL + Caffeine으로 fail-open하고, 복구 전 공유 캐시를 비웁니다.
- Redis AUTH/Secret Manager/Direct VPC 및 Cloud Run 후보 검증을 배포 workflow에 추가합니다.
- 기존 DB 버전 poll/publish 브릿지는 Caffeine L1 인스턴스 간 일관성을 위해 유지합니다.

## 검증

- `./gradlew clean test bootJar`: 191개 테스트, 실패 0, skip 2
- 최종 Cloud Run 후보 health/과목 API/반복 필터 조회: 모두 HTTP 200
- 1,000 VU, 최대 3 인스턴스: 123,256 요청, 실패율 0.0114%, 평균 493.82ms, p95 1,922.09ms, p99 6,465.63ms
- 같은 구간 서버 5xx 0, 애플리케이션 WARNING/ERROR 0, Redis fallback 0
- Redis 포트 장애 주입: 첫 miss도 HTTP 200 DB fallback, 이후 L1 hit 72~79ms

## 해석

기존 Caffeine 기준선 대비 처리량 -2.3%, 평균 +4.1%, p95 -2.1%, p99 -1.4%로 성능은 대체로 동급입니다. 큰 성능 향상으로 과장하지 않고, 공유 L2와 장애 격리 확보를 이번 단계의 가치로 판단했습니다. Redis Pub/Sub로 L1 무효화를 대체하기 전에는 DB 버전 폴링을 끄지 않습니다.

상세 수치와 원본 k6 결과는 `reports/performance/2026-07-27-redis-shared-cache/README.md`에 있습니다.