### PR TITLE
fix: 과목 반영 변경을 충돌 정리 전에 저장

### DIFF
--- a/src/main/java/inu/timetable/repository/UserTimetableRepository.java
+++ b/src/main/java/inu/timetable/repository/UserTimetableRepository.java
@@ -52,7 +52,7 @@ public interface UserTimetableRepository extends JpaRepository<UserTimetable, Lo
     List<Long> findDistinctUserIdsBySubjectIdsAndSemester(@Param("subjectIds") List<Long> subjectIds,
                                                           @Param("semester") String semester);
 
-    @Modifying(clearAutomatically = true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query("DELETE FROM UserTimetable ut " +
            "WHERE ut.subject.id IN :subjectIds AND ut.semester = :semester")
     int deleteAllBySubjectIdsAndSemester(@Param("subjectIds") List<Long> subjectIds,

--- a/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
+++ b/src/main/java/inu/timetable/service/OfficialSubjectImportService.java
@@ -87,6 +87,10 @@ public class OfficialSubjectImportService {
             }
         }
 
+        // 아래 충돌 정리에서 bulk delete 후 영속성 컨텍스트를 비우므로, 과목/스케줄 변경과
+        // 미개설 active=false를 먼저 DB에 확정해 변경 내용이 함께 유실되지 않도록 한다.
+        subjectRepository.flush();
+
         // 변경 영향을 받은 유저에게 알리고, 새 시간과 충돌하는 항목 및 미개설 과목을
         // 같은 트랜잭션에서 시간표로부터 제거한다.
         timetableConflictResolutionService.reconcileImportChanges(

--- a/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
+++ b/src/test/java/inu/timetable/service/OfficialSubjectImportServiceTest.java
@@ -102,6 +102,7 @@ class OfficialSubjectImportServiceTest {
 
         officialSubjectImportService.apply(sampleWorkbook(), "2026-1", true);
 
+        verify(subjectRepository).flush();
         ArgumentCaptor<List<Subject>> modifiedCaptor = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<List<Subject>> timeChangedCaptor = ArgumentCaptor.forClass(List.class);
         ArgumentCaptor<List<Subject>> deactivatedCaptor = ArgumentCaptor.forClass(List.class);


### PR DESCRIPTION
## 변경 내용

- 공식 과목 변경과 스케줄을 충돌 정리 전에 명시적으로 DB에 반영합니다.
- 시간표 bulk delete가 실행되기 전 미처리 변경을 자동 flush하도록 이중 안전장치를 추가합니다.

## 원인

충돌 정리용 bulk delete가 영속성 컨텍스트를 비우면서, 같은 트랜잭션에 남아 있던 과목·스케줄·비활성화 변경이 저장되기 전에 유실될 수 있었습니다.

## 영향

첫 반영에서 사용자 알림과 시간표 제거는 처리됐지만 `삶과천문학` 비활성화와 공식 과목 변경 저장이 남아 재반영이 필요합니다. 동일 미읽음 알림은 중복 생성되지 않습니다.

## 검증

- `./gradlew clean test`
- 운영 DB 사후 대조로 문제 확인
