### PR TITLE
fix: 공식 과목 변경 시 사용자 시간표 안전 조정

### DIFF
--- a/src/main/java/inu/timetable/repository/UserNotificationRepository.java
+++ b/src/main/java/inu/timetable/repository/UserNotificationRepository.java
@@ -15,6 +15,11 @@ public interface UserNotificationRepository extends JpaRepository<UserNotificati
 
     List<UserNotification> findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(Long userId);
 
+    @Query("SELECT DISTINCT n.userId FROM UserNotification n " +
+           "WHERE n.userId IN :userIds AND n.message = :message AND n.readAt IS NULL")
+    List<Long> findUserIdsWithUnreadMessage(@Param("userIds") List<Long> userIds,
+                                            @Param("message") String message);
+
     @Modifying(clearAutomatically = true)
     @Query("UPDATE UserNotification n SET n.readAt = :readAt " +
            "WHERE n.userId = :userId AND n.readAt IS NULL")

--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -35,7 +35,10 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     @Query("DELETE FROM UserTimetable ut WHERE ut.user.id = :userId AND ut.subject.id = :subjectId")
     int deleteAllByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
     
-    @Query("SELECT DISTINCT ut FROM UserTimetable ut JOIN FETCH ut.subject s WHERE ut.user.id = :userId AND ut.semester = :semester")
+    @Query("SELECT DISTINCT ut FROM UserTimetable ut " +
+           "JOIN FETCH ut.subject s " +
+           "LEFT JOIN FETCH s.schedules " +
+           "WHERE ut.user.id = :userId AND ut.semester = :semester")
     List<UserTimetable> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
 
     // 시간 변경 충돌 검사용: 특정 과목을 해당 학기 시간표에 담아둔 모든 유저 항목을 조회한다.
@@ -43,6 +46,17 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
            "WHERE ut.subject.id = :subjectId AND ut.semester = :semester")
     List<UserTimetable> findAllBySubjectIdAndSemesterWithUser(@Param("subjectId") Long subjectId,
                                                               @Param("semester") String semester);
+
+    @Query("SELECT DISTINCT ut.user.id FROM UserTimetable ut " +
+           "WHERE ut.subject.id IN :subjectIds AND ut.semester = :semester")
+    List<Long> findDistinctUserIdsBySubjectIdsAndSemester(@Param("subjectIds") List<Long> subjectIds,
+                                                          @Param("semester") String semester);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM UserTimetable ut " +
+           "WHERE ut.subject.id IN :subjectIds AND ut.semester = :semester")
+    int deleteAllBySubjectIdsAndSemester(@Param("subjectIds") List<Long> subjectIds,
+                                         @Param("semester") String semester);
 
     @Query("SELECT ut.subject.id AS subjectId, COUNT(DISTINCT ut.user.id) AS timetableAddCount " +
            "FROM UserTimetable ut " +

--- a/src/main/java/inu/timetable/repository/WishlistRepository.java
+++ b/src/main/java/inu/timetable/repository/WishlistRepository.java
@@ -24,6 +24,7 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
            "JOIN FETCH w.subject s " +
            "LEFT JOIN FETCH s.schedules " +
            "WHERE w.user.id = :userId AND w.semester = :semester " +
+           "AND s.active = true " +
            "ORDER BY w.priority")
     List<WishlistItem> findByUserIdAndSemesterWithSubjectAndSchedules(@Param("userId") Long userId, @Param("semester") String semester);
     
