### PR TITLE
강의실 시간 구간 정규화 및 공식 엑셀 반영

### DIFF
--- a/src/main/java/inu/timetable/dto/ScheduleRoomSegmentDto.java
+++ b/src/main/java/inu/timetable/dto/ScheduleRoomSegmentDto.java
@@ -1,0 +1,31 @@
+package inu.timetable.dto;
+
+import inu.timetable.entity.ScheduleRoomSegment;
+import inu.timetable.util.TimeConverter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ScheduleRoomSegmentDto {
+
+    private Long id;
+    private String room;
+    private String startTime;
+    private String endTime;
+
+    public static ScheduleRoomSegmentDto fromEntity(ScheduleRoomSegment segment) {
+        return ScheduleRoomSegmentDto.builder()
+                .id(segment.getId())
+                .room(segment.getRoom())
+                .startTime(TimeConverter.convertToClockTime(segment.getStartTime()))
+                .endTime(TimeConverter.convertToClockTime(segment.getEndTime()))
+                .build();
+    }
+}

--- a/src/main/java/inu/timetable/dto/SubjectDto.java
+++ b/src/main/java/inu/timetable/dto/SubjectDto.java
@@ -46,6 +46,7 @@ public class SubjectDto {
         private String dayOfWeek;
         private String startTime;
         private String endTime;
+        private List<ScheduleRoomSegmentDto> roomSegments;
         
         public static ScheduleDto fromEntity(Schedule schedule) {
             return ScheduleDto.builder()
@@ -53,6 +54,9 @@ public class SubjectDto {
                 .dayOfWeek(schedule.getDayOfWeek())
                 .startTime(TimeConverter.convertToClockTime(schedule.getStartTime()))
                 .endTime(TimeConverter.convertToClockTime(schedule.getEndTime()))
+                .roomSegments(schedule.getRoomSegments().stream()
+                    .map(ScheduleRoomSegmentDto::fromEntity)
+                    .toList())
                 .build();
         }
     }

--- a/src/main/java/inu/timetable/dto/SubjectManagementResponse.java
+++ b/src/main/java/inu/timetable/dto/SubjectManagementResponse.java
@@ -1,6 +1,7 @@
 package inu.timetable.dto;
 
 import inu.timetable.entity.Schedule;
+import inu.timetable.entity.ScheduleRoomSegment;
 import inu.timetable.entity.Subject;
 import inu.timetable.enums.ClassMethod;
 import inu.timetable.enums.SubjectType;
@@ -57,6 +58,7 @@ public class SubjectManagementResponse {
         private String dayOfWeek;
         private Double startTime;
         private Double endTime;
+        private List<RoomSegmentResponse> roomSegments;
 
         public static ScheduleResponse from(Schedule schedule) {
             return ScheduleResponse.builder()
@@ -64,6 +66,28 @@ public class SubjectManagementResponse {
                     .dayOfWeek(schedule.getDayOfWeek())
                     .startTime(schedule.getStartTime())
                     .endTime(schedule.getEndTime())
+                    .roomSegments(schedule.getRoomSegments().stream()
+                            .map(RoomSegmentResponse::from)
+                            .toList())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class RoomSegmentResponse {
+        private Long id;
+        private String room;
+        private Double startTime;
+        private Double endTime;
+
+        public static RoomSegmentResponse from(ScheduleRoomSegment segment) {
+            return RoomSegmentResponse.builder()
+                    .id(segment.getId())
+                    .room(segment.getRoom())
+                    .startTime(segment.getStartTime())
+                    .endTime(segment.getEndTime())
                     .build();
         }
     }

--- a/src/main/java/inu/timetable/dto/WishlistItemDto.java
+++ b/src/main/java/inu/timetable/dto/WishlistItemDto.java
@@ -47,6 +47,7 @@ public class WishlistItemDto {
         private String dayOfWeek;
         private String startTime;  // "09:00" 형태
         private String endTime;    // "10:30" 형태
+        private List<ScheduleRoomSegmentDto> roomSegments;
         
         public static ScheduleDto fromEntity(Schedule schedule) {
             return ScheduleDto.builder()
@@ -54,6 +55,9 @@ public class WishlistItemDto {
                 .dayOfWeek(schedule.getDayOfWeek())
                 .startTime(TimeConverter.convertToClockTime(schedule.getStartTime()))
                 .endTime(TimeConverter.convertToClockTime(schedule.getEndTime()))
+                .roomSegments(schedule.getRoomSegments().stream()
+                    .map(ScheduleRoomSegmentDto::fromEntity)
+                    .toList())
                 .build();
         }
     }

--- a/src/main/java/inu/timetable/entity/Schedule.java
+++ b/src/main/java/inu/timetable/entity/Schedule.java
@@ -7,6 +7,10 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.BatchSize;
+
+import java.util.LinkedHashSet;
+import java.util.Set;
 
 @Entity
 @Table(name = "schedules", indexes = {
@@ -38,4 +42,10 @@ public class Schedule {
     
     @Column(name = "end_time")
     private Double endTime; // 2, 2.5, 3, 3.5, etc.
+
+    @OneToMany(mappedBy = "schedule", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("startTime ASC, endTime ASC, id ASC")
+    @BatchSize(size = 100)
+    @Builder.Default
+    private Set<ScheduleRoomSegment> roomSegments = new LinkedHashSet<>();
 }

--- a/src/main/java/inu/timetable/entity/ScheduleRoomSegment.java
+++ b/src/main/java/inu/timetable/entity/ScheduleRoomSegment.java
@@ -1,0 +1,52 @@
+package inu.timetable.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Table(
+        name = "schedule_room_segments",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uq_schedule_room_segment",
+                columnNames = {"schedule_id", "room", "start_time", "end_time"}),
+        indexes = @Index(name = "idx_schedule_room_segments_schedule_id", columnList = "schedule_id"))
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ScheduleRoomSegment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @JsonIgnore
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "schedule_id", nullable = false)
+    private Schedule schedule;
+
+    @Column(nullable = false, length = 100)
+    private String room;
+
+    @Column(name = "start_time", nullable = false)
+    private Double startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private Double endTime;
+}

--- a/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
+++ b/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
@@ -2,6 +2,7 @@ package inu.timetable.service;
 
 import inu.timetable.dto.OfficialSubjectImportResponse;
 import inu.timetable.entity.Schedule;
+import inu.timetable.entity.ScheduleRoomSegment;
 import inu.timetable.entity.Subject;
 import inu.timetable.enums.ClassMethod;
 import inu.timetable.enums.SubjectType;
@@ -39,7 +40,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class OfficialSubjectImportService {
 
-    private static final Pattern BRACKET_TIME_PATTERN = Pattern.compile("\\[[^:\\]]+:([^\\]]+)\\]");
+    private static final Pattern BRACKET_SCHEDULE_PATTERN = Pattern.compile("\\[([^:\\]]+):([^\\]]+)\\]");
     private static final Pattern DAY_PATTERN = Pattern.compile("^([월화수목금토일])\\s*(.*)$");
     private static final Pattern PERIOD_PATTERN = Pattern.compile("\\(([^)]+)\\)");
     private static final Pattern BARE_PERIOD_PATTERN = Pattern.compile("(?:야)?\\d{1,2}[AB]?(?:\\s*-\\s*(?:야)?\\d{1,2}[AB]?)?");
@@ -320,14 +321,97 @@ public class OfficialSubjectImportService {
         subject.setClassMethod(record.classMethod());
         subject.setIsNight(record.isNight());
 
-        subject.getSchedules().clear();
-        for (ScheduleValue scheduleValue : record.schedules()) {
-            subject.getSchedules().add(Schedule.builder()
-                    .subject(subject)
-                    .dayOfWeek(scheduleValue.dayOfWeek())
-                    .startTime(scheduleValue.startTime())
-                    .endTime(scheduleValue.endTime())
-                    .build());
+        synchronizeSchedules(subject, record.schedules());
+    }
+
+    private void synchronizeSchedules(Subject subject, List<ScheduleValue> scheduleValues) {
+        Map<String, Schedule> existingByKey = subject.getSchedules().stream()
+                .collect(Collectors.toMap(
+                        schedule -> scheduleKey(
+                                schedule.getDayOfWeek(),
+                                schedule.getStartTime(),
+                                schedule.getEndTime()),
+                        schedule -> schedule,
+                        (left, right) -> left,
+                        LinkedHashMap::new));
+        Set<String> incomingKeys = scheduleValues.stream()
+                .map(schedule -> scheduleKey(schedule.dayOfWeek(), schedule.startTime(), schedule.endTime()))
+                .collect(Collectors.toSet());
+
+        subject.getSchedules().removeIf(schedule -> !incomingKeys.contains(scheduleKey(
+                schedule.getDayOfWeek(),
+                schedule.getStartTime(),
+                schedule.getEndTime())));
+
+        for (ScheduleValue scheduleValue : scheduleValues) {
+            String key = scheduleKey(
+                    scheduleValue.dayOfWeek(),
+                    scheduleValue.startTime(),
+                    scheduleValue.endTime());
+            Schedule schedule = existingByKey.get(key);
+            if (schedule == null) {
+                schedule = Schedule.builder()
+                        .subject(subject)
+                        .dayOfWeek(scheduleValue.dayOfWeek())
+                        .startTime(scheduleValue.startTime())
+                        .endTime(scheduleValue.endTime())
+                        .build();
+                subject.getSchedules().add(schedule);
+                existingByKey.put(key, schedule);
+            } else {
+                schedule.setSubject(subject);
+                schedule.setDayOfWeek(scheduleValue.dayOfWeek());
+                schedule.setStartTime(scheduleValue.startTime());
+                schedule.setEndTime(scheduleValue.endTime());
+            }
+            synchronizeRoomSegments(schedule, scheduleValue.roomSegments());
+        }
+
+        subject.getSchedules().sort((left, right) -> {
+            int dayCompare = Integer.compare(
+                    DAYS.indexOf(left.getDayOfWeek()),
+                    DAYS.indexOf(right.getDayOfWeek()));
+            return dayCompare != 0 ? dayCompare : Double.compare(left.getStartTime(), right.getStartTime());
+        });
+    }
+
+    private void synchronizeRoomSegments(Schedule schedule, List<RoomSegmentValue> roomSegmentValues) {
+        Map<String, ScheduleRoomSegment> existingByKey = schedule.getRoomSegments().stream()
+                .collect(Collectors.toMap(
+                        segment -> roomSegmentKey(
+                                segment.getRoom(),
+                                segment.getStartTime(),
+                                segment.getEndTime()),
+                        segment -> segment,
+                        (left, right) -> left,
+                        LinkedHashMap::new));
+        Set<String> incomingKeys = roomSegmentValues.stream()
+                .map(segment -> roomSegmentKey(segment.room(), segment.startTime(), segment.endTime()))
+                .collect(Collectors.toSet());
+
+        schedule.getRoomSegments().removeIf(segment -> !incomingKeys.contains(roomSegmentKey(
+                segment.getRoom(),
+                segment.getStartTime(),
+                segment.getEndTime())));
+
+        for (RoomSegmentValue roomSegmentValue : roomSegmentValues) {
+            String key = roomSegmentKey(
+                    roomSegmentValue.room(),
+                    roomSegmentValue.startTime(),
+                    roomSegmentValue.endTime());
+            ScheduleRoomSegment roomSegment = existingByKey.get(key);
+            if (roomSegment == null) {
+                roomSegment = ScheduleRoomSegment.builder()
+                        .schedule(schedule)
+                        .room(roomSegmentValue.room())
+                        .startTime(roomSegmentValue.startTime())
+                        .endTime(roomSegmentValue.endTime())
+                        .build();
+                schedule.getRoomSegments().add(roomSegment);
+                existingByKey.put(key, roomSegment);
+            } else {
+                roomSegment.setSchedule(schedule);
+            }
         }
     }
 
@@ -341,8 +425,11 @@ public class OfficialSubjectImportService {
         addIfChanged(fields, "이수구분", subject.getSubjectType(), record.subjectType());
         addIfChanged(fields, "수업유형", subject.getClassMethod(), record.classMethod());
         addIfChanged(fields, "야간여부", subject.getIsNight(), record.isNight());
-        if (!sameSchedules(subject.getSchedules(), record.schedules())) {
+        boolean schedulesChanged = !sameSchedules(subject.getSchedules(), record.schedules());
+        if (schedulesChanged) {
             fields.add("시간표");
+        } else if (!sameRoomSegments(subject.getSchedules(), record.schedules())) {
+            fields.add("강의실");
         }
         if (!Boolean.TRUE.equals(subject.getActive())) {
             fields.add("비활성화 상태");
@@ -363,6 +450,28 @@ public class OfficialSubjectImportService {
                 .toList();
         List<String> right = scheduleValues.stream()
                 .map(schedule -> scheduleKey(schedule.dayOfWeek(), schedule.startTime(), schedule.endTime()))
+                .sorted()
+                .toList();
+        return left.equals(right);
+    }
+
+    private boolean sameRoomSegments(List<Schedule> schedules, List<ScheduleValue> scheduleValues) {
+        List<String> left = schedules.stream()
+                .flatMap(schedule -> schedule.getRoomSegments().stream()
+                        .map(segment -> scheduleRoomSegmentKey(
+                                schedule.getDayOfWeek(),
+                                segment.getRoom(),
+                                segment.getStartTime(),
+                                segment.getEndTime())))
+                .sorted()
+                .toList();
+        List<String> right = scheduleValues.stream()
+                .flatMap(schedule -> schedule.roomSegments().stream()
+                        .map(segment -> scheduleRoomSegmentKey(
+                                schedule.dayOfWeek(),
+                                segment.room(),
+                                segment.startTime(),
+                                segment.endTime())))
                 .sorted()
                 .toList();
         return left.equals(right);
@@ -415,24 +524,29 @@ public class OfficialSubjectImportService {
             return List.of();
         }
 
-        List<String> timeSegments = new ArrayList<>();
-        Matcher bracketMatcher = BRACKET_TIME_PATTERN.matcher(timeSchedule);
-        while (bracketMatcher.find()) {
-            timeSegments.add(bracketMatcher.group(1));
-        }
-        if (timeSegments.isEmpty()) {
-            timeSegments.add(timeSchedule);
-        }
-
-        List<ScheduleValue> schedules = new ArrayList<>();
+        List<RawScheduleValue> schedules = new ArrayList<>();
+        Matcher bracketMatcher = BRACKET_SCHEDULE_PATTERN.matcher(timeSchedule);
         String currentDay = null;
-        for (String segment : timeSegments) {
-            currentDay = parseSegment(segment, schedules, currentDay);
+        boolean foundBracket = false;
+        while (bracketMatcher.find()) {
+            foundBracket = true;
+            currentDay = parseSegment(
+                    bracketMatcher.group(2),
+                    trimToNull(bracketMatcher.group(1)),
+                    schedules,
+                    currentDay);
+        }
+        if (!foundBracket) {
+            parseSegment(timeSchedule, null, schedules, currentDay);
         }
         return mergeSchedules(schedules);
     }
 
-    private String parseSegment(String segment, List<ScheduleValue> schedules, String currentDay) {
+    private String parseSegment(
+            String segment,
+            String room,
+            List<RawScheduleValue> schedules,
+            String currentDay) {
         for (String rawPart : segment.split(",")) {
             String part = rawPart.trim();
             if (!hasText(part)) {
@@ -451,24 +565,28 @@ public class OfficialSubjectImportService {
             boolean foundPeriod = false;
             Matcher periodMatcher = PERIOD_PATTERN.matcher(part);
             while (periodMatcher.find()) {
-                addPeriod(schedules, currentDay, periodMatcher.group(1));
+                addPeriod(schedules, currentDay, room, periodMatcher.group(1));
                 foundPeriod = true;
             }
 
             if (!foundPeriod) {
                 Matcher bareMatcher = BARE_PERIOD_PATTERN.matcher(part);
                 while (bareMatcher.find()) {
-                    addPeriod(schedules, currentDay, bareMatcher.group());
+                    addPeriod(schedules, currentDay, room, bareMatcher.group());
                 }
             }
         }
         return currentDay;
     }
 
-    private void addPeriod(List<ScheduleValue> schedules, String dayOfWeek, String period) {
+    private void addPeriod(
+            List<RawScheduleValue> schedules,
+            String dayOfWeek,
+            String room,
+            String period) {
         double[] range = parsePeriod(period);
         if (range != null) {
-            schedules.add(new ScheduleValue(dayOfWeek, range[0], range[1]));
+            schedules.add(new RawScheduleValue(dayOfWeek, range[0], range[1], room));
         }
     }
 
@@ -513,17 +631,17 @@ public class OfficialSubjectImportService {
         return Double.parseDouble(normalized);
     }
 
-    private List<ScheduleValue> mergeSchedules(List<ScheduleValue> schedules) {
+    private List<ScheduleValue> mergeSchedules(List<RawScheduleValue> schedules) {
         if (schedules.isEmpty()) {
             return List.of();
         }
 
-        Map<String, ScheduleValue> deduplicated = new LinkedHashMap<>();
-        for (ScheduleValue schedule : schedules) {
+        Map<String, RawScheduleValue> deduplicated = new LinkedHashMap<>();
+        for (RawScheduleValue schedule : schedules) {
             deduplicated.put(scheduleKey(schedule.dayOfWeek(), schedule.startTime(), schedule.endTime()), schedule);
         }
 
-        List<ScheduleValue> sorted = new ArrayList<>(deduplicated.values());
+        List<RawScheduleValue> sorted = new ArrayList<>(deduplicated.values());
         sorted.sort((left, right) -> {
             int dayCompare = Integer.compare(DAYS.indexOf(left.dayOfWeek()), DAYS.indexOf(right.dayOfWeek()));
             if (dayCompare != 0) {
@@ -533,23 +651,115 @@ public class OfficialSubjectImportService {
         });
 
         List<ScheduleValue> merged = new ArrayList<>();
-        ScheduleValue current = sorted.get(0);
+        ScheduleValue current = new ScheduleValue(
+                sorted.get(0).dayOfWeek(),
+                sorted.get(0).startTime(),
+                sorted.get(0).endTime(),
+                List.of());
         for (int index = 1; index < sorted.size(); index++) {
-            ScheduleValue next = sorted.get(index);
+            RawScheduleValue next = sorted.get(index);
             if (current.dayOfWeek().equals(next.dayOfWeek())
                     && Math.abs(current.endTime() - next.startTime()) < 0.001) {
-                current = new ScheduleValue(current.dayOfWeek(), current.startTime(), next.endTime());
+                current = new ScheduleValue(
+                        current.dayOfWeek(),
+                        current.startTime(),
+                        next.endTime(),
+                        List.of());
             } else {
                 merged.add(current);
-                current = next;
+                current = new ScheduleValue(
+                        next.dayOfWeek(),
+                        next.startTime(),
+                        next.endTime(),
+                        List.of());
             }
         }
         merged.add(current);
+
+        List<RoomSegmentValue> roomSegments = mergeRoomSegments(schedules);
+        return merged.stream()
+                .map(schedule -> new ScheduleValue(
+                        schedule.dayOfWeek(),
+                        schedule.startTime(),
+                        schedule.endTime(),
+                        roomSegments.stream()
+                                .filter(segment -> segment.dayOfWeek().equals(schedule.dayOfWeek()))
+                                .filter(segment -> segment.startTime() >= schedule.startTime() - 0.001)
+                                .filter(segment -> segment.endTime() <= schedule.endTime() + 0.001)
+                                .toList()))
+                .toList();
+    }
+
+    private List<RoomSegmentValue> mergeRoomSegments(List<RawScheduleValue> schedules) {
+        Map<String, RoomSegmentValue> deduplicated = new LinkedHashMap<>();
+        schedules.stream()
+                .filter(schedule -> hasText(schedule.room()))
+                .forEach(schedule -> {
+                    RoomSegmentValue segment = new RoomSegmentValue(
+                            schedule.room(),
+                            schedule.dayOfWeek(),
+                            schedule.startTime(),
+                            schedule.endTime());
+                    deduplicated.put(
+                            scheduleRoomSegmentKey(
+                                    segment.dayOfWeek(),
+                                    segment.room(),
+                                    segment.startTime(),
+                                    segment.endTime()),
+                            segment);
+                });
+
+        List<RoomSegmentValue> sorted = new ArrayList<>(deduplicated.values());
+        sorted.sort((left, right) -> {
+            int dayCompare = Integer.compare(
+                    DAYS.indexOf(left.dayOfWeek()),
+                    DAYS.indexOf(right.dayOfWeek()));
+            if (dayCompare != 0) {
+                return dayCompare;
+            }
+            int timeCompare = Double.compare(left.startTime(), right.startTime());
+            if (timeCompare != 0) {
+                return timeCompare;
+            }
+            return left.room().compareTo(right.room());
+        });
+
+        List<RoomSegmentValue> merged = new ArrayList<>();
+        for (RoomSegmentValue next : sorted) {
+            if (merged.isEmpty()) {
+                merged.add(next);
+                continue;
+            }
+            RoomSegmentValue current = merged.get(merged.size() - 1);
+            if (current.dayOfWeek().equals(next.dayOfWeek())
+                    && current.room().equals(next.room())
+                    && Math.abs(current.endTime() - next.startTime()) < 0.001) {
+                merged.set(merged.size() - 1, new RoomSegmentValue(
+                        current.room(),
+                        current.dayOfWeek(),
+                        current.startTime(),
+                        next.endTime()));
+            } else {
+                merged.add(next);
+            }
+        }
         return merged;
     }
 
     private String scheduleKey(String dayOfWeek, Double startTime, Double endTime) {
         return dayOfWeek + ":" + startTime + "-" + endTime;
+    }
+
+    private String roomSegmentKey(String room, Double startTime, Double endTime) {
+        return room + ":" + startTime + "-" + endTime;
+    }
+
+    private String scheduleRoomSegmentKey(
+            String dayOfWeek,
+            String room,
+            Double startTime,
+            Double endTime) {
+        return dayOfWeek + ":" + roomSegmentKey(room, startTime, endTime);
     }
 
     private SubjectType parseSubjectType(String type) {
@@ -683,7 +893,25 @@ public class OfficialSubjectImportService {
             List<ScheduleValue> schedules) {
     }
 
-    private record ScheduleValue(String dayOfWeek, Double startTime, Double endTime) {
+    private record ScheduleValue(
+            String dayOfWeek,
+            Double startTime,
+            Double endTime,
+            List<RoomSegmentValue> roomSegments) {
+    }
+
+    private record RawScheduleValue(
+            String dayOfWeek,
+            Double startTime,
+            Double endTime,
+            String room) {
+    }
+
+    private record RoomSegmentValue(
+            String room,
+            String dayOfWeek,
+            Double startTime,
+            Double endTime) {
     }
 
     private record ImportDiff(

--- a/src/main/java/inu/timetable/service/SubjectAdminService.java
+++ b/src/main/java/inu/timetable/service/SubjectAdminService.java
@@ -15,10 +15,17 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class SubjectAdminService {
+
+    private static final String DAYS = "월화수목금토일";
 
     private final SubjectRepository subjectRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -81,23 +88,72 @@ public class SubjectAdminService {
         subject.setClassMethod(request.getClassMethod());
         subject.setIsNight(request.getIsNight());
 
-        subject.getSchedules().clear();
-        for (SubjectManagementRequest.ScheduleRequest scheduleRequest : request.getSchedules()) {
-            validateSchedule(scheduleRequest);
-            Schedule schedule = Schedule.builder()
-                    .subject(subject)
-                    .dayOfWeek(scheduleRequest.getDayOfWeek().trim())
-                    .startTime(scheduleRequest.getStartTime())
-                    .endTime(scheduleRequest.getEndTime())
-                    .build();
-            subject.getSchedules().add(schedule);
+        synchronizeSchedules(subject, request.getSchedules());
+    }
+
+    private void synchronizeSchedules(
+            Subject subject,
+            List<SubjectManagementRequest.ScheduleRequest> scheduleRequests) {
+        scheduleRequests.forEach(this::validateSchedule);
+
+        Map<String, Schedule> existingByKey = subject.getSchedules().stream()
+                .collect(Collectors.toMap(
+                        schedule -> scheduleKey(
+                                schedule.getDayOfWeek(),
+                                schedule.getStartTime(),
+                                schedule.getEndTime()),
+                        schedule -> schedule,
+                        (left, right) -> left,
+                        LinkedHashMap::new));
+        Set<String> incomingKeys = scheduleRequests.stream()
+                .map(request -> scheduleKey(
+                        request.getDayOfWeek().trim(),
+                        request.getStartTime(),
+                        request.getEndTime()))
+                .collect(Collectors.toSet());
+
+        subject.getSchedules().removeIf(schedule -> !incomingKeys.contains(scheduleKey(
+                schedule.getDayOfWeek(),
+                schedule.getStartTime(),
+                schedule.getEndTime())));
+
+        for (SubjectManagementRequest.ScheduleRequest scheduleRequest : scheduleRequests) {
+            String dayOfWeek = scheduleRequest.getDayOfWeek().trim();
+            String key = scheduleKey(
+                    dayOfWeek,
+                    scheduleRequest.getStartTime(),
+                    scheduleRequest.getEndTime());
+            Schedule schedule = existingByKey.get(key);
+            if (schedule == null) {
+                schedule = Schedule.builder()
+                        .subject(subject)
+                        .dayOfWeek(dayOfWeek)
+                        .startTime(scheduleRequest.getStartTime())
+                        .endTime(scheduleRequest.getEndTime())
+                        .build();
+                subject.getSchedules().add(schedule);
+                existingByKey.put(key, schedule);
+            } else {
+                schedule.setSubject(subject);
+            }
         }
+
+        subject.getSchedules().sort((left, right) -> {
+            int dayCompare = Integer.compare(
+                    DAYS.indexOf(left.getDayOfWeek()),
+                    DAYS.indexOf(right.getDayOfWeek()));
+            return dayCompare != 0 ? dayCompare : Double.compare(left.getStartTime(), right.getStartTime());
+        });
     }
 
     private void validateSchedule(SubjectManagementRequest.ScheduleRequest scheduleRequest) {
         if (scheduleRequest.getEndTime() <= scheduleRequest.getStartTime()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Schedule endTime must be greater than startTime");
         }
+    }
+
+    private String scheduleKey(String dayOfWeek, Double startTime, Double endTime) {
+        return dayOfWeek + ":" + startTime + "-" + endTime;
     }
 
     private String trimToNull(String value) {

--- a/src/main/resources/db/migration/V20260728_01__create_schedule_room_segments.sql
+++ b/src/main/resources/db/migration/V20260728_01__create_schedule_room_segments.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS schedule_room_segments (
+    id BIGSERIAL PRIMARY KEY,
+    schedule_id BIGINT NOT NULL,
+    room VARCHAR(100) NOT NULL,
+    start_time DOUBLE PRECISION NOT NULL,
+    end_time DOUBLE PRECISION NOT NULL,
+    CONSTRAINT fk_schedule_room_segments_schedule
+        FOREIGN KEY (schedule_id) REFERENCES schedules(id) ON DELETE CASCADE,
+    CONSTRAINT uq_schedule_room_segment
+        UNIQUE (schedule_id, room, start_time, end_time),
+    CONSTRAINT chk_schedule_room_segment_time
+        CHECK (start_time < end_time)
+);
+
+CREATE INDEX IF NOT EXISTS idx_schedule_room_segments_schedule_id
+    ON schedule_room_segments (schedule_id);

--- a/src/test/java/inu/timetable/dto/ScheduleRoomSegmentDtoTest.java
+++ b/src/test/java/inu/timetable/dto/ScheduleRoomSegmentDtoTest.java
@@ -1,0 +1,103 @@
+package inu.timetable.dto;
+
+import inu.timetable.entity.Schedule;
+import inu.timetable.entity.ScheduleRoomSegment;
+import inu.timetable.entity.Subject;
+import inu.timetable.entity.WishlistItem;
+import inu.timetable.enums.ClassMethod;
+import inu.timetable.enums.SubjectType;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ScheduleRoomSegmentDtoTest {
+
+    @Test
+    void publicSubjectDtoExposesRoomSegmentsWithClockTimes() {
+        Subject subject = subjectWithRoomSegment();
+
+        SubjectDto dto = SubjectDto.from(subject);
+
+        assertThat(dto.getSchedules().get(0).getRoomSegments())
+                .singleElement()
+                .satisfies(segment -> {
+                    assertThat(segment.getId()).isEqualTo(20L);
+                    assertThat(segment.getRoom()).isEqualTo("05-432");
+                    assertThat(segment.getStartTime()).isEqualTo("09:00");
+                    assertThat(segment.getEndTime()).isEqualTo("10:30");
+                });
+    }
+
+    @Test
+    void wishlistDtoExposesRoomSegmentsWithClockTimes() {
+        Subject subject = subjectWithRoomSegment();
+        WishlistItem wishlistItem = WishlistItem.builder()
+                .id(30L)
+                .subject(subject)
+                .semester("2026-2")
+                .priority(1)
+                .isRequired(false)
+                .build();
+
+        WishlistItemDto dto = WishlistItemDto.fromEntity(wishlistItem);
+
+        assertThat(dto.getSchedules().get(0).getRoomSegments())
+                .singleElement()
+                .satisfies(segment -> {
+                    assertThat(segment.getRoom()).isEqualTo("05-432");
+                    assertThat(segment.getStartTime()).isEqualTo("09:00");
+                    assertThat(segment.getEndTime()).isEqualTo("10:30");
+                });
+    }
+
+    @Test
+    void managementResponseExposesNumericRoomSegmentRange() {
+        Subject subject = subjectWithRoomSegment();
+
+        SubjectManagementResponse response = SubjectManagementResponse.from(subject);
+
+        assertThat(response.getSchedules().get(0).getRoomSegments())
+                .singleElement()
+                .satisfies(segment -> {
+                    assertThat(segment.getRoom()).isEqualTo("05-432");
+                    assertThat(segment.getStartTime()).isEqualTo(1.0);
+                    assertThat(segment.getEndTime()).isEqualTo(2.5);
+                });
+    }
+
+    private Subject subjectWithRoomSegment() {
+        Subject subject = Subject.builder()
+                .id(1L)
+                .courseCode("CSE0001001")
+                .semester("2026-2")
+                .active(true)
+                .subjectName("자료구조")
+                .credits(3)
+                .professor("김교수")
+                .department("컴퓨터공학부")
+                .grade(2)
+                .subjectType(SubjectType.전심)
+                .classMethod(ClassMethod.OFFLINE)
+                .isNight(false)
+                .schedules(new ArrayList<>())
+                .build();
+        Schedule schedule = Schedule.builder()
+                .id(10L)
+                .subject(subject)
+                .dayOfWeek("월")
+                .startTime(1.0)
+                .endTime(3.0)
+                .build();
+        schedule.getRoomSegments().add(ScheduleRoomSegment.builder()
+                .id(20L)
+                .schedule(schedule)
+                .room("05-432")
+                .startTime(1.0)
+                .endTime(2.5)
+                .build());
+        subject.getSchedules().add(schedule);
+        return subject;
+    }
+}

--- a/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
+++ b/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
@@ -1,6 +1,7 @@
 package inu.timetable.repository;
 
 import inu.timetable.entity.Schedule;
+import inu.timetable.entity.ScheduleRoomSegment;
 import inu.timetable.entity.Subject;
 import inu.timetable.entity.User;
 import inu.timetable.entity.UserTimetable;
@@ -71,6 +72,32 @@ class SubjectRepositoryIntegrationTest {
                 .orElseThrow();
         assertThat(loadedTarget.getSchedules()).hasSize(1);
         assertThat(loadedTarget.getSchedules().get(0).getDayOfWeek()).isEqualTo("월");
+    }
+
+    @Test
+    void findImportCandidatesLoadsNormalizedRoomSegments() {
+        Subject targetSubject = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
+        Schedule schedule = targetSubject.getSchedules().get(0);
+        entityManager.persistAndFlush(ScheduleRoomSegment.builder()
+                .schedule(schedule)
+                .room("05-432")
+                .startTime(4.0)
+                .endTime(5.5)
+                .build());
+        entityManager.clear();
+
+        Subject loaded = subjectRepository.findImportCandidatesBySemester("2026-1")
+                .stream()
+                .filter(subject -> "AI01001001".equals(subject.getCourseCode()))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(loaded.getSchedules().get(0).getRoomSegments())
+                .extracting(
+                        ScheduleRoomSegment::getRoom,
+                        ScheduleRoomSegment::getStartTime,
+                        ScheduleRoomSegment::getEndTime)
+                .containsExactly(tuple("05-432", 4.0, 5.5));
     }
 
     @Test

--- a/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
+++ b/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
@@ -2,6 +2,7 @@ package inu.timetable.service;
 
 import inu.timetable.dto.OfficialSubjectImportResponse;
 import inu.timetable.entity.Schedule;
+import inu.timetable.entity.ScheduleRoomSegment;
 import inu.timetable.entity.Subject;
 import inu.timetable.enums.ClassMethod;
 import inu.timetable.enums.SubjectType;
@@ -157,6 +158,89 @@ class OfficialSubjectImportServiceTest {
         assertThat(schedule.getDayOfWeek()).isEqualTo("금");
         assertThat(schedule.getStartTime()).isEqualTo(5.0);
         assertThat(schedule.getEndTime()).isEqualTo(9.0);
+        assertThat(schedule.getRoomSegments())
+                .extracting(
+                        ScheduleRoomSegment::getRoom,
+                        ScheduleRoomSegment::getStartTime,
+                        ScheduleRoomSegment::getEndTime)
+                .containsExactly(
+                        org.assertj.core.groups.Tuple.tuple("05-527", 5.0, 7.0),
+                        org.assertj.core.groups.Tuple.tuple("05-432", 7.0, 9.0));
+    }
+
+    @Test
+    void applyBackfillsRoomsWithoutReplacingExistingScheduleTuple() throws Exception {
+        Subject existing = matchingFirstRowSubjectWithoutRooms();
+        Schedule existingSchedule = existing.getSchedules().get(0);
+        when(subjectRepository.findImportCandidatesBySemester("2026-1"))
+                .thenReturn(List.of(existing));
+
+        OfficialSubjectImportResponse response =
+                officialSubjectImportService.apply(sampleWorkbook(), "2026-1", true);
+
+        assertThat(response.getModifiedSubjects())
+                .filteredOn(item -> "AI01001001".equals(item.getCourseCode()))
+                .singleElement()
+                .satisfies(item -> {
+                    assertThat(item.getChangedFields()).containsExactly("강의실");
+                });
+        assertThat(existing.getSchedules()).containsExactly(existingSchedule);
+        assertThat(existing.getSchedules().get(0).getId()).isEqualTo(77L);
+        assertThat(existing.getSchedules().get(0).getRoomSegments())
+                .extracting(ScheduleRoomSegment::getRoom)
+                .containsExactly("05-527", "05-432");
+    }
+
+    @Test
+    void applyKeepsExistingRoomSegmentTuplesWhenWorkbookIsUnchanged() throws Exception {
+        Subject existing = matchingFirstRowSubjectWithoutRooms();
+        Schedule existingSchedule = existing.getSchedules().get(0);
+        ScheduleRoomSegment firstSegment = ScheduleRoomSegment.builder()
+                .id(101L)
+                .schedule(existingSchedule)
+                .room("05-527")
+                .startTime(5.0)
+                .endTime(7.0)
+                .build();
+        ScheduleRoomSegment secondSegment = ScheduleRoomSegment.builder()
+                .id(102L)
+                .schedule(existingSchedule)
+                .room("05-432")
+                .startTime(7.0)
+                .endTime(9.0)
+                .build();
+        existingSchedule.getRoomSegments().add(firstSegment);
+        existingSchedule.getRoomSegments().add(secondSegment);
+        when(subjectRepository.findImportCandidatesBySemester("2026-1"))
+                .thenReturn(List.of(existing));
+
+        officialSubjectImportService.apply(sampleWorkbook(), "2026-1", true);
+
+        assertThat(existing.getSchedules()).containsExactly(existingSchedule);
+        assertThat(existingSchedule.getRoomSegments())
+                .containsExactly(firstSegment, secondSegment);
+        assertThat(existingSchedule.getRoomSegments())
+                .extracting(ScheduleRoomSegment::getId)
+                .containsExactly(101L, 102L);
+    }
+
+    @Test
+    void applyKeepsThreeRoomSegmentsInsideOneMergedSchedule() throws Exception {
+        when(subjectRepository.findImportCandidatesBySemester("2026-1"))
+                .thenReturn(List.of());
+
+        officialSubjectImportService.apply(threeRoomWorkbook(), "2026-1", true);
+
+        ArgumentCaptor<List<Subject>> captor = ArgumentCaptor.forClass(List.class);
+        verify(subjectRepository).saveAll(captor.capture());
+        Schedule schedule = captor.getValue().get(0).getSchedules().get(0);
+
+        assertThat(schedule.getDayOfWeek()).isEqualTo("목");
+        assertThat(schedule.getStartTime()).isEqualTo(1.0);
+        assertThat(schedule.getEndTime()).isEqualTo(7.0);
+        assertThat(schedule.getRoomSegments())
+                .extracting(ScheduleRoomSegment::getRoom)
+                .containsExactly("28-508", "09-501", "27-104");
     }
 
     @Test
@@ -287,6 +371,42 @@ class OfficialSubjectImportServiceTest {
         }
     }
 
+    private MockMultipartFile threeRoomWorkbook() throws Exception {
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("sheet1");
+            sheet.createRow(0).createCell(0)
+                    .setCellValue("2026학년도 1학기 인천대학교 학부 종합강의시간표");
+            Row header = sheet.createRow(1);
+            List<String> headers = List.of(
+                    "순번", "대학(원)", "학과(부)", "학년", "이수구분", "이수영역", "학수번호", "교과목명",
+                    "교과목명(영문)", "담당교수", "강의실", "시간표(교시)", "시간표(시간)", "교시유형", "학점",
+                    "수업구분", "수업유형", "집중이수제", "성적평가", "원어강의구분");
+            for (int index = 0; index < headers.size(); index++) {
+                header.createCell(index).setCellValue(headers.get(index));
+            }
+            createSubjectRow(
+                    sheet,
+                    2,
+                    "0001993003",
+                    "건축공학종합설계",
+                    "테스트교수",
+                    "건축공학부",
+                    "4",
+                    "전공심화",
+                    " [09-501:목(4-5A)] [27-104:(5B-6)] [28-508:(1-2A)(2B-3)]",
+                    3,
+                    "실험실습");
+
+            workbook.write(outputStream);
+            return new MockMultipartFile(
+                    "file",
+                    "three-rooms.xlsx",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                    outputStream.toByteArray());
+        }
+    }
+
     private void createSubjectRow(
             Sheet sheet,
             int rowIndex,
@@ -328,11 +448,44 @@ class OfficialSubjectImportServiceTest {
                 .isNight(false)
                 .schedules(new ArrayList<>())
                 .build();
-        subject.getSchedules().add(Schedule.builder()
+        Schedule schedule = Schedule.builder()
                 .subject(subject)
                 .dayOfWeek("화")
                 .startTime(7.0)
                 .endTime(8.0)
+                .build();
+        schedule.getRoomSegments().add(ScheduleRoomSegment.builder()
+                .schedule(schedule)
+                .room("15-119")
+                .startTime(7.0)
+                .endTime(8.0)
+                .build());
+        subject.getSchedules().add(schedule);
+        return subject;
+    }
+
+    private Subject matchingFirstRowSubjectWithoutRooms() {
+        Subject subject = Subject.builder()
+                .id(1L)
+                .courseCode("AI01001001")
+                .semester("2026-1")
+                .active(true)
+                .subjectName("AI에이전트")
+                .credits(3)
+                .professor("신규교수")
+                .department("컴퓨터공학부")
+                .grade(2)
+                .subjectType(SubjectType.전심)
+                .classMethod(ClassMethod.OFFLINE)
+                .isNight(false)
+                .schedules(new ArrayList<>())
+                .build();
+        subject.getSchedules().add(Schedule.builder()
+                .id(77L)
+                .subject(subject)
+                .dayOfWeek("금")
+                .startTime(5.0)
+                .endTime(9.0)
                 .build());
         return subject;
     }

--- a/src/test/java/inu/timetable/service/SubjectAdminServiceTest.java
+++ b/src/test/java/inu/timetable/service/SubjectAdminServiceTest.java
@@ -3,6 +3,7 @@ package inu.timetable.service;
 import inu.timetable.dto.SubjectManagementRequest;
 import inu.timetable.dto.SubjectManagementResponse;
 import inu.timetable.entity.Schedule;
+import inu.timetable.entity.ScheduleRoomSegment;
 import inu.timetable.entity.Subject;
 import inu.timetable.enums.ClassMethod;
 import inu.timetable.enums.SubjectType;
@@ -102,6 +103,32 @@ class SubjectAdminServiceTest {
                 .isInstanceOf(ResponseStatusException.class)
                 .satisfies(exception -> assertThat(((ResponseStatusException) exception).getStatusCode())
                         .isEqualTo(HttpStatus.BAD_REQUEST));
+    }
+
+    @Test
+    void updateSubjectPreservesMatchingScheduleTupleAndRoomSegments() {
+        Subject subject = sampleSubject();
+        Schedule existingSchedule = subject.getSchedules().get(0);
+        existingSchedule.getRoomSegments().add(ScheduleRoomSegment.builder()
+                .id(20L)
+                .schedule(existingSchedule)
+                .room("05-432")
+                .startTime(1.0)
+                .endTime(2.0)
+                .build());
+        when(subjectRepository.findWithSchedulesById(1L)).thenReturn(Optional.of(subject));
+
+        SubjectManagementRequest request = sampleRequest();
+        request.setSchedules(List.of(
+                new SubjectManagementRequest.ScheduleRequest("월", 1.0, 2.0)));
+
+        SubjectManagementResponse response = subjectAdminService.updateSubject(1L, request);
+
+        assertThat(subject.getSchedules()).containsExactly(existingSchedule);
+        assertThat(subject.getSchedules().get(0).getId()).isEqualTo(10L);
+        assertThat(response.getSchedules().get(0).getRoomSegments())
+                .extracting(SubjectManagementResponse.RoomSegmentResponse::getRoom)
+                .containsExactly("05-432");
     }
 
     @Test


### PR DESCRIPTION
## 변경 사항

- `schedule_room_segments` 테이블과 JPA 엔티티를 추가했습니다.
- 강의실, 시작 교시, 종료 교시를 기존 `Schedule`의 자식 튜플로 정규화했습니다.
- 공식 엑셀의 `[강의실:시간표]` 블록을 파싱하고 같은 강의실의 연속 교시를 하나의 세그먼트로 병합합니다.
- 강의실만 추가·변경되는 재업로드에서는 기존 `Schedule`을 `(요일, 시작, 종료)`로 매칭해 ID를 유지합니다.
- 관리자 과목 수정도 시간 구간이 동일하면 기존 스케줄과 강의실 세그먼트를 보존합니다.
- 과목 검색, 위시리스트, 관리자 응답의 `schedules[].roomSegments`에 강의실 구간을 노출합니다.

## 배경

기존 공식 엑셀 파서는 대괄호 앞의 강의실 정보를 버렸고, 반영 시 `subject.getSchedules().clear()` 후 모든 스케줄을 다시 생성했습니다. 따라서 동일한 파일로 강의실만 백필해도 기존 스케줄 튜플과 ID가 교체될 수 있었습니다.

이번 변경은 기존 `schedules` 행을 유지하면서 강의실 정보를 별도 관계로 추가합니다. 시간표 자체가 달라진 경우에만 기존과 같이 해당 스케줄을 교체하고 충돌 해소를 수행합니다.

## 데이터베이스

- Flyway: `V20260728_01__create_schedule_room_segments.sql`
- `schedule_id` 외래 키 및 `ON DELETE CASCADE`
- `(schedule_id, room, start_time, end_time)` 유니크 제약
- `start_time < end_time` 체크 제약

## 검증

- `./gradlew test --no-daemon`
  - 총 200개 테스트, 실패 0개, 기존 비활성 테스트 2개 skip
- 제공된 2026-2 강의계획서 엑셀 실데이터 검증
  - 2,386개 과목 파싱
  - 한 기존 스케줄에 강의실 3개가 포함된 2개 사례 보존
  - 최대 강의실 수 3개 확인
- 강의실 백필 시 기존 schedule ID 유지 테스트
- 동일 파일 재적용 시 기존 room segment ID 유지 테스트
- DTO 및 JPA 저장/조회 테스트
