### PR TITLE
fix: 강의실 Flyway 마이그레이션 버전 충돌 해소

### DIFF
--- a/src/main/resources/db/migration/V20260728_02__create_schedule_room_segments.sql
+++ b/src/main/resources/db/migration/V20260728_02__create_schedule_room_segments.sql
@@ -1,3 +1,4 @@
+-- V20260728_01 is reserved for the user inquiries migration.
 CREATE TABLE IF NOT EXISTS schedule_room_segments (
     id BIGSERIAL PRIMARY KEY,
     schedule_id BIGINT NOT NULL,


### PR DESCRIPTION
## 원인

`V20260728_01` 버전을 문의 기능과 강의실 구간 기능이 동시에 사용해 Flyway가 애플리케이션 시작을 차단했습니다. 이로 인해 Cloud Run 후보 리비전 생성이 실패했습니다.

## 변경 사항

- 강의실 구간 마이그레이션을 `V20260728_01`에서 `V20260728_02`로 변경
- `V20260728_01`이 문의 기능에 예약되어 있음을 주석으로 명시

## 영향

- 기존 운영 리비전과 데이터에는 변경 없음
- 신규 배포 시 문의 기능 마이그레이션 다음에 강의실 구간 테이블이 생성됨

## 검증

- Flyway 마이그레이션 버전 중복 없음
- `./gradlew clean test bootJar` 통과