### PR TITLE
feat: 인스타 DM 링크 대신 사이트 내 문의 접수 기능 추가

### DIFF
--- a/src/main/java/inu/timetable/config/SecurityConfig.java
+++ b/src/main/java/inu/timetable/config/SecurityConfig.java
@@ -86,7 +86,8 @@ public class SecurityConfig {
                                 "/api/dev/**",
                                 "/api/subjects",
                                 "/api/subjects/**",
-                                "/api/events"))
+                                "/api/events",
+                                "/api/inquiries"))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/", "/error").permitAll()
                         .requestMatchers("/admin/**", "/admin/api/**").permitAll()
@@ -101,6 +102,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/subjects/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/settings/current-semester").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/events").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/inquiries").permitAll()
                         .anyRequest().denyAll())
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint((request, response, authException) ->

--- a/src/main/java/inu/timetable/controller/AdminController.java
+++ b/src/main/java/inu/timetable/controller/AdminController.java
@@ -103,8 +103,19 @@ public class AdminController {
     }
 
     /**
+     * 문의 관리 페이지 (사이트 내 문의 목록/처리)
+     */
+    @GetMapping("/inquiries")
+    public String inquiriesPage(HttpSession session) {
+        if (!isAuthenticated(session)) {
+            return "redirect:/admin/login";
+        }
+        return "admin/inquiries";
+    }
+
+    /**
      * PDF 업로드 처리
-     * 
+     *
      * @param mode "incremental" (기본값) 또는 "replace"
      */
     @PostMapping("/upload/pdf")

--- a/src/main/java/inu/timetable/controller/InquiryController.java
+++ b/src/main/java/inu/timetable/controller/InquiryController.java
@@ -1,0 +1,64 @@
+package inu.timetable.controller;
+
+import inu.timetable.dto.AdminInquiryPageResponse;
+import inu.timetable.dto.InquiryCreateRequest;
+import inu.timetable.security.AuthenticatedUser;
+import inu.timetable.service.AdminAccessGuard;
+import inu.timetable.service.UserInquiryService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+/**
+ * 사이트 내 문의 API.
+ * 기존 인스타그램 DM 링크 대신 앱 안에서 문의를 남기고, 관리자가 목록 확인/처리한다.
+ */
+@RestController
+@RequiredArgsConstructor
+public class InquiryController {
+
+    private final UserInquiryService userInquiryService;
+    private final AdminAccessGuard adminAccessGuard;
+
+    /**
+     * 문의 접수(비로그인 허용). 로그인 상태면 작성자를 함께 기록한다.
+     */
+    @PostMapping("/api/inquiries")
+    public ResponseEntity<Map<String, String>> submit(
+            @RequestBody InquiryCreateRequest request,
+            @AuthenticationPrincipal AuthenticatedUser authenticatedUser,
+            HttpServletRequest servletRequest) {
+        Long userId = authenticatedUser != null ? authenticatedUser.id() : null;
+        userInquiryService.submit(userId, request.content(), request.contact(), servletRequest);
+        return ResponseEntity.ok(Map.of("message", "문의가 접수되었습니다."));
+    }
+
+    @GetMapping("/admin/api/inquiries")
+    public AdminInquiryPageResponse getInquiries(
+            HttpServletRequest request,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(defaultValue = "false") boolean unresolvedOnly) {
+        adminAccessGuard.requireAuthenticated(request);
+        return userInquiryService.getInquiries(
+                Math.max(0, page), Math.max(1, Math.min(size, 100)), unresolvedOnly);
+    }
+
+    @PostMapping("/admin/api/inquiries/{id}/resolve")
+    public ResponseEntity<Map<String, String>> resolve(
+            HttpServletRequest request,
+            @PathVariable Long id) {
+        adminAccessGuard.requireAuthenticated(request);
+        userInquiryService.resolve(id);
+        return ResponseEntity.ok(Map.of("message", "처리 완료로 표시했습니다."));
+    }
+}

--- a/src/main/java/inu/timetable/dto/AdminInquiryPageResponse.java
+++ b/src/main/java/inu/timetable/dto/AdminInquiryPageResponse.java
@@ -1,0 +1,12 @@
+package inu.timetable.dto;
+
+import java.util.List;
+
+public record AdminInquiryPageResponse(
+        List<AdminInquiryResponse> inquiries,
+        int page,
+        int size,
+        long totalElements,
+        int totalPages,
+        long unresolvedCount) {
+}

--- a/src/main/java/inu/timetable/dto/AdminInquiryResponse.java
+++ b/src/main/java/inu/timetable/dto/AdminInquiryResponse.java
@@ -1,0 +1,26 @@
+package inu.timetable.dto;
+
+import inu.timetable.entity.UserInquiry;
+
+import java.time.LocalDateTime;
+
+public record AdminInquiryResponse(
+        Long id,
+        Long userId,
+        String username,
+        String content,
+        String contact,
+        LocalDateTime createdAt,
+        LocalDateTime resolvedAt) {
+
+    public static AdminInquiryResponse fromEntity(UserInquiry inquiry, String username) {
+        return new AdminInquiryResponse(
+                inquiry.getId(),
+                inquiry.getUserId(),
+                username,
+                inquiry.getContent(),
+                inquiry.getContact(),
+                inquiry.getCreatedAt(),
+                inquiry.getResolvedAt());
+    }
+}

--- a/src/main/java/inu/timetable/dto/InquiryCreateRequest.java
+++ b/src/main/java/inu/timetable/dto/InquiryCreateRequest.java
@@ -1,0 +1,6 @@
+package inu.timetable.dto;
+
+public record InquiryCreateRequest(
+        String content,
+        String contact) {
+}

--- a/src/main/java/inu/timetable/entity/UserInquiry.java
+++ b/src/main/java/inu/timetable/entity/UserInquiry.java
@@ -1,0 +1,56 @@
+package inu.timetable.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 사이트 내 문의. resolved_at 이 NULL 이면 미처리 상태다.
+ * 비로그인 문의를 허용하므로 user_id 는 NULL 일 수 있고,
+ * 조회 시 User 연관을 로딩할 일이 없어 user_id 컬럼만 매핑한다(FK 는 DB 마이그레이션에서 보장).
+ */
+@Entity
+@Table(
+        name = "user_inquiries",
+        indexes = @Index(name = "idx_user_inquiries_resolved_created", columnList = "resolved_at, created_at"))
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserInquiry {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Column(length = 100)
+    private String contact;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "resolved_at")
+    private LocalDateTime resolvedAt;
+
+    public void resolve(LocalDateTime resolvedAt) {
+        if (this.resolvedAt == null) {
+            this.resolvedAt = resolvedAt;
+        }
+    }
+}

