### PR TITLE
CI 테스트 캐시 provider 격리

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -93,6 +93,11 @@ jobs:
           cache: gradle
 
       - name: Run tests and build
+        env:
+          # Rollout variables are already in GITHUB_ENV, but unit tests must verify
+          # the local/default cache path without requiring a Redis connection.
+          SUBJECT_CACHE_PROVIDER: caffeine
+          REDIS_HEALTH_ENABLED: "false"
         run: ./gradlew clean test bootJar
 
       - name: Authenticate to Google Cloud


### PR DESCRIPTION
## 원인

배포 rollout 변수를 테스트 전에 `GITHUB_ENV`에 넣어 CI 테스트가 운영용 `two-level` provider로 실행됐습니다. 이 때문에 Caffeine 기본 경로 테스트 컨텍스트가 Redis bean을 요구하며 실패했습니다.

## 수정

`Run tests and build` 단계에서만 `SUBJECT_CACHE_PROVIDER=caffeine`, `REDIS_HEALTH_ENABLED=false`로 고정합니다. 실제 후보 배포 단계는 기존 rollout env의 `two-level` 설정을 그대로 사용합니다.

## 검증

- 같은 환경 변수를 지정한 `./gradlew clean test bootJar` 성공
- 191 tests, 실패 0, skip 2