### PR TITLE
fix: SPA 쿠키 CSRF 토큰 호환 처리

### DIFF
--- a/src/main/java/inu/timetable/config/SecurityConfig.java
+++ b/src/main/java/inu/timetable/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package inu.timetable.config;
 
 import inu.timetable.security.LegacySha256DelegatingPasswordEncoder;
 import inu.timetable.security.SessionMigrationBridgeFilter;
+import inu.timetable.security.SpaCsrfTokenRequestHandler;
 import inu.timetable.security.UserDetailsJpaService;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -71,6 +72,7 @@ public class SecurityConfig {
                 .securityContext(context -> context.securityContextRepository(securityContextRepository))
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRequestHandler(new SpaCsrfTokenRequestHandler())
                         .ignoringRequestMatchers(
                                 "/",
                                 "/error",

--- a/src/main/java/inu/timetable/security/SpaCsrfTokenRequestHandler.java
+++ b/src/main/java/inu/timetable/security/SpaCsrfTokenRequestHandler.java
@@ -1,0 +1,51 @@
+package inu.timetable.security;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRequestAttributeHandler;
+import org.springframework.security.web.csrf.CsrfTokenRequestHandler;
+import org.springframework.security.web.csrf.XorCsrfTokenRequestAttributeHandler;
+import org.springframework.util.StringUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.util.function.Supplier;
+
+/**
+ * Keeps Spring Security's XOR-masked response tokens while accepting the raw cookie token
+ * that browser SPAs conventionally copy into the {@code X-XSRF-TOKEN} request header.
+ *
+ * <p>The masked header form remains valid so existing clients that use the token returned by
+ * {@code /api/auth/csrf} continue to work during the transition.</p>
+ */
+public final class SpaCsrfTokenRequestHandler implements CsrfTokenRequestHandler {
+
+    private final CsrfTokenRequestHandler plain = new CsrfTokenRequestAttributeHandler();
+    private final CsrfTokenRequestHandler xor = new XorCsrfTokenRequestAttributeHandler();
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Supplier<CsrfToken> csrfToken) {
+        xor.handle(request, response, csrfToken);
+        csrfToken.get();
+    }
+
+    @Override
+    public String resolveCsrfTokenValue(HttpServletRequest request, CsrfToken csrfToken) {
+        String headerValue = request.getHeader(csrfToken.getHeaderName());
+        if (StringUtils.hasText(headerValue)
+                && constantTimeEquals(headerValue, csrfToken.getToken())) {
+            return plain.resolveCsrfTokenValue(request, csrfToken);
+        }
+        return xor.resolveCsrfTokenValue(request, csrfToken);
+    }
+
+    private boolean constantTimeEquals(String actual, String expected) {
+        return MessageDigest.isEqual(
+                actual.getBytes(StandardCharsets.UTF_8),
+                expected.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/inu/timetable/controller/UserSecurityIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/UserSecurityIntegrationTest.java
@@ -286,6 +286,43 @@ class UserSecurityIntegrationTest {
     }
 
     @Test
+    void csrfCookieTokenAllowsNextSpaMutationWithoutRefresh() throws Exception {
+        RegisteredUser registeredUser = registerAndReturnSession();
+        CsrfProof csrfProof = fetchCsrfProof(registeredUser.session());
+        String requestBody = """
+                {
+                  "userId": %d,
+                  "semester": "2026-1",
+                  "targetCredits": 18
+                }
+                """.formatted(registeredUser.userId());
+
+        mockMvc.perform(post("/api/timetable-combination/generate")
+                        .session(registeredUser.session())
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", csrfProof.token())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/timetable-combination/generate")
+                        .session(registeredUser.session())
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", csrfProof.cookie().getValue())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/timetable-combination/generate")
+                        .session(registeredUser.session())
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", "invalid-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
     void privateApiValidationReturnsStandardBadRequestResponse() throws Exception {
         RegisteredUser registeredUser = registerAndReturnSession();
         CsrfProof csrfProof = fetchCsrfProof(registeredUser.session());


### PR DESCRIPTION
## 변경 내용

- Spring Security의 XOR 마스킹 토큰 응답은 유지합니다.
- SPA가 `XSRF-TOKEN` 쿠키의 원본 값을 `X-XSRF-TOKEN` 헤더로 복사하는 요청을 허용합니다.
- 기존 `/api/auth/csrf` 응답 본문의 마스킹 토큰을 사용하는 클라이언트도 계속 허용합니다.
- 올바르지 않은 토큰은 기존과 동일하게 403으로 거절합니다.

## 원인

프론트는 첫 상태 변경 요청에서 `/api/auth/csrf` 응답 본문의 마스킹 토큰을 사용하지만, 이후 요청에서는 쿠키에 저장된 원본 토큰을 헤더로 전송합니다. Spring Security의 기본 XOR 요청 처리기는 이 원본 헤더 값을 마스킹 토큰으로 해석해 403을 반환했고, 프론트의 토큰 갱신·재시도로 최종 요청만 성공했습니다.

## 구현 방식

SPA용 CSRF 요청 처리기를 추가해 다음 두 표현을 모두 동일한 원본 CSRF 토큰과 비교합니다.

- 응답 본문에서 받은 XOR 마스킹 토큰
- `XSRF-TOKEN` 쿠키에서 읽은 원본 토큰

원본 토큰 비교는 상수 시간 비교를 사용하며, 임의의 토큰이나 누락된 토큰은 계속 거절합니다. 따라서 프론트와 관리자 검증 스크립트를 동시에 배포하지 않아도 되는 하위 호환 변경입니다.

## 검증

- 수정 전 회귀 테스트에서 `마스킹 토큰 200 → 쿠키 원본 토큰 403` 재현
- 수정 후 `마스킹 토큰 200 → 쿠키 원본 토큰 200 → 잘못된 토큰 403` 확인
- 관리자 CSRF, 회원 보안, 회원정보 수정, 알림 관련 테스트 통과
- `./gradlew test` — 192 tests, 0 failures, 0 errors
- `./gradlew check` — 성공