--- a/src/main/java/inu/timetable/repository/UserInquiryRepository.java
+++ b/src/main/java/inu/timetable/repository/UserInquiryRepository.java
@@ -1,0 +1,15 @@
+package inu.timetable.repository;
+
+import inu.timetable.entity.UserInquiry;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserInquiryRepository extends JpaRepository<UserInquiry, Long> {
+
+    Page<UserInquiry> findAllByOrderByCreatedAtDescIdDesc(Pageable pageable);
+
+    Page<UserInquiry> findAllByResolvedAtIsNullOrderByCreatedAtDescIdDesc(Pageable pageable);
+
+    long countByResolvedAtIsNull();
+}

--- a/src/main/java/inu/timetable/service/UserInquiryService.java
+++ b/src/main/java/inu/timetable/service/UserInquiryService.java
@@ -23,7 +23,6 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 /**

--- a/src/main/java/inu/timetable/service/UserInquiryService.java
+++ b/src/main/java/inu/timetable/service/UserInquiryService.java
@@ -1,0 +1,127 @@
+package inu.timetable.service;
+
+import inu.timetable.dto.AdminInquiryPageResponse;
+import inu.timetable.dto.AdminInquiryResponse;
+import inu.timetable.entity.User;
+import inu.timetable.entity.UserInquiry;
+import inu.timetable.repository.UserInquiryRepository;
+import inu.timetable.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+/**
+ * 사이트 내 문의 접수/관리.
+ * 기존 인스타그램 DM 링크 문의를 대체하며, 비로그인 문의도 허용한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class UserInquiryService {
+
+    private static final String RATE_LIMIT_NAMESPACE = "INQUIRY";
+    private static final int MAX_CONTENT_LENGTH = 1000;
+    private static final int MAX_CONTACT_LENGTH = 100;
+
+    private final UserInquiryRepository userInquiryRepository;
+    private final UserRepository userRepository;
+    private final LoginAttemptStore loginAttemptStore;
+    private final Clock clock;
+
+    @Value("${inquiry.rate-limit.max-submissions:10}")
+    private int maxSubmissions;
+
+    @Value("${inquiry.rate-limit.block-minutes:60}")
+    private long blockMinutes;
+
+    @Transactional
+    public void submit(Long userId, String rawContent, String rawContact, HttpServletRequest request) {
+        String content = rawContent == null ? "" : rawContent.trim();
+        if (content.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "문의 내용을 입력해주세요.");
+        }
+        if (content.length() > MAX_CONTENT_LENGTH) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "문의 내용은 " + MAX_CONTENT_LENGTH + "자 이하로 입력해주세요.");
+        }
+        String contact = rawContact == null || rawContact.isBlank() ? null : rawContact.trim();
+        if (contact != null && contact.length() > MAX_CONTACT_LENGTH) {
+            throw new ResponseStatusException(
+                    HttpStatus.BAD_REQUEST, "연락처는 " + MAX_CONTACT_LENGTH + "자 이하로 입력해주세요.");
+        }
+
+        // 비로그인도 접수 가능한 공개 엔드포인트라 IP 단위로 접수 횟수를 제한한다.
+        // LoginAttemptStore 의 실패 카운터를 '접수 카운터'로 재사용해 인스턴스 간에도 공유된다.
+        String clientIp = request.getRemoteAddr();
+        if (loginAttemptStore.isBlocked(RATE_LIMIT_NAMESPACE, clientIp)) {
+            throw new ResponseStatusException(
+                    HttpStatus.TOO_MANY_REQUESTS, "문의가 너무 자주 접수되었습니다. 잠시 후 다시 시도해주세요.");
+        }
+        loginAttemptStore.recordFailure(
+                RATE_LIMIT_NAMESPACE, clientIp, maxSubmissions, Duration.ofMinutes(blockMinutes));
+
+        userInquiryRepository.save(UserInquiry.builder()
+                .userId(userId)
+                .content(content)
+                .contact(contact)
+                .createdAt(LocalDateTime.now(clock))
+                .build());
+    }
+
+    @Transactional(readOnly = true)
+    public AdminInquiryPageResponse getInquiries(int page, int size, boolean unresolvedOnly) {
+        Pageable pageable = PageRequest.of(page, size);
+        Page<UserInquiry> inquiryPage = unresolvedOnly
+                ? userInquiryRepository.findAllByResolvedAtIsNullOrderByCreatedAtDescIdDesc(pageable)
+                : userInquiryRepository.findAllByOrderByCreatedAtDescIdDesc(pageable);
+
+        Map<Long, String> usernamesById = loadUsernames(inquiryPage.getContent());
+        List<AdminInquiryResponse> inquiries = inquiryPage.getContent().stream()
+                .map(inquiry -> AdminInquiryResponse.fromEntity(
+                        inquiry, usernamesById.get(inquiry.getUserId())))
+                .toList();
+
+        return new AdminInquiryPageResponse(
+                inquiries,
+                page,
+                size,
+                inquiryPage.getTotalElements(),
+                inquiryPage.getTotalPages(),
+                userInquiryRepository.countByResolvedAtIsNull());
+    }
+
+    @Transactional
+    public void resolve(Long inquiryId) {
+        UserInquiry inquiry = userInquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "문의를 찾을 수 없습니다."));
+        inquiry.resolve(LocalDateTime.now(clock));
+    }
+
+    private Map<Long, String> loadUsernames(List<UserInquiry> inquiries) {
+        List<Long> userIds = inquiries.stream()
+                .map(UserInquiry::getUserId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+        if (userIds.isEmpty()) {
+            return Map.of();
+        }
+        return userRepository.findAllById(userIds).stream()
+                .collect(Collectors.toMap(User::getId, User::getUsername, (first, second) -> first));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -86,6 +86,12 @@ user:
     max-failures: ${USER_LOGIN_MAX_FAILURES:5}
     lock-minutes: ${USER_LOGIN_LOCK_MINUTES:10}
 
+inquiry:
+  rate-limit:
+    # 비로그인 허용 엔드포인트라 IP 당 접수 횟수를 제한한다.
+    max-submissions: ${INQUIRY_RATE_LIMIT_MAX_SUBMISSIONS:10}
+    block-minutes: ${INQUIRY_RATE_LIMIT_BLOCK_MINUTES:60}
+
 subject:
   cache:
     # Local development/tests use Caffeine. Cloud Run uses Caffeine L1 + Redis L2.

--- a/src/main/resources/db/migration/V20260728_01__create_user_inquiries.sql
+++ b/src/main/resources/db/migration/V20260728_01__create_user_inquiries.sql
@@ -1,0 +1,16 @@
+-- 사이트 내 문의 테이블.
+-- 기존에는 인스타그램 DM 링크로 문의를 받았으나, 앱 안에서 직접 문의를 남기고
+-- 관리자가 admin 페이지에서 확인/처리할 수 있도록 저장한다.
+-- 비로그인 문의도 허용하므로 user_id 는 NULL 가능, 탈퇴 시에는 문의만 남기고 연결을 끊는다.
+CREATE TABLE IF NOT EXISTS user_inquiries (
+    id BIGSERIAL PRIMARY KEY,
+    user_id BIGINT REFERENCES users(id) ON DELETE SET NULL,
+    content VARCHAR(1000) NOT NULL,
+    contact VARCHAR(100),
+    created_at TIMESTAMP NOT NULL,
+    resolved_at TIMESTAMP
+);
+
+-- 관리자 문의 목록 조회(미처리 필터 + 최신순)를 커버하는 인덱스.
+CREATE INDEX IF NOT EXISTS idx_user_inquiries_resolved_created
+    ON user_inquiries (resolved_at, created_at DESC);

--- a/src/main/resources/templates/admin/dashboard.html
+++ b/src/main/resources/templates/admin/dashboard.html
@@ -49,7 +49,7 @@
           <button data-days="14" class="active">14일</button>
           <button data-days="30">30일</button>
         </div>
-        <nav><a href="/admin/upload">업로드</a><a href="/admin/login">로그아웃</a></nav>
+        <nav><a href="/admin/upload">업로드</a><a href="/admin/inquiries">문의</a><a href="/admin/login">로그아웃</a></nav>
       </div>
     </header>
 

--- a/src/main/resources/templates/admin/inquiries.html
+++ b/src/main/resources/templates/admin/inquiries.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <meta name="_csrf" th:content="${_csrf.token}" />
+  <meta name="_csrf_header" th:content="${_csrf.headerName}" />
+  <title>문의 관리 · INU 시간표</title>
+  <style>
+    :root { --bg:#f8fafc; --card:#ffffff; --ink:#0f172a; --muted:#64748b; --line:#e2e8f0; --brand:#2563eb; --ok:#16a34a; }
+    * { box-sizing: border-box; }
+    body { margin:0; background:var(--bg); color:var(--ink);
+      font-family:'Pretendard','Apple SD Gothic Neo','Malgun Gothic',system-ui,sans-serif; }
+    .wrap { max-width:1100px; margin:0 auto; padding:24px 16px 64px; }
+    header { display:flex; align-items:center; justify-content:space-between; gap:12px; margin-bottom:20px; flex-wrap:wrap; }
+    h1 { font-size:20px; font-weight:800; margin:0; }
+    .sub { color:var(--muted); font-size:13px; margin-top:2px; }
+    nav a { color:var(--muted); text-decoration:none; font-size:13px; font-weight:600; margin-left:12px; }
+    nav a:hover { color:var(--ink); }
+    .filter { display:inline-flex; gap:4px; background:#eef2f7; border-radius:999px; padding:3px; }
+    .filter button { border:0; background:transparent; color:var(--muted); font-weight:700; font-size:13px;
+      padding:6px 12px; border-radius:999px; cursor:pointer; }
+    .filter button.active { background:var(--card); color:var(--brand); box-shadow:0 1px 2px rgba(15,23,42,.12); }
+    .panel { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:18px; }
+    table { width:100%; border-collapse:collapse; font-size:14px; }
+    th, td { text-align:left; padding:10px 6px; border-bottom:1px solid var(--line); vertical-align:top; }
+    th { color:var(--muted); font-size:12px; font-weight:700; white-space:nowrap; }
+    td.content { white-space:pre-wrap; word-break:break-word; max-width:480px; }
+    td.nowrap { white-space:nowrap; }
+    .muted { color:var(--muted); font-size:13px; }
+    .empty { color:var(--muted); font-size:13px; padding:24px 0; text-align:center; }
+    .badge { display:inline-block; font-size:12px; font-weight:700; border-radius:999px; padding:3px 10px; }
+    .badge.open { background:#fef3c7; color:#92400e; }
+    .badge.done { background:#dcfce7; color:#166534; }
+    .resolveBtn { border:1px solid var(--line); background:var(--card); color:var(--brand); font-weight:700;
+      font-size:12px; padding:5px 10px; border-radius:8px; cursor:pointer; }
+    .resolveBtn:hover { background:#eff6ff; }
+    .pager { display:flex; align-items:center; justify-content:center; gap:12px; margin-top:14px; }
+    .pager button { border:1px solid var(--line); background:var(--card); color:var(--ink); font-weight:700;
+      font-size:13px; padding:6px 12px; border-radius:8px; cursor:pointer; }
+    .pager button:disabled { color:var(--muted); cursor:default; opacity:.5; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <header>
+      <div>
+        <h1>문의 관리</h1>
+        <div class="sub">미처리 <span id="unresolvedCount">–</span>건 · 전체 <span id="totalCount">–</span>건</div>
+      </div>
+      <div style="display:flex; align-items:center; gap:16px;">
+        <div class="filter" id="filter">
+          <button data-unresolved="true" class="active">미처리</button>
+          <button data-unresolved="false">전체</button>
+        </div>
+        <nav><a href="/admin/dashboard">대시보드</a><a href="/admin/upload">업로드</a><a href="/admin/login">로그아웃</a></nav>
+      </div>
+    </header>
+
+    <div class="panel">
+      <table id="inquiryTable">
+        <thead>
+          <tr>
+            <th style="width:60px;">#</th>
+            <th>내용</th>
+            <th>연락처</th>
+            <th>작성자</th>
+            <th>접수 시각</th>
+            <th style="width:110px;">상태</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+      <div class="empty" id="emptyMessage" style="display:none;">문의가 없습니다.</div>
+      <div class="pager">
+        <button id="prevBtn">이전</button>
+        <span class="muted" id="pageLabel">–</span>
+        <button id="nextBtn">다음</button>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    const PAGE_SIZE = 20;
+    let currentPage = 0;
+    let totalPages = 0;
+    let unresolvedOnly = true;
+
+    const csrfToken = document.querySelector('meta[name="_csrf"]').content;
+    const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
+
+    async function load() {
+      const res = await fetch(
+        `/admin/api/inquiries?page=${currentPage}&size=${PAGE_SIZE}&unresolvedOnly=${unresolvedOnly}`,
+        { credentials: 'same-origin' });
+      if (res.status === 401 || res.status === 403) { location.href = '/admin/login'; return; }
+      const d = await res.json();
+
+      totalPages = d.totalPages ?? 0;
+      document.getElementById('unresolvedCount').textContent = (d.unresolvedCount ?? 0).toLocaleString();
+      document.getElementById('totalCount').textContent =
+        unresolvedOnly ? '–' : (d.totalElements ?? 0).toLocaleString();
+      renderRows(d.inquiries || []);
+      renderPager();
+    }
+
+    function renderRows(rows) {
+      const tbody = document.querySelector('#inquiryTable tbody');
+      const empty = document.getElementById('emptyMessage');
+      const table = document.getElementById('inquiryTable');
+      tbody.innerHTML = '';
+      if (!rows.length) { table.style.display = 'none'; empty.style.display = 'block'; return; }
+      table.style.display = 'table'; empty.style.display = 'none';
+
+      rows.forEach(r => {
+        const tr = document.createElement('tr');
+        const writer = r.username ? escapeHtml(r.username) : '<span class="muted">비로그인</span>';
+        const status = r.resolvedAt
+          ? '<span class="badge done">처리됨</span>'
+          : `<span class="badge open">미처리</span> <button class="resolveBtn" data-id="${r.id}">처리</button>`;
+        tr.innerHTML = `
+          <td class="nowrap">${r.id}</td>
+          <td class="content">${escapeHtml(r.content)}</td>
+          <td class="nowrap">${r.contact ? escapeHtml(r.contact) : '<span class="muted">–</span>'}</td>
+          <td class="nowrap">${writer}</td>
+          <td class="nowrap muted">${formatDate(r.createdAt)}</td>
+          <td class="nowrap">${status}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
+
+    function renderPager() {
+      document.getElementById('pageLabel').textContent =
+        totalPages > 0 ? `${currentPage + 1} / ${totalPages}` : '0 / 0';
+      document.getElementById('prevBtn').disabled = currentPage <= 0;
+      document.getElementById('nextBtn').disabled = currentPage >= totalPages - 1;
+    }
+
+    async function resolve(id) {
+      const res = await fetch(`/admin/api/inquiries/${id}/resolve`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: { [csrfHeader]: csrfToken }
+      });
+      if (res.status === 401 || res.status === 403) { location.href = '/admin/login'; return; }
+      if (!res.ok) { alert('처리에 실패했습니다. 새로고침 후 다시 시도해주세요.'); return; }
+      load();
+    }
+
+    function formatDate(iso) {
+      if (!iso) return '–';
+      return iso.replace('T', ' ').slice(0, 16);
+    }
+
+    function escapeHtml(s) {
+      return String(s ?? '').replace(/[&<>"']/g, c =>
+        ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+    }
+
+    document.getElementById('filter').addEventListener('click', (e) => {
+      const btn = e.target.closest('button[data-unresolved]');
+      if (!btn) return;
+      document.querySelectorAll('#filter button').forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      unresolvedOnly = btn.dataset.unresolved === 'true';
+      currentPage = 0;
+      load();
+    });
+
+    document.querySelector('#inquiryTable tbody').addEventListener('click', (e) => {
+      const btn = e.target.closest('button.resolveBtn');
+      if (!btn) return;
+      btn.disabled = true;
+      resolve(Number(btn.dataset.id));
+    });
+
+    document.getElementById('prevBtn').addEventListener('click', () => {
+      if (currentPage > 0) { currentPage--; load(); }
+    });
+    document.getElementById('nextBtn').addEventListener('click', () => {
+      if (currentPage < totalPages - 1) { currentPage++; load(); }
+    });
+
+    load().catch(() => { document.getElementById('emptyMessage').textContent = '목록을 불러오지 못했습니다.';
+      document.getElementById('emptyMessage').style.display = 'block';
+      document.getElementById('inquiryTable').style.display = 'none'; });
+  </script>
+</body>
+</html>

--- a/src/main/resources/templates/admin/inquiries.html
+++ b/src/main/resources/templates/admin/inquiries.html
@@ -136,14 +136,18 @@
       document.getElementById('nextBtn').disabled = currentPage >= totalPages - 1;
     }
 
-    async function resolve(id) {
+    async function resolve(id, button) {
       const res = await fetch(`/admin/api/inquiries/${id}/resolve`, {
         method: 'POST',
         credentials: 'same-origin',
         headers: { [csrfHeader]: csrfToken }
       });
       if (res.status === 401 || res.status === 403) { location.href = '/admin/login'; return; }
-      if (!res.ok) { alert('처리에 실패했습니다. 새로고침 후 다시 시도해주세요.'); return; }
+      if (!res.ok) {
+        button.disabled = false;
+        alert('처리에 실패했습니다. 다시 시도해주세요.');
+        return;
+      }
       load();
     }
 
@@ -171,7 +175,7 @@
       const btn = e.target.closest('button.resolveBtn');
       if (!btn) return;
       btn.disabled = true;
-      resolve(Number(btn.dataset.id));
+      resolve(Number(btn.dataset.id), btn);
     });
 
     document.getElementById('prevBtn').addEventListener('click', () => {

--- a/src/test/java/inu/timetable/service/UserInquiryServiceTest.java
+++ b/src/test/java/inu/timetable/service/UserInquiryServiceTest.java
@@ -1,0 +1,158 @@
+package inu.timetable.service;
+
+import inu.timetable.dto.AdminInquiryPageResponse;
+import inu.timetable.entity.User;
+import inu.timetable.entity.UserInquiry;
+import inu.timetable.repository.UserInquiryRepository;
+import inu.timetable.repository.UserRepository;
+import jakarta.servlet.http.HttpServletRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class UserInquiryServiceTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-07-28T03:00:00Z"),
+            ZoneId.of("Asia/Seoul"));
+
+    private UserInquiryRepository userInquiryRepository;
+    private UserRepository userRepository;
+    private LoginAttemptStore loginAttemptStore;
+    private HttpServletRequest request;
+    private UserInquiryService userInquiryService;
+
+    @BeforeEach
+    void setUp() {
+        userInquiryRepository = mock(UserInquiryRepository.class);
+        userRepository = mock(UserRepository.class);
+        loginAttemptStore = mock(LoginAttemptStore.class);
+        request = mock(HttpServletRequest.class);
+        when(request.getRemoteAddr()).thenReturn("10.0.0.1");
+        userInquiryService = new UserInquiryService(
+                userInquiryRepository, userRepository, loginAttemptStore, FIXED_CLOCK);
+        ReflectionTestUtils.setField(userInquiryService, "maxSubmissions", 10);
+        ReflectionTestUtils.setField(userInquiryService, "blockMinutes", 60L);
+    }
+
+    @Test
+    void submitSavesTrimmedInquiryAndCountsSubmission() {
+        userInquiryService.submit(42L, "  시간표가 안 보여요  ", "  ", request);
+
+        ArgumentCaptor<UserInquiry> inquiryCaptor = ArgumentCaptor.forClass(UserInquiry.class);
+        verify(userInquiryRepository).save(inquiryCaptor.capture());
+        UserInquiry saved = inquiryCaptor.getValue();
+        assertThat(saved.getUserId()).isEqualTo(42L);
+        assertThat(saved.getContent()).isEqualTo("시간표가 안 보여요");
+        assertThat(saved.getContact()).isNull();
+        assertThat(saved.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 7, 28, 12, 0));
+        assertThat(saved.getResolvedAt()).isNull();
+        verify(loginAttemptStore).recordFailure("INQUIRY", "10.0.0.1", 10, Duration.ofMinutes(60));
+    }
+
+    @Test
+    void submitAllowsAnonymousInquiryWithContact() {
+        userInquiryService.submit(null, "회원가입이 안 돼요", "insta@someone", request);
+
+        ArgumentCaptor<UserInquiry> inquiryCaptor = ArgumentCaptor.forClass(UserInquiry.class);
+        verify(userInquiryRepository).save(inquiryCaptor.capture());
+        assertThat(inquiryCaptor.getValue().getUserId()).isNull();
+        assertThat(inquiryCaptor.getValue().getContact()).isEqualTo("insta@someone");
+    }
+
+    @Test
+    void submitRejectsBlankContent() {
+        assertThatThrownBy(() -> userInquiryService.submit(1L, "   ", null, request))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+        verify(userInquiryRepository, never()).save(any());
+    }
+
+    @Test
+    void submitRejectsTooLongContent() {
+        assertThatThrownBy(() -> userInquiryService.submit(1L, "a".repeat(1001), null, request))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+        verify(userInquiryRepository, never()).save(any());
+    }
+
+    @Test
+    void submitRejectsWhenRateLimited() {
+        when(loginAttemptStore.isBlocked("INQUIRY", "10.0.0.1")).thenReturn(true);
+
+        assertThatThrownBy(() -> userInquiryService.submit(1L, "문의합니다", null, request))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.TOO_MANY_REQUESTS));
+        verify(userInquiryRepository, never()).save(any());
+    }
+
+    @Test
+    void getInquiriesMapsUsernamesAndUnresolvedCount() {
+        UserInquiry memberInquiry = UserInquiry.builder()
+                .id(1L).userId(42L).content("질문 있어요")
+                .createdAt(LocalDateTime.of(2026, 7, 28, 11, 0)).build();
+        UserInquiry anonymousInquiry = UserInquiry.builder()
+                .id(2L).content("비로그인 문의")
+                .createdAt(LocalDateTime.of(2026, 7, 28, 10, 0)).build();
+        when(userInquiryRepository.findAllByOrderByCreatedAtDescIdDesc(PageRequest.of(0, 20)))
+                .thenReturn(new PageImpl<>(List.of(memberInquiry, anonymousInquiry), PageRequest.of(0, 20), 2));
+        when(userRepository.findAllById(anyList()))
+                .thenReturn(List.of(User.builder().id(42L).username("student").password("pw").build()));
+        when(userInquiryRepository.countByResolvedAtIsNull()).thenReturn(2L);
+
+        AdminInquiryPageResponse response = userInquiryService.getInquiries(0, 20, false);
+
+        assertThat(response.inquiries()).hasSize(2);
+        assertThat(response.inquiries().get(0).username()).isEqualTo("student");
+        assertThat(response.inquiries().get(1).username()).isNull();
+        assertThat(response.unresolvedCount()).isEqualTo(2L);
+        assertThat(response.totalElements()).isEqualTo(2L);
+    }
+
+    @Test
+    void resolveMarksInquiryResolvedOnce() {
+        UserInquiry inquiry = UserInquiry.builder()
+                .id(1L).content("문의").createdAt(LocalDateTime.of(2026, 7, 27, 9, 0)).build();
+        when(userInquiryRepository.findById(1L)).thenReturn(Optional.of(inquiry));
+
+        userInquiryService.resolve(1L);
+        assertThat(inquiry.getResolvedAt()).isEqualTo(LocalDateTime.of(2026, 7, 28, 12, 0));
+
+        // 이미 처리된 문의는 처리 시각을 덮어쓰지 않는다.
+        ReflectionTestUtils.setField(inquiry, "resolvedAt", LocalDateTime.of(2026, 7, 27, 10, 0));
+        userInquiryService.resolve(1L);
+        assertThat(inquiry.getResolvedAt()).isEqualTo(LocalDateTime.of(2026, 7, 27, 10, 0));
+    }
+
+    @Test
+    void resolveRejectsUnknownInquiry() {
+        when(userInquiryRepository.findById(eq(99L))).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> userInquiryService.resolve(99L))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        e -> assertThat(e.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
+    }
+}


### PR DESCRIPTION
## 개요
기존에 푸터의 "문의하기"가 인스타그램 DM 링크로 연결되던 것을 대체하기 위해, 앱 안에서 직접 문의를 남기고 관리자가 확인/처리할 수 있는 백엔드 기능을 추가합니다. (프론트 변경은 `inu_timetable_front`의 같은 이름 브랜치 PR 참고)

## 변경 사항
- **문의 접수 API** `POST /api/inquiries` (permitAll, CSRF ignore)
  - 비로그인 접수 허용, 로그인 상태면 작성자(user_id) 자동 기록
  - 내용 1000자 / 연락처(선택) 100자 검증
  - 공개 엔드포인트라 IP당 접수 횟수 제한(기본 10회, 초과 시 60분 차단) — 기존 `LoginAttemptStore`(JDBC) 재사용으로 인스턴스 간 공유
- **관리자 문의함**
  - `/admin/inquiries` 페이지: 미처리/전체 필터, 페이징, 처리 완료 버튼 (대시보드 네비에 링크 추가)
  - `GET /admin/api/inquiries`, `POST /admin/api/inquiries/{id}/resolve` (AdminAccessGuard)
- **DB**: `user_inquiries` 테이블 Flyway 마이그레이션 (비로그인 문의는 user_id NULL, 탈퇴 시 ON DELETE SET NULL)
- **설정**: `inquiry.rate-limit.*` 프로퍼티 추가 (환경변수로 조정 가능)

## 테스트
- `UserInquiryServiceTest` 8건 신규 (접수/검증/레이트리밋/관리자 목록/처리)
- 전체 테스트 스위트 통과 (`./gradlew test` BUILD SUCCESSFUL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LsfPaPnM9bVcZYi3XHajfL

---
_Generated by [Claude Code](https://claude.ai/code/session_01LsfPaPnM9bVcZYi3XHajfL)_