@@ -41,6 +42,11 @@ public interface WishlistRepository extends JpaRepository<WishlistItem, Long> {
     @Modifying
     @Query("DELETE FROM WishlistItem w WHERE w.user.id = :userId AND w.subject.id = :subjectId")
     void deleteByUserIdAndSubjectId(@Param("userId") Long userId, @Param("subjectId") Long subjectId);
+
+    @Query("SELECT DISTINCT w.user.id FROM WishlistItem w " +
+           "WHERE w.subject.id IN :subjectIds AND w.semester = :semester")
+    List<Long> findDistinctUserIdsBySubjectIdsAndSemester(@Param("subjectIds") List<Long> subjectIds,
+                                                          @Param("semester") String semester);
 
     @Query("SELECT w.subject.id AS subjectId, COUNT(w.id) AS wishlistCount " +
            "FROM WishlistItem w " +

--- a/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
+++ b/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
@@ -87,9 +87,13 @@ public class OfficialSubjectImportService {
             }
         }
 
-        // 시간표가 바뀐 과목은 이미 담아둔 유저 시간표와 겹칠 수 있으므로 같은 트랜잭션에서 충돌을 해소한다.
-        timetableConflictResolutionService.resolveScheduleConflicts(
-                timeChangedSubjects(diff, subjectsToSave), normalizedSemester);
+        // 변경 영향을 받은 유저에게 알리고, 새 시간과 충돌하는 항목 및 미개설 과목을
+        // 같은 트랜잭션에서 시간표로부터 제거한다.
+        timetableConflictResolutionService.reconcileImportChanges(
+                modifiedSubjects(diff, subjectsToSave),
+                timeChangedSubjects(diff, subjectsToSave),
+                deactivateMissing ? diff.removed() : List.of(),
+                normalizedSemester);
 
         subjectUpdateLogService.record(
                 normalizedSemester,
@@ -108,8 +112,19 @@ public class OfficialSubjectImportService {
                 .filter(item -> item.getChangedFields().contains("시간표"))
                 .map(OfficialSubjectImportResponse.ModifiedSubjectImportItem::getId)
                 .collect(Collectors.toSet());
-        return subjectsToSave.stream()
-                .filter(subject -> subject.getId() != null && timeChangedSubjectIds.contains(subject.getId()))
+        return subjectsWithIds(subjectsToSave, timeChangedSubjectIds);
+    }
+
+    private List<Subject> modifiedSubjects(ImportDiff diff, List<Subject> subjectsToSave) {
+        Set<Long> modifiedSubjectIds = diff.modifiedSubjects().stream()
+                .map(OfficialSubjectImportResponse.ModifiedSubjectImportItem::getId)
+                .collect(Collectors.toSet());
+        return subjectsWithIds(subjectsToSave, modifiedSubjectIds);
+    }
+
+    private List<Subject> subjectsWithIds(List<Subject> subjects, Set<Long> subjectIds) {
+        return subjects.stream()
+                .filter(subject -> subject.getId() != null && subjectIds.contains(subject.getId()))
                 .toList();
     }
 

--- a/src/main/java/inu/timetable/service/TimetableConflictResolutionService.java
+++ b/src/main/java/inu/timetable/service/TimetableConflictResolutionService.java
@@ -6,6 +6,7 @@ import inu.timetable.entity.UserNotification;
 import inu.timetable.entity.UserTimetable;
 import inu.timetable.repository.UserNotificationRepository;
 import inu.timetable.repository.UserTimetableRepository;
+import inu.timetable.repository.WishlistRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,78 +14,202 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 /**
- * 공식 엑셀 반영으로 과목 시간이 바뀌었을 때, 그 과목을 담아둔 유저 시간표에서
- * 새 시간이 다른 과목과 겹치면 해당 과목을 시간표에서 제거하고 1회성 알림을 남긴다.
- * 겹치지 않으면 시간만 바뀐 채로 유지한다.
+ * 공식 과목 데이터 변경을 유저 시간표와 위시리스트에 안전하게 반영한다.
+ * 변경된 시간 때문에 충돌하는 과목은 시간표에서 제거하고, 변경 영향을 받은 유저에게
+ * 로그인 후 한 번 확인할 수 있는 알림을 남긴다.
  */
 @Service
 @RequiredArgsConstructor
 @Slf4j
 public class TimetableConflictResolutionService {
 
+    static final String SUBJECT_CHANGE_NOTICE =
+            "강의계획서가 변경되어 충돌이 생겼을 경우 과목은 시간표에서 제외되었습니다.";
+
     private final UserTimetableRepository userTimetableRepository;
+    private final WishlistRepository wishlistRepository;
     private final UserNotificationRepository userNotificationRepository;
     private final Clock clock;
 
     /**
-     * @param timeChangedSubjects 시간표가 변경된 과목들(스케줄은 이미 '새' 시간으로 갱신된 상태)
-     * @param semester            반영 대상 학기
-     * @return 시간표에서 제거된 항목 수
+     * 스케줄은 이미 새 값으로 갱신되고, 폐강 과목은 active=false가 된 상태에서 호출한다.
+     *
+     * <p>충돌 판정은 삭제 전 시간표 스냅샷을 기준으로 한 번에 수행한다. 따라서 변경된 두 과목이
+     * 서로 충돌하면 처리 순서와 관계없이 두 과목을 모두 제외해 결과 시간표에 충돌이 남지 않는다.</p>
+     */
+    @Transactional
+    public ReconciliationResult reconcileImportChanges(
+            List<Subject> modifiedSubjects,
+            List<Subject> timeChangedSubjects,
+            List<Subject> deactivatedSubjects,
+            String semester) {
+        List<Long> modifiedSubjectIds = subjectIds(modifiedSubjects);
+        List<Long> timeChangedSubjectIds = subjectIds(timeChangedSubjects);
+        List<Long> deactivatedSubjectIds = subjectIds(deactivatedSubjects);
+
+        Set<Long> affectedSubjectIds = new LinkedHashSet<>(modifiedSubjectIds);
+        affectedSubjectIds.addAll(deactivatedSubjectIds);
+        Set<Long> affectedUserIds = findAffectedUserIds(new ArrayList<>(affectedSubjectIds), semester);
+
+        int deactivatedRemovedCount = deactivatedSubjectIds.isEmpty()
+                ? 0
+                : userTimetableRepository.deleteAllBySubjectIdsAndSemester(deactivatedSubjectIds, semester);
+        // 없어질 과목과의 겹침 때문에 정상 개설 과목까지 함께 빠지는 일을 막기 위해
+        // 미개설 항목을 먼저 제거한 뒤 남은 시간표에서 충돌을 판정한다.
+        int conflictRemovedCount = removeConflictingChangedEntries(timeChangedSubjectIds, semester);
+        int notifiedUserCount = createNotifications(affectedUserIds);
+
+        if (!affectedUserIds.isEmpty()) {
+            log.info(
+                    "공식 과목 변경을 유저 데이터에 반영했습니다. semester={}, affectedUsers={}, "
+                            + "conflictRemoved={}, deactivatedRemoved={}, notifications={}",
+                    semester,
+                    affectedUserIds.size(),
+                    conflictRemovedCount,
+                    deactivatedRemovedCount,
+                    notifiedUserCount);
+        }
+
+        return new ReconciliationResult(
+                conflictRemovedCount,
+                deactivatedRemovedCount,
+                notifiedUserCount);
+    }
+
+    /**
+     * 기존 호출부 호환용. 시간 변경 과목을 전체 변경 과목으로 간주한다.
      */
     @Transactional
     public int resolveScheduleConflicts(List<Subject> timeChangedSubjects, String semester) {
-        int removedCount = 0;
-        for (Subject subject : timeChangedSubjects) {
-            removedCount += resolveForSubject(subject, semester);
-        }
-        if (removedCount > 0) {
-            log.info("시간 변경 충돌로 유저 시간표 {}건을 제거하고 알림을 생성했습니다. semester={}", removedCount, semester);
-        }
-        return removedCount;
+        return reconcileImportChanges(
+                timeChangedSubjects,
+                timeChangedSubjects,
+                List.of(),
+                semester).conflictRemovedCount();
     }
 
-    private int resolveForSubject(Subject subject, String semester) {
-        List<UserTimetable> entries =
-                userTimetableRepository.findAllBySubjectIdAndSemesterWithUser(subject.getId(), semester);
+    private Set<Long> findAffectedUserIds(List<Long> affectedSubjectIds, String semester) {
+        Set<Long> userIds = new LinkedHashSet<>();
+        if (affectedSubjectIds.isEmpty()) {
+            return userIds;
+        }
+        userIds.addAll(userTimetableRepository
+                .findDistinctUserIdsBySubjectIdsAndSemester(affectedSubjectIds, semester));
+        userIds.addAll(wishlistRepository
+                .findDistinctUserIdsBySubjectIdsAndSemester(affectedSubjectIds, semester));
+        return userIds;
+    }
 
-        int removed = 0;
-        for (UserTimetable entry : entries) {
-            Long userId = entry.getUser().getId();
-            if (hasConflictWithOtherSubjects(userId, subject, semester)) {
-                userTimetableRepository.delete(entry);
-                userNotificationRepository.save(UserNotification.builder()
-                        .userId(userId)
-                        .message(conflictMessage(subject.getSubjectName()))
-                        .createdAt(LocalDateTime.now(clock))
-                        .build());
-                removed++;
+    private int removeConflictingChangedEntries(List<Long> timeChangedSubjectIds, String semester) {
+        if (timeChangedSubjectIds.isEmpty()) {
+            return 0;
+        }
+
+        Set<Long> changedSubjectIds = Set.copyOf(timeChangedSubjectIds);
+        List<Long> candidateUserIds = userTimetableRepository
+                .findDistinctUserIdsBySubjectIdsAndSemester(timeChangedSubjectIds, semester);
+        List<UserTimetable> entriesToRemove = new ArrayList<>();
+
+        for (Long userId : candidateUserIds) {
+            List<UserTimetable> snapshot =
+                    userTimetableRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
+            for (UserTimetable changedEntry : snapshot) {
+                if (!changedSubjectIds.contains(changedEntry.getSubject().getId())) {
+                    continue;
+                }
+                boolean hasConflict = snapshot.stream()
+                        .filter(otherEntry -> !Objects.equals(otherEntry.getId(), changedEntry.getId()))
+                        .anyMatch(otherEntry -> overlaps(
+                                changedEntry.getSubject().getSchedules(),
+                                otherEntry.getSubject().getSchedules()));
+                if (hasConflict) {
+                    entriesToRemove.add(changedEntry);
+                }
             }
         }
-        return removed;
+
+        userTimetableRepository.deleteAll(entriesToRemove);
+        return entriesToRemove.size();
     }
 
-    private boolean hasConflictWithOtherSubjects(Long userId, Subject changedSubject, String semester) {
-        List<UserTimetable> userEntries =
-                userTimetableRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
-        return userEntries.stream()
-                .map(UserTimetable::getSubject)
-                .filter(other -> !other.getId().equals(changedSubject.getId()))
-                .anyMatch(other -> overlaps(changedSubject.getSchedules(), other.getSchedules()));
+    private int createNotifications(Set<Long> affectedUserIds) {
+        if (affectedUserIds.isEmpty()) {
+            return 0;
+        }
+
+        List<Long> userIds = new ArrayList<>(affectedUserIds);
+        Set<Long> alreadyNotified = Set.copyOf(userNotificationRepository
+                .findUserIdsWithUnreadMessage(userIds, SUBJECT_CHANGE_NOTICE));
+        LocalDateTime createdAt = LocalDateTime.now(clock);
+        List<UserNotification> notifications = userIds.stream()
+                .filter(userId -> !alreadyNotified.contains(userId))
+                .map(userId -> UserNotification.builder()
+                        .userId(userId)
+                        .message(SUBJECT_CHANGE_NOTICE)
+                        .createdAt(createdAt)
+                        .build())
+                .toList();
+        userNotificationRepository.saveAll(notifications);
+        return notifications.size();
+    }
+
+    private List<Long> subjectIds(List<Subject> subjects) {
+        if (subjects == null || subjects.isEmpty()) {
+            return List.of();
+        }
+        return subjects.stream()
+                .filter(Objects::nonNull)
+                .map(Subject::getId)
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
     }
 
     // 같은 요일이고 newStart < otherEnd AND newEnd > otherStart 이면 겹침으로 본다.
     private boolean overlaps(List<Schedule> newSchedules, List<Schedule> otherSchedules) {
+        if (newSchedules == null || otherSchedules == null) {
+            return false;
+        }
         return newSchedules.stream().anyMatch(changed -> otherSchedules.stream()
-                .anyMatch(other -> changed.getDayOfWeek() != null
-                        && changed.getDayOfWeek().equals(other.getDayOfWeek())
-                        && changed.getStartTime() < other.getEndTime()
-                        && changed.getEndTime() > other.getStartTime()));
+                .anyMatch(other -> overlaps(changed, other)));
     }
 
-    private String conflictMessage(String subjectName) {
-        return "'" + subjectName + "' 수업 시간이 변경되어 기존 시간표의 다른 과목과 겹쳐 시간표에서 제거했어요. 필요하면 다시 담아주세요.";
+    private boolean overlaps(Schedule changed, Schedule other) {
+        if (changed == null
+                || other == null
+                || changed.getDayOfWeek() == null
+                || changed.getStartTime() == null
+                || changed.getEndTime() == null
+                || other.getDayOfWeek() == null
+                || other.getStartTime() == null
+                || other.getEndTime() == null
+                || !changed.getDayOfWeek().equals(other.getDayOfWeek())) {
+            return false;
+        }
+
+        double changedStart = changed.getStartTime();
+        double changedEnd = changed.getEndTime();
+        double otherStart = other.getStartTime();
+        double otherEnd = other.getEndTime();
+        if (changedStart > changedEnd) {
+            changedEnd += 8.0;
+        }
+        if (otherStart > otherEnd) {
+            otherEnd += 8.0;
+        }
+        return changedStart < otherEnd && changedEnd > otherStart;
+    }
+
+    public record ReconciliationResult(
+            int conflictRemovedCount,
+            int deactivatedRemovedCount,
+            int notifiedUserCount) {
     }
 }

--- a/src/main/java/inu/timetable/service/TimetableService.java
+++ b/src/main/java/inu/timetable/service/TimetableService.java
@@ -41,6 +41,10 @@ public class TimetableService {
             
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> ApiException.notFound("과목을 찾을 수 없습니다."));
+
+        if (!Boolean.TRUE.equals(subject.getActive())) {
+            throw ApiException.conflict("현재 학기에 개설되지 않은 과목입니다.");
+        }
         
         // 같은 학기에 이미 추가된 과목인지 확인(다른 학기에는 같은 과목을 추가할 수 있다)
         if (userTimetableRepository.existsByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)) {

--- a/src/main/java/inu/timetable/service/WishlistService.java
+++ b/src/main/java/inu/timetable/service/WishlistService.java
@@ -41,6 +41,10 @@ public class WishlistService {
             
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> ApiException.notFound("과목을 찾을 수 없습니다."));
+
+        if (!Boolean.TRUE.equals(subject.getActive())) {
+            throw ApiException.conflict("현재 학기에 개설되지 않은 과목입니다.");
+        }
         
         // 같은 학기에 이미 담겨 있는지 확인(다른 학기에는 같은 과목을 담을 수 있다)
         if (wishlistRepository.existsByUserIdAndSubjectIdAndSemester(userId, subjectId, semester)) {

--- a/src/test/java/inu/timetable/service/InactiveSubjectGuardTest.java
+++ b/src/test/java/inu/timetable/service/InactiveSubjectGuardTest.java
@@ -1,0 +1,95 @@
+package inu.timetable.service;
+
+import inu.timetable.entity.Subject;
+import inu.timetable.entity.User;
+import inu.timetable.exception.ApiException;
+import inu.timetable.repository.SubjectRepository;
+import inu.timetable.repository.UserRepository;
+import inu.timetable.repository.UserTimetableRepository;
+import inu.timetable.repository.WishlistRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class InactiveSubjectGuardTest {
+
+    @Mock
+    private WishlistRepository wishlistRepository;
+
+    @Mock
+    private UserTimetableRepository userTimetableRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private SubjectRepository subjectRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    private WishlistService wishlistService;
+    private TimetableService timetableService;
+    private User user;
+    private Subject inactiveSubject;
+
+    @BeforeEach
+    void setUp() {
+        wishlistService = new WishlistService(wishlistRepository, userRepository, subjectRepository);
+        timetableService = new TimetableService(
+                userTimetableRepository,
+                userRepository,
+                subjectRepository,
+                eventPublisher);
+        user = User.builder().id(1L).username("student").password("encoded").build();
+        inactiveSubject = Subject.builder().id(10L).active(false).build();
+        when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+        when(subjectRepository.findById(10L)).thenReturn(Optional.of(inactiveSubject));
+    }
+
+    @Test
+    @DisplayName("미개설 과목은 위시리스트에 새로 추가할 수 없다")
+    void rejectsInactiveSubjectFromWishlist() {
+        assertThatThrownBy(() -> wishlistService.addToWishlist(1L, 10L, "2026-2", 3))
+                .isInstanceOf(ApiException.class)
+                .satisfies(error -> {
+                    ApiException apiException = (ApiException) error;
+                    org.assertj.core.api.Assertions.assertThat(apiException.getStatus())
+                            .isEqualTo(HttpStatus.CONFLICT);
+                    org.assertj.core.api.Assertions.assertThat(apiException.getMessage())
+                            .isEqualTo("현재 학기에 개설되지 않은 과목입니다.");
+                });
+
+        verify(wishlistRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    @DisplayName("미개설 과목은 시간표에 새로 추가할 수 없다")
+    void rejectsInactiveSubjectFromTimetable() {
+        assertThatThrownBy(() -> timetableService.addSubjectToTimetable(
+                1L, 10L, "2026-2", null))
+                .isInstanceOf(ApiException.class)
+                .satisfies(error -> {
+                    ApiException apiException = (ApiException) error;
+                    org.assertj.core.api.Assertions.assertThat(apiException.getStatus())
+                            .isEqualTo(HttpStatus.CONFLICT);
+                    org.assertj.core.api.Assertions.assertThat(apiException.getMessage())
+                            .isEqualTo("현재 학기에 개설되지 않은 과목입니다.");
+                });
+
+        verify(userTimetableRepository, never()).save(org.mockito.ArgumentMatchers.any());
+    }
+}

--- a/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
+++ b/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
@@ -102,13 +102,23 @@ class OfficialSubjectImportServiceTest {
 
         officialSubjectImportService.apply(sampleWorkbook(), "2026-1", true);
 
-        ArgumentCaptor<List<Subject>> captor = ArgumentCaptor.forClass(List.class);
-        verify(timetableConflictResolutionService).resolveScheduleConflicts(captor.capture(), eq("2026-1"));
-        assertThat(captor.getValue())
+        ArgumentCaptor<List<Subject>> modifiedCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Subject>> timeChangedCaptor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<Subject>> deactivatedCaptor = ArgumentCaptor.forClass(List.class);
+        verify(timetableConflictResolutionService).reconcileImportChanges(
+                modifiedCaptor.capture(),
+                timeChangedCaptor.capture(),
+                deactivatedCaptor.capture(),
+                eq("2026-1"));
+        assertThat(modifiedCaptor.getValue())
                 .extracting(Subject::getCourseCode)
                 .containsExactly("AI01001001");
+        assertThat(timeChangedCaptor.getValue())
+                .extracting(Subject::getCourseCode)
+                .containsExactly("AI01001001");
+        assertThat(deactivatedCaptor.getValue()).isEmpty();
         // 충돌 검사 대상 과목의 스케줄은 이미 '새' 시간으로 갱신되어 있어야 한다.
-        Subject passed = captor.getValue().get(0);
+        Subject passed = timeChangedCaptor.getValue().get(0);
         assertThat(passed.getSchedules())
                 .extracting(Schedule::getDayOfWeek)
                 .containsExactly("금");
@@ -129,6 +139,10 @@ class OfficialSubjectImportServiceTest {
         assertThat(response.getRemovedCount()).isEqualTo(1);
         verify(subjectRepository).saveAll(anyList());
         verify(eventPublisher).publishEvent(any(SubjectDataChangedEvent.class));
+        ArgumentCaptor<List<Subject>> deactivatedCaptor = ArgumentCaptor.forClass(List.class);
+        verify(timetableConflictResolutionService).reconcileImportChanges(
+                anyList(), anyList(), deactivatedCaptor.capture(), eq("2026-1"));
+        assertThat(deactivatedCaptor.getValue()).containsExactly(removed);
     }
 
     @Test

--- a/src/test/java/inu/timetable/service/TimetableConflictResolutionServiceTest.java
+++ b/src/test/java/inu/timetable/service/TimetableConflictResolutionServiceTest.java
@@ -5,10 +5,12 @@ import inu.timetable.entity.Subject;
 import inu.timetable.entity.User;
 import inu.timetable.entity.UserNotification;
 import inu.timetable.entity.UserTimetable;
+import inu.timetable.entity.WishlistItem;
 import inu.timetable.enums.ClassMethod;
 import inu.timetable.enums.SubjectType;
 import inu.timetable.repository.UserNotificationRepository;
 import inu.timetable.repository.UserTimetableRepository;
+import inu.timetable.repository.WishlistRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -62,6 +64,9 @@ class TimetableConflictResolutionServiceTest {
     private UserNotificationRepository userNotificationRepository;
 
     @Autowired
+    private WishlistRepository wishlistRepository;
+
+    @Autowired
     private TestEntityManager entityManager;
 
     private Subject changedSubject;
@@ -92,13 +97,14 @@ class TimetableConflictResolutionServiceTest {
         List<UserNotification> notifications = userNotificationRepository
                 .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(conflictUser.getId());
         assertThat(notifications).hasSize(1);
-        assertThat(notifications.get(0).getMessage()).contains("'자료구조'");
+        assertThat(notifications.get(0).getMessage())
+                .isEqualTo(TimetableConflictResolutionService.SUBJECT_CHANGE_NOTICE);
         assertThat(notifications.get(0).getReadAt()).isNull();
     }
 
     @Test
-    @DisplayName("새 시간이 겹치지 않는 유저는 시간표가 유지되고 알림도 생성되지 않는다")
-    void keepsNonConflictingEntryWithoutNotification() {
+    @DisplayName("새 시간이 겹치지 않는 유저는 시간표가 유지되고 변경 알림을 받는다")
+    void keepsNonConflictingEntryAndCreatesNotification() {
         User safeUser = persistUser();
         persistTimetableEntry(safeUser, changedSubject);
         persistTimetableEntry(safeUser, persistSubject("다른요일과목", "화", 5.0, 7.0));
@@ -114,11 +120,11 @@ class TimetableConflictResolutionServiceTest {
         assertThat(removedCount).isZero();
         assertThat(userTimetableRepository.findByUserIdAndSemester(safeUser.getId(), SEMESTER)).hasSize(3);
         assertThat(userNotificationRepository
-                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(safeUser.getId())).isEmpty();
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(safeUser.getId())).hasSize(1);
     }
 
     @Test
-    @DisplayName("여러 유저가 담아둔 경우 겹치는 유저만 제거되고 각자 알림을 받는다")
+    @DisplayName("여러 유저가 담아둔 경우 겹치는 유저만 제거되고 두 유저 모두 알림을 받는다")
     void resolvesPerUserIndependently() {
         User conflictUser = persistUser();
         persistTimetableEntry(conflictUser, changedSubject);
@@ -140,7 +146,147 @@ class TimetableConflictResolutionServiceTest {
         assertThat(userNotificationRepository
                 .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(conflictUser.getId())).hasSize(1);
         assertThat(userNotificationRepository
-                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(safeUser.getId())).isEmpty();
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(safeUser.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("시간이 변경된 두 과목이 서로 겹치면 처리 순서와 무관하게 둘 다 제거된다")
+    void removesBothChangedSubjectsWhenTheyConflictWithEachOther() {
+        User user = persistUser();
+        Subject anotherChangedSubject = persistSubject("운영체제", "월", 6.0, 8.0);
+        persistTimetableEntry(user, changedSubject);
+        persistTimetableEntry(user, anotherChangedSubject);
+        entityManager.flush();
+
+        TimetableConflictResolutionService.ReconciliationResult result =
+                timetableConflictResolutionService.reconcileImportChanges(
+                        List.of(changedSubject, anotherChangedSubject),
+                        List.of(changedSubject, anotherChangedSubject),
+                        List.of(),
+                        SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result.conflictRemovedCount()).isEqualTo(2);
+        assertThat(userTimetableRepository.findByUserIdAndSemester(user.getId(), SEMESTER)).isEmpty();
+        assertThat(userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(user.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("변경 과목을 위시리스트에만 담은 유저도 알림을 받고 항목은 유지된다")
+    void notifiesWishlistOnlyUserAndKeepsWishlistItem() {
+        User user = persistUser();
+        persistWishlistEntry(user, changedSubject);
+        entityManager.flush();
+
+        TimetableConflictResolutionService.ReconciliationResult result =
+                timetableConflictResolutionService.reconcileImportChanges(
+                        List.of(changedSubject),
+                        List.of(changedSubject),
+                        List.of(),
+                        SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result.conflictRemovedCount()).isZero();
+        assertThat(result.notifiedUserCount()).isEqualTo(1);
+        assertThat(wishlistRepository.findByUserIdAndSemester(user.getId(), SEMESTER)).hasSize(1);
+        assertThat(userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(user.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("미개설 과목은 시간표에서 제거하고 위시리스트 기록은 보존하되 조회에서는 숨긴다")
+    void removesDeactivatedSubjectFromTimetableAndHidesPreservedWishlistItem() {
+        User user = persistUser();
+        changedSubject.setActive(false);
+        persistTimetableEntry(user, changedSubject);
+        persistWishlistEntry(user, changedSubject);
+        entityManager.flush();
+
+        TimetableConflictResolutionService.ReconciliationResult result =
+                timetableConflictResolutionService.reconcileImportChanges(
+                        List.of(),
+                        List.of(),
+                        List.of(changedSubject),
+                        SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result.deactivatedRemovedCount()).isEqualTo(1);
+        assertThat(userTimetableRepository.findByUserIdAndSemester(user.getId(), SEMESTER)).isEmpty();
+        assertThat(wishlistRepository.findByUserIdAndSemester(user.getId(), SEMESTER)).hasSize(1);
+        assertThat(wishlistRepository
+                .findByUserIdAndSemesterWithSubjectAndSchedules(user.getId(), SEMESTER)).isEmpty();
+        assertThat(userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(user.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("변경 과목이 미개설 과목과만 겹치면 미개설 과목만 제거하고 변경 과목은 유지한다")
+    void keepsChangedSubjectWhenOnlyConflictIsDeactivatedSubject() {
+        User user = persistUser();
+        Subject deactivatedSubject = persistSubject("폐강과목", "월", 6.0, 8.0);
+        deactivatedSubject.setActive(false);
+        persistTimetableEntry(user, changedSubject);
+        persistTimetableEntry(user, deactivatedSubject);
+        entityManager.flush();
+
+        TimetableConflictResolutionService.ReconciliationResult result =
+                timetableConflictResolutionService.reconcileImportChanges(
+                        List.of(changedSubject),
+                        List.of(changedSubject),
+                        List.of(deactivatedSubject),
+                        SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result.deactivatedRemovedCount()).isEqualTo(1);
+        assertThat(result.conflictRemovedCount()).isZero();
+        assertThat(userTimetableRepository.findByUserIdAndSemester(user.getId(), SEMESTER))
+                .extracting(entry -> entry.getSubject().getSubjectName())
+                .containsExactly("자료구조");
+    }
+
+    @Test
+    @DisplayName("동일한 변경 알림이 아직 읽히지 않았다면 중복 생성하지 않는다")
+    void doesNotDuplicateUnreadNotification() {
+        User user = persistUser();
+        persistTimetableEntry(user, changedSubject);
+        entityManager.flush();
+
+        timetableConflictResolutionService.reconcileImportChanges(
+                List.of(changedSubject), List.of(), List.of(), SEMESTER);
+        timetableConflictResolutionService.reconcileImportChanges(
+                List.of(changedSubject), List.of(), List.of(), SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(userNotificationRepository
+                .findAllByUserIdAndReadAtIsNullOrderByCreatedAtAscIdAsc(user.getId())).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("시간 정보가 비어 있는 스케줄은 충돌 판정에서 제외한다")
+    void ignoresScheduleWithMissingTime() {
+        User user = persistUser();
+        Subject noTimeSubject = persistSubject("비동기수업", null, null, null);
+        persistTimetableEntry(user, changedSubject);
+        persistTimetableEntry(user, noTimeSubject);
+        entityManager.flush();
+
+        TimetableConflictResolutionService.ReconciliationResult result =
+                timetableConflictResolutionService.reconcileImportChanges(
+                        List.of(changedSubject),
+                        List.of(changedSubject),
+                        List.of(),
+                        SEMESTER);
+        entityManager.flush();
+        entityManager.clear();
+
+        assertThat(result.conflictRemovedCount()).isZero();
+        assertThat(userTimetableRepository.findByUserIdAndSemester(user.getId(), SEMESTER)).hasSize(2);
     }
 
     private User persistUser() {
@@ -152,7 +298,7 @@ class TimetableConflictResolutionServiceTest {
                 .build());
     }
 
-    private Subject persistSubject(String subjectName, String dayOfWeek, double startTime, double endTime) {
+    private Subject persistSubject(String subjectName, String dayOfWeek, Double startTime, Double endTime) {
         Subject subject = Subject.builder()
                 .courseCode("CC" + UUID.randomUUID().toString().substring(0, 8))
                 .semester(SEMESTER)
@@ -180,6 +326,16 @@ class TimetableConflictResolutionServiceTest {
                 .user(user)
                 .subject(subject)
                 .semester(SEMESTER)
+                .build());
+    }
+
+    private void persistWishlistEntry(User user, Subject subject) {
+        entityManager.persist(WishlistItem.builder()
+                .user(user)
+                .subject(subject)
+                .semester(SEMESTER)
+                .priority(3)
+                .isRequired(false)
                 .build());
     }
 }


### PR DESCRIPTION
## 변경 내용

- 공식 강의계획서 반영 시 변경 과목을 담은 사용자에게 1회성 알림을 생성합니다.
- 변경된 수업 시간으로 충돌이 생긴 과목은 삭제 전 스냅샷을 기준으로 순서와 무관하게 시간표에서 제외합니다.
- 공식 데이터에서 사라진 과목은 시간표에서 제거하고, 위시리스트 기록은 보존하되 활성 조회에서는 숨깁니다.
- 비활성 과목을 시간표나 위시리스트에 다시 추가하지 못하도록 차단합니다.
- 미읽음 동일 알림의 중복 생성을 방지합니다.

## 배경

2026학년도 2학기 강의계획서가 갱신되면서 일부 과목의 교수·시간 정보가 바뀌고 `삶과천문학`이 공식 목록에서 제외되었습니다. 기존 데이터와 새 시간표가 충돌해도 사용자 시간표에 충돌이 남거나, 변경 사실을 사용자가 알지 못하는 문제를 방지합니다.

## 사용자 영향

변경된 과목을 시간표 또는 위시리스트에 담은 사용자는 다음 로그인 시 안내를 한 번 받습니다.

> 강의계획서가 변경되어 충돌이 생겼을 경우 과목은 시간표에서 제외되었습니다.

충돌하지 않는 과목은 유지되고, 충돌한 변경 과목과 공식 목록에서 제외된 과목만 시간표에서 제거됩니다.

## 검증

- `./gradlew clean test`
- 공식 2026-2 데이터 기준 영향 사전 계산
- 2학기 전용 반영 파일 2,385행, 학수번호 중복 0, 타 학기 행 0, `삶과천문학` 행 0 확인
