### PR TITLE
관리자 문의 Q&A 관리 기능 추가

### DIFF
--- a/src/main/java/inu/timetable/config/SecurityConfig.java
+++ b/src/main/java/inu/timetable/config/SecurityConfig.java
@@ -101,6 +101,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/notifications/**").authenticated()
                         .requestMatchers("/api/subjects/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/settings/current-semester").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/inquiries/faqs").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/events").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/inquiries").permitAll()
                         .anyRequest().denyAll())

--- a/src/main/java/inu/timetable/controller/InquiryFaqController.java
+++ b/src/main/java/inu/timetable/controller/InquiryFaqController.java
@@ -1,0 +1,64 @@
+package inu.timetable.controller;
+
+import inu.timetable.dto.AdminInquiryFaqResponse;
+import inu.timetable.dto.InquiryFaqResponse;
+import inu.timetable.dto.InquiryFaqUpsertRequest;
+import inu.timetable.service.AdminAccessGuard;
+import inu.timetable.service.InquiryFaqService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class InquiryFaqController {
+
+    private final InquiryFaqService inquiryFaqService;
+    private final AdminAccessGuard adminAccessGuard;
+
+    @GetMapping("/api/inquiries/faqs")
+    public List<InquiryFaqResponse> getPublicFaqs() {
+        return inquiryFaqService.getPublicFaqs();
+    }
+
+    @GetMapping("/admin/api/inquiry-faqs")
+    public List<AdminInquiryFaqResponse> getAdminFaqs(HttpServletRequest request) {
+        adminAccessGuard.requireAuthenticated(request);
+        return inquiryFaqService.getAdminFaqs();
+    }
+
+    @PostMapping("/admin/api/inquiry-faqs")
+    public AdminInquiryFaqResponse create(
+            HttpServletRequest servletRequest,
+            @RequestBody InquiryFaqUpsertRequest request) {
+        adminAccessGuard.requireAuthenticated(servletRequest);
+        return inquiryFaqService.create(request);
+    }
+
+    @PutMapping("/admin/api/inquiry-faqs/{id}")
+    public AdminInquiryFaqResponse update(
+            HttpServletRequest servletRequest,
+            @PathVariable Long id,
+            @RequestBody InquiryFaqUpsertRequest request) {
+        adminAccessGuard.requireAuthenticated(servletRequest);
+        return inquiryFaqService.update(id, request);
+    }
+
+    @DeleteMapping("/admin/api/inquiry-faqs/{id}")
+    public ResponseEntity<Void> delete(
+            HttpServletRequest servletRequest,
+            @PathVariable Long id) {
+        adminAccessGuard.requireAuthenticated(servletRequest);
+        inquiryFaqService.delete(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/inu/timetable/dto/AdminInquiryFaqResponse.java
+++ b/src/main/java/inu/timetable/dto/AdminInquiryFaqResponse.java
@@ -1,0 +1,13 @@
+package inu.timetable.dto;
+
+import java.time.LocalDateTime;
+
+public record AdminInquiryFaqResponse(
+        Long id,
+        String question,
+        String answer,
+        int sortOrder,
+        boolean active,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt) {
+}

--- a/src/main/java/inu/timetable/dto/InquiryFaqResponse.java
+++ b/src/main/java/inu/timetable/dto/InquiryFaqResponse.java
@@ -1,0 +1,7 @@
+package inu.timetable.dto;
+
+public record InquiryFaqResponse(
+        Long id,
+        String question,
+        String answer) {
+}

--- a/src/main/java/inu/timetable/dto/InquiryFaqUpsertRequest.java
+++ b/src/main/java/inu/timetable/dto/InquiryFaqUpsertRequest.java
@@ -1,0 +1,8 @@
+package inu.timetable.dto;
+
+public record InquiryFaqUpsertRequest(
+        String question,
+        String answer,
+        Integer sortOrder,
+        Boolean active) {
+}

--- a/src/main/java/inu/timetable/entity/InquiryFaq.java
+++ b/src/main/java/inu/timetable/entity/InquiryFaq.java
@@ -1,0 +1,67 @@
+package inu.timetable.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 문의 작성 전에 노출하는 관리자 작성 Q&A.
+ * 초기 데이터는 만들지 않고, 관리자가 등록한 활성 항목만 사용자에게 노출한다.
+ */
+@Entity
+@Table(
+        name = "inquiry_faqs",
+        indexes = @Index(
+                name = "idx_inquiry_faqs_active_order",
+                columnList = "active, sort_order, id"))
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class InquiryFaq {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 200)
+    private String question;
+
+    @Column(nullable = false, length = 2000)
+    private String answer;
+
+    @Column(name = "sort_order", nullable = false)
+    private int sortOrder;
+
+    @Column(nullable = false)
+    private boolean active;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    public void update(
+            String question,
+            String answer,
+            int sortOrder,
+            boolean active,
+            LocalDateTime updatedAt) {
+        this.question = question;
+        this.answer = answer;
+        this.sortOrder = sortOrder;
+        this.active = active;
+        this.updatedAt = updatedAt;
+    }
+}

--- a/src/main/java/inu/timetable/repository/InquiryFaqRepository.java
+++ b/src/main/java/inu/timetable/repository/InquiryFaqRepository.java
@@ -1,0 +1,13 @@
+package inu.timetable.repository;
+
+import inu.timetable.entity.InquiryFaq;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InquiryFaqRepository extends JpaRepository<InquiryFaq, Long> {
+
+    List<InquiryFaq> findAllByActiveTrueOrderBySortOrderAscIdAsc();
+
+    List<InquiryFaq> findAllByOrderBySortOrderAscIdAsc();
+}

--- a/src/main/java/inu/timetable/service/InquiryFaqService.java
+++ b/src/main/java/inu/timetable/service/InquiryFaqService.java
@@ -1,0 +1,132 @@
+package inu.timetable.service;
+
+import inu.timetable.dto.AdminInquiryFaqResponse;
+import inu.timetable.dto.InquiryFaqResponse;
+import inu.timetable.dto.InquiryFaqUpsertRequest;
+import inu.timetable.entity.InquiryFaq;
+import inu.timetable.repository.InquiryFaqRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class InquiryFaqService {
+
+    private static final int MAX_QUESTION_LENGTH = 200;
+    private static final int MAX_ANSWER_LENGTH = 2000;
+
+    private final InquiryFaqRepository inquiryFaqRepository;
+    private final Clock clock;
+
+    @Transactional(readOnly = true)
+    public List<InquiryFaqResponse> getPublicFaqs() {
+        return inquiryFaqRepository.findAllByActiveTrueOrderBySortOrderAscIdAsc().stream()
+                .map(this::toPublicResponse)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<AdminInquiryFaqResponse> getAdminFaqs() {
+        return inquiryFaqRepository.findAllByOrderBySortOrderAscIdAsc().stream()
+                .map(this::toAdminResponse)
+                .toList();
+    }
+
+    @Transactional
+    public AdminInquiryFaqResponse create(InquiryFaqUpsertRequest request) {
+        NormalizedFaq normalized = normalize(request);
+        LocalDateTime now = LocalDateTime.now(clock);
+        InquiryFaq saved = inquiryFaqRepository.save(InquiryFaq.builder()
+                .question(normalized.question())
+                .answer(normalized.answer())
+                .sortOrder(normalized.sortOrder())
+                .active(normalized.active())
+                .createdAt(now)
+                .updatedAt(now)
+                .build());
+        return toAdminResponse(saved);
+    }
+
+    @Transactional
+    public AdminInquiryFaqResponse update(Long id, InquiryFaqUpsertRequest request) {
+        NormalizedFaq normalized = normalize(request);
+        InquiryFaq faq = inquiryFaqRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "Q&A를 찾을 수 없습니다."));
+        faq.update(
+                normalized.question(),
+                normalized.answer(),
+                normalized.sortOrder(),
+                normalized.active(),
+                LocalDateTime.now(clock));
+        return toAdminResponse(faq);
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        if (!inquiryFaqRepository.existsById(id)) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Q&A를 찾을 수 없습니다.");
+        }
+        inquiryFaqRepository.deleteById(id);
+    }
+
+    private NormalizedFaq normalize(InquiryFaqUpsertRequest request) {
+        if (request == null) {
+            throw badRequest("Q&A 내용을 입력해주세요.");
+        }
+        String question = request.question() == null ? "" : request.question().trim();
+        String answer = request.answer() == null ? "" : request.answer().trim();
+        int sortOrder = request.sortOrder() == null ? 0 : request.sortOrder();
+        boolean active = request.active() != null && request.active();
+
+        if (question.isEmpty()) {
+            throw badRequest("질문을 입력해주세요.");
+        }
+        if (question.length() > MAX_QUESTION_LENGTH) {
+            throw badRequest("질문은 " + MAX_QUESTION_LENGTH + "자 이하로 입력해주세요.");
+        }
+        if (answer.isEmpty()) {
+            throw badRequest("답변을 입력해주세요.");
+        }
+        if (answer.length() > MAX_ANSWER_LENGTH) {
+            throw badRequest("답변은 " + MAX_ANSWER_LENGTH + "자 이하로 입력해주세요.");
+        }
+        if (sortOrder < 0) {
+            throw badRequest("노출 순서는 0 이상이어야 합니다.");
+        }
+        return new NormalizedFaq(question, answer, sortOrder, active);
+    }
+
+    private ResponseStatusException badRequest(String reason) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, reason);
+    }
+
+    private InquiryFaqResponse toPublicResponse(InquiryFaq faq) {
+        return new InquiryFaqResponse(faq.getId(), faq.getQuestion(), faq.getAnswer());
+    }
+
+    private AdminInquiryFaqResponse toAdminResponse(InquiryFaq faq) {
+        return new AdminInquiryFaqResponse(
+                faq.getId(),
+                faq.getQuestion(),
+                faq.getAnswer(),
+                faq.getSortOrder(),
+                faq.isActive(),
+                faq.getCreatedAt(),
+                faq.getUpdatedAt());
+    }
+
+    private record NormalizedFaq(
+            String question,
+            String answer,
+            int sortOrder,
+            boolean active) {
+    }
+}

--- a/src/main/resources/db/migration/V20260729_03__create_inquiry_faqs.sql
+++ b/src/main/resources/db/migration/V20260729_03__create_inquiry_faqs.sql
@@ -1,0 +1,14 @@
+-- 문의 작성 전에 사용자에게 보여줄 관리자 작성 Q&A.
+-- 초기 Q&A는 넣지 않으며 관리자가 문의 관리 화면에서 직접 등록한다.
+CREATE TABLE IF NOT EXISTS inquiry_faqs (
+    id BIGSERIAL PRIMARY KEY,
+    question VARCHAR(200) NOT NULL,
+    answer VARCHAR(2000) NOT NULL,
+    sort_order INTEGER NOT NULL DEFAULT 0 CHECK (sort_order >= 0),
+    active BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMP NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_inquiry_faqs_active_order
+    ON inquiry_faqs (active, sort_order, id);

--- a/src/main/resources/templates/admin/inquiries.html
+++ b/src/main/resources/templates/admin/inquiries.html
@@ -7,7 +7,8 @@
   <meta name="_csrf_header" th:content="${_csrf.headerName}" />
   <title>문의 관리 · INU 시간표</title>
   <style>
-    :root { --bg:#f8fafc; --card:#ffffff; --ink:#0f172a; --muted:#64748b; --line:#e2e8f0; --brand:#2563eb; --ok:#16a34a; }
+    :root { --bg:#f8fafc; --card:#ffffff; --ink:#0f172a; --muted:#64748b; --line:#e2e8f0;
+      --brand:#2563eb; --ok:#16a34a; --danger:#dc2626; }
     * { box-sizing: border-box; }
     body { margin:0; background:var(--bg); color:var(--ink);
       font-family:'Pretendard','Apple SD Gothic Neo','Malgun Gothic',system-ui,sans-serif; }
@@ -25,6 +26,37 @@
       padding:6px 12px; border-radius:999px; cursor:pointer; }
     .filter button.active { background:var(--card); color:var(--brand); box-shadow:0 1px 2px rgba(15,23,42,.12); }
     .panel { background:var(--card); border:1px solid var(--line); border-radius:16px; padding:18px; }
+    .section { margin-top:24px; }
+    .sectionHeader { display:flex; align-items:flex-start; justify-content:space-between; gap:16px; margin-bottom:14px; }
+    .sectionHeader h2 { margin:0; font-size:17px; }
+    .primaryBtn, .secondaryBtn, .dangerBtn { border-radius:9px; padding:8px 13px; font-size:13px;
+      font-weight:700; cursor:pointer; }
+    .primaryBtn { border:1px solid var(--brand); color:#fff; background:var(--brand); }
+    .secondaryBtn { border:1px solid var(--line); color:var(--ink); background:var(--card); }
+    .dangerBtn { border:1px solid #fecaca; color:var(--danger); background:#fff; }
+    .primaryBtn:disabled, .secondaryBtn:disabled, .dangerBtn:disabled { opacity:.55; cursor:default; }
+    .faqForm { display:none; margin-bottom:16px; padding:16px; border:1px solid #bfdbfe;
+      border-radius:12px; background:#eff6ff; }
+    .faqForm.open { display:block; }
+    .field { margin-bottom:12px; }
+    .field label { display:block; margin-bottom:6px; font-size:12px; font-weight:700; color:#334155; }
+    .field input[type="text"], .field input[type="number"], .field textarea { width:100%; border:1px solid #cbd5e1;
+      border-radius:9px; padding:9px 10px; background:#fff; color:var(--ink); font:inherit; font-size:14px; }
+    .field textarea { min-height:110px; resize:vertical; }
+    .fieldRow { display:grid; grid-template-columns:minmax(120px, 180px) 1fr; gap:16px; align-items:end; }
+    .checkLabel { display:flex; align-items:center; gap:8px; min-height:38px; font-size:13px; font-weight:700; }
+    .formActions { display:flex; justify-content:flex-end; gap:8px; }
+    .faqList { display:grid; gap:10px; }
+    .faqCard { border:1px solid var(--line); border-radius:12px; padding:14px; }
+    .faqTop { display:flex; align-items:flex-start; justify-content:space-between; gap:16px; }
+    .faqQuestion { margin:0; font-size:14px; line-height:1.5; word-break:break-word; }
+    .faqAnswer { margin:9px 0 0; color:#475569; font-size:13px; line-height:1.6; white-space:pre-wrap;
+      word-break:break-word; }
+    .faqMeta { display:flex; align-items:center; flex-wrap:wrap; gap:7px; margin-top:11px; }
+    .faqActions { display:flex; flex-shrink:0; gap:6px; }
+    .smallBtn { padding:5px 9px; }
+    .badge.active { background:#dcfce7; color:#166534; }
+    .badge.inactive { background:#f1f5f9; color:#64748b; }
     table { width:100%; border-collapse:collapse; font-size:14px; }
     th, td { text-align:left; padding:10px 6px; border-bottom:1px solid var(--line); vertical-align:top; }
     th { color:var(--muted); font-size:12px; font-weight:700; white-space:nowrap; }
@@ -42,6 +74,12 @@
     .pager button { border:1px solid var(--line); background:var(--card); color:var(--ink); font-weight:700;
       font-size:13px; padding:6px 12px; border-radius:8px; cursor:pointer; }
     .pager button:disabled { color:var(--muted); cursor:default; opacity:.5; }
+    @media (max-width:700px) {
+      .panel { padding:14px; overflow-x:auto; }
+      .sectionHeader, .faqTop { align-items:stretch; flex-direction:column; }
+      .fieldRow { grid-template-columns:1fr; gap:0; }
+      .faqActions { align-self:flex-end; }
+    }
   </style>
 </head>
 <body>
@@ -88,6 +126,46 @@
         <button id="nextBtn">다음</button>
       </div>
     </div>
+
+    <section class="section panel" aria-labelledby="faqHeading">
+      <div class="sectionHeader">
+        <div>
+          <h2 id="faqHeading">문의 Q&amp;A 관리</h2>
+          <div class="sub">공개 상태인 항목만 사용자 문의창에 순서대로 표시됩니다.</div>
+        </div>
+        <button type="button" class="primaryBtn" id="addFaqBtn">Q&amp;A 추가</button>
+      </div>
+
+      <form id="faqForm" class="faqForm">
+        <div class="field">
+          <label for="faqQuestion">질문</label>
+          <input id="faqQuestion" name="question" type="text" maxlength="200" required />
+        </div>
+        <div class="field">
+          <label for="faqAnswer">답변</label>
+          <textarea id="faqAnswer" name="answer" maxlength="2000" required></textarea>
+        </div>
+        <div class="fieldRow">
+          <div class="field">
+            <label for="faqSortOrder">표시 순서</label>
+            <input id="faqSortOrder" name="sortOrder" type="number" min="0" step="1" value="0" required />
+          </div>
+          <label class="checkLabel">
+            <input id="faqActive" name="active" type="checkbox" />
+            사용자에게 공개
+          </label>
+        </div>
+        <div class="formActions">
+          <button type="button" class="secondaryBtn" id="cancelFaqBtn">취소</button>
+          <button type="submit" class="primaryBtn" id="saveFaqBtn">저장</button>
+        </div>
+      </form>
+
+      <div id="faqList" class="faqList"></div>
+      <div id="faqEmptyMessage" class="empty" style="display:none;">
+        등록된 Q&amp;A가 없습니다. 필요한 내용을 직접 추가해주세요.
+      </div>
+    </section>
   </div>
 
   <script>
@@ -95,6 +173,18 @@
     let currentPage = 0;
     let totalPages = 0;
     let unresolvedOnly = true;
+    let faqItems = [];
+    let editingFaqId = null;
+    const SERVER_TIME_ZONE_PATTERN = /(?:Z|[+-]\d{2}:?\d{2})$/i;
+    const KOREA_DATE_TIME_FORMATTER = new Intl.DateTimeFormat('ko-KR-u-nu-latn', {
+      timeZone: 'Asia/Seoul',
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hourCycle: 'h23'
+    });
 
     const csrfToken = document.querySelector('meta[name="_csrf"]').content;
     const csrfHeader = document.querySelector('meta[name="_csrf_header"]').content;
@@ -161,9 +251,128 @@
       load();
     }
 
+    async function loadFaqs() {
+      const res = await fetch('/admin/api/inquiry-faqs', { credentials: 'same-origin' });
+      if (res.status === 401 || res.status === 403) { location.href = '/admin/login'; return; }
+      if (!res.ok) throw new Error('Q&A 목록 조회 실패');
+      faqItems = await res.json();
+      renderFaqs();
+    }
+
+    function renderFaqs() {
+      const list = document.getElementById('faqList');
+      const empty = document.getElementById('faqEmptyMessage');
+      list.innerHTML = '';
+      empty.style.display = faqItems.length ? 'none' : 'block';
+
+      faqItems.forEach(faq => {
+        const card = document.createElement('article');
+        card.className = 'faqCard';
+        card.innerHTML = `
+          <div class="faqTop">
+            <div>
+              <h3 class="faqQuestion">${escapeHtml(faq.question)}</h3>
+              <p class="faqAnswer">${escapeHtml(faq.answer)}</p>
+              <div class="faqMeta">
+                <span class="badge ${faq.active ? 'active' : 'inactive'}">${faq.active ? '공개' : '비공개'}</span>
+                <span class="muted">순서 ${faq.sortOrder}</span>
+                <span class="muted">수정 ${formatDate(faq.updatedAt)}</span>
+              </div>
+            </div>
+            <div class="faqActions">
+              <button type="button" class="secondaryBtn smallBtn editFaqBtn" data-id="${faq.id}">수정</button>
+              <button type="button" class="dangerBtn smallBtn deleteFaqBtn" data-id="${faq.id}">삭제</button>
+            </div>
+          </div>`;
+        list.appendChild(card);
+      });
+    }
+
+    function openFaqForm(faq = null) {
+      editingFaqId = faq?.id ?? null;
+      document.getElementById('faqQuestion').value = faq?.question ?? '';
+      document.getElementById('faqAnswer').value = faq?.answer ?? '';
+      document.getElementById('faqSortOrder').value = faq?.sortOrder ?? 0;
+      document.getElementById('faqActive').checked = faq?.active ?? false;
+      document.getElementById('saveFaqBtn').textContent = editingFaqId ? '수정 저장' : '추가';
+      document.getElementById('faqForm').classList.add('open');
+      document.getElementById('faqQuestion').focus();
+    }
+
+    function closeFaqForm() {
+      editingFaqId = null;
+      document.getElementById('faqForm').reset();
+      document.getElementById('faqSortOrder').value = 0;
+      document.getElementById('faqActive').checked = false;
+      document.getElementById('faqForm').classList.remove('open');
+      document.getElementById('saveFaqBtn').textContent = '저장';
+    }
+
+    async function saveFaq() {
+      const saveButton = document.getElementById('saveFaqBtn');
+      const payload = {
+        question: document.getElementById('faqQuestion').value,
+        answer: document.getElementById('faqAnswer').value,
+        sortOrder: Number(document.getElementById('faqSortOrder').value),
+        active: document.getElementById('faqActive').checked
+      };
+      const url = editingFaqId
+        ? `/admin/api/inquiry-faqs/${editingFaqId}`
+        : '/admin/api/inquiry-faqs';
+
+      saveButton.disabled = true;
+      try {
+        const res = await fetch(url, {
+          method: editingFaqId ? 'PUT' : 'POST',
+          credentials: 'same-origin',
+          headers: { 'Content-Type': 'application/json', [csrfHeader]: csrfToken },
+          body: JSON.stringify(payload)
+        });
+        if (res.status === 401 || res.status === 403) { location.href = '/admin/login'; return; }
+        if (!res.ok) {
+          const message = await res.text();
+          throw new Error(message || '저장에 실패했습니다.');
+        }
+        closeFaqForm();
+        await loadFaqs();
+      } catch (error) {
+        alert(error.message || '저장에 실패했습니다. 다시 시도해주세요.');
+      } finally {
+        saveButton.disabled = false;
+      }
+    }
+
+    async function deleteFaq(id, button) {
+      if (!confirm('이 Q&A를 삭제할까요? 삭제 후에는 복구할 수 없습니다.')) return;
+      button.disabled = true;
+      try {
+        const res = await fetch(`/admin/api/inquiry-faqs/${id}`, {
+          method: 'DELETE',
+          credentials: 'same-origin',
+          headers: { [csrfHeader]: csrfToken }
+        });
+        if (res.status === 401 || res.status === 403) { location.href = '/admin/login'; return; }
+        if (!res.ok) throw new Error('삭제에 실패했습니다.');
+        if (editingFaqId === id) closeFaqForm();
+        await loadFaqs();
+      } catch (error) {
+        button.disabled = false;
+        alert(error.message || '삭제에 실패했습니다. 다시 시도해주세요.');
+      }
+    }
+
     function formatDate(iso) {
       if (!iso) return '–';
-      return iso.replace('T', ' ').slice(0, 16);
+      const value = String(iso).trim();
+      const date = new Date(SERVER_TIME_ZONE_PATTERN.test(value) ? value : `${value}Z`);
+      if (Number.isNaN(date.getTime())) return '–';
+      const parts = Object.fromEntries(
+        KOREA_DATE_TIME_FORMATTER
+          .formatToParts(date)
+          .filter(({ type }) => type !== 'literal')
+          .map(({ type, value: partValue }) => [type, partValue])
+      );
+      return `${parts.year}.${parts.month}.${parts.day} ${parts.hour}:${parts.minute}`;
     }
 
     function escapeHtml(s) {
@@ -195,9 +404,32 @@
       if (currentPage < totalPages - 1) { currentPage++; load(); }
     });
 
-    load().catch(() => { document.getElementById('emptyMessage').textContent = '목록을 불러오지 못했습니다.';
+    document.getElementById('addFaqBtn').addEventListener('click', () => openFaqForm());
+    document.getElementById('cancelFaqBtn').addEventListener('click', closeFaqForm);
+    document.getElementById('faqForm').addEventListener('submit', (event) => {
+      event.preventDefault();
+      saveFaq();
+    });
+    document.getElementById('faqList').addEventListener('click', (event) => {
+      const editButton = event.target.closest('.editFaqBtn');
+      if (editButton) {
+        const faq = faqItems.find(item => item.id === Number(editButton.dataset.id));
+        if (faq) openFaqForm(faq);
+        return;
+      }
+      const deleteButton = event.target.closest('.deleteFaqBtn');
+      if (deleteButton) deleteFaq(Number(deleteButton.dataset.id), deleteButton);
+    });
+
+    load().catch(() => {
+      document.getElementById('emptyMessage').textContent = '목록을 불러오지 못했습니다.';
       document.getElementById('emptyMessage').style.display = 'block';
-      document.getElementById('inquiryTable').style.display = 'none'; });
+      document.getElementById('inquiryTable').style.display = 'none';
+    });
+    loadFaqs().catch(() => {
+      document.getElementById('faqEmptyMessage').textContent = 'Q&A 목록을 불러오지 못했습니다.';
+      document.getElementById('faqEmptyMessage').style.display = 'block';
+    });
   </script>
 </body>
 </html>

--- a/src/test/java/inu/timetable/controller/InquiryFaqControllerTest.java
+++ b/src/test/java/inu/timetable/controller/InquiryFaqControllerTest.java
@@ -1,0 +1,158 @@
+package inu.timetable.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import inu.timetable.controller.CsrfTestSupport.CsrfProof;
+import inu.timetable.entity.AdminAccount;
+import inu.timetable.entity.InquiryFaq;
+import inu.timetable.repository.AdminAccountRepository;
+import inu.timetable.repository.InquiryFaqRepository;
+import inu.timetable.service.AdminAuthService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static inu.timetable.controller.CsrfTestSupport.fetchCsrfProof;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("dev")
+@Transactional
+class InquiryFaqControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private InquiryFaqRepository inquiryFaqRepository;
+
+    @Autowired
+    private AdminAccountRepository adminAccountRepository;
+
+    @Test
+    void publicFaqListReturnsOnlyActiveFaqsInDisplayOrder() throws Exception {
+        saveFaq("두 번째", "답변 2", 20, true);
+        saveFaq("숨김", "숨긴 답변", 5, false);
+        saveFaq("첫 번째", "답변 1", 10, true);
+
+        mockMvc.perform(get("/api/inquiries/faqs"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0].question").value("첫 번째"))
+                .andExpect(jsonPath("$[1].question").value("두 번째"));
+    }
+
+    @Test
+    void adminFaqMutationRequiresAdminSession() throws Exception {
+        MockHttpSession session = new MockHttpSession();
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
+
+        mockMvc.perform(post("/admin/api/inquiry-faqs")
+                .session(session)
+                .cookie(csrfProof.cookie())
+                .header("X-XSRF-TOKEN", csrfProof.token())
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(Map.of(
+                        "question", "질문",
+                        "answer", "답변"))))
+                .andExpect(status().isForbidden());
+
+        assertThat(inquiryFaqRepository.count()).isZero();
+    }
+
+    @Test
+    void adminCanCreateUpdateAndDeleteFaq() throws Exception {
+        MockHttpSession session = adminSession();
+        CsrfProof csrfProof = fetchCsrfProof(mockMvc, objectMapper, session);
+
+        String created = mockMvc.perform(post("/admin/api/inquiry-faqs")
+                        .session(session)
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", csrfProof.token())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "question", "등록 질문",
+                                "answer", "등록 답변",
+                                "sortOrder", 10,
+                                "active", true))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.question").value("등록 질문"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long id = objectMapper.readTree(created).get("id").asLong();
+
+        mockMvc.perform(put("/admin/api/inquiry-faqs/{id}", id)
+                        .session(session)
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", csrfProof.token())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(Map.of(
+                                "question", "수정 질문",
+                                "answer", "수정 답변",
+                                "sortOrder", 30,
+                                "active", false))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.question").value("수정 질문"))
+                .andExpect(jsonPath("$.active").value(false));
+
+        mockMvc.perform(delete("/admin/api/inquiry-faqs/{id}", id)
+                        .session(session)
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", csrfProof.token()))
+                .andExpect(status().isNoContent());
+
+        assertThat(inquiryFaqRepository.findById(id)).isEmpty();
+    }
+
+    private InquiryFaq saveFaq(
+            String question,
+            String answer,
+            int sortOrder,
+            boolean active) {
+        LocalDateTime now = LocalDateTime.of(2026, 7, 29, 12, 0);
+        return inquiryFaqRepository.save(InquiryFaq.builder()
+                .question(question)
+                .answer(answer)
+                .sortOrder(sortOrder)
+                .active(active)
+                .createdAt(now)
+                .updatedAt(now)
+                .build());
+    }
+
+    private MockHttpSession adminSession() {
+        adminAccountRepository.findById(AdminAccount.SINGLETON_ID)
+                .orElseGet(() -> adminAccountRepository.save(AdminAccount.builder()
+                        .id(AdminAccount.SINGLETON_ID)
+                        .username("admin")
+                        .passwordHash("unused-in-session-test")
+                        .passwordChangeRequired(false)
+                        .credentialVersion(1L)
+                        .build()));
+        MockHttpSession session = new MockHttpSession();
+        session.setAttribute(AdminAuthService.SESSION_AUTHENTICATED, true);
+        session.setAttribute(AdminAuthService.SESSION_USERNAME, "admin");
+        session.setAttribute(AdminAuthService.SESSION_CREDENTIAL_VERSION, 1L);
+        session.setAttribute(AdminAuthService.SESSION_PASSWORD_CHANGE_REQUIRED, false);
+        return session;
+    }
+}

--- a/src/test/java/inu/timetable/service/InquiryFaqServiceTest.java
+++ b/src/test/java/inu/timetable/service/InquiryFaqServiceTest.java
@@ -1,0 +1,147 @@
+package inu.timetable.service;
+
+import inu.timetable.dto.AdminInquiryFaqResponse;
+import inu.timetable.dto.InquiryFaqResponse;
+import inu.timetable.dto.InquiryFaqUpsertRequest;
+import inu.timetable.entity.InquiryFaq;
+import inu.timetable.repository.InquiryFaqRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class InquiryFaqServiceTest {
+
+    private static final Clock FIXED_CLOCK = Clock.fixed(
+            Instant.parse("2026-07-29T04:00:00Z"),
+            ZoneId.of("Asia/Seoul"));
+
+    private InquiryFaqRepository inquiryFaqRepository;
+    private InquiryFaqService inquiryFaqService;
+
+    @BeforeEach
+    void setUp() {
+        inquiryFaqRepository = mock(InquiryFaqRepository.class);
+        inquiryFaqService = new InquiryFaqService(inquiryFaqRepository, FIXED_CLOCK);
+    }
+
+    @Test
+    void getPublicFaqsReturnsOnlyActiveFaqsInDisplayOrder() {
+        when(inquiryFaqRepository.findAllByActiveTrueOrderBySortOrderAscIdAsc())
+                .thenReturn(List.of(
+                        InquiryFaq.builder()
+                                .id(2L)
+                                .question("과목이 검색되지 않아요")
+                                .answer("공식 데이터 반영 여부를 확인해주세요.")
+                                .sortOrder(10)
+                                .active(true)
+                                .createdAt(LocalDateTime.of(2026, 7, 29, 12, 0))
+                                .updatedAt(LocalDateTime.of(2026, 7, 29, 12, 0))
+                                .build()));
+
+        List<InquiryFaqResponse> response = inquiryFaqService.getPublicFaqs();
+
+        assertThat(response).containsExactly(new InquiryFaqResponse(
+                2L,
+                "과목이 검색되지 않아요",
+                "공식 데이터 반영 여부를 확인해주세요."));
+    }
+
+    @Test
+    void createTrimsContentAndDefaultsToPrivateDraft() {
+        when(inquiryFaqRepository.save(any(InquiryFaq.class)))
+                .thenAnswer(invocation -> {
+                    InquiryFaq faq = invocation.getArgument(0);
+                    return InquiryFaq.builder()
+                            .id(11L)
+                            .question(faq.getQuestion())
+                            .answer(faq.getAnswer())
+                            .sortOrder(faq.getSortOrder())
+                            .active(faq.isActive())
+                            .createdAt(faq.getCreatedAt())
+                            .updatedAt(faq.getUpdatedAt())
+                            .build();
+                });
+
+        AdminInquiryFaqResponse response = inquiryFaqService.create(
+                new InquiryFaqUpsertRequest("  질문  ", "  답변  ", null, null));
+
+        ArgumentCaptor<InquiryFaq> captor = ArgumentCaptor.forClass(InquiryFaq.class);
+        verify(inquiryFaqRepository).save(captor.capture());
+        InquiryFaq saved = captor.getValue();
+        assertThat(saved.getQuestion()).isEqualTo("질문");
+        assertThat(saved.getAnswer()).isEqualTo("답변");
+        assertThat(saved.getSortOrder()).isZero();
+        assertThat(saved.isActive()).isFalse();
+        assertThat(saved.getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 7, 29, 13, 0));
+        assertThat(saved.getUpdatedAt()).isEqualTo(LocalDateTime.of(2026, 7, 29, 13, 0));
+        assertThat(response.id()).isEqualTo(11L);
+    }
+
+    @Test
+    void updateChangesExistingFaq() {
+        InquiryFaq faq = InquiryFaq.builder()
+                .id(7L)
+                .question("기존 질문")
+                .answer("기존 답변")
+                .sortOrder(0)
+                .active(true)
+                .createdAt(LocalDateTime.of(2026, 7, 28, 12, 0))
+                .updatedAt(LocalDateTime.of(2026, 7, 28, 12, 0))
+                .build();
+        when(inquiryFaqRepository.findById(7L)).thenReturn(Optional.of(faq));
+
+        AdminInquiryFaqResponse response = inquiryFaqService.update(
+                7L,
+                new InquiryFaqUpsertRequest(" 새 질문 ", " 새 답변 ", 20, false));
+
+        assertThat(response.question()).isEqualTo("새 질문");
+        assertThat(response.answer()).isEqualTo("새 답변");
+        assertThat(response.sortOrder()).isEqualTo(20);
+        assertThat(response.active()).isFalse();
+        assertThat(response.updatedAt()).isEqualTo(LocalDateTime.of(2026, 7, 29, 13, 0));
+    }
+
+    @Test
+    void createRejectsInvalidContent() {
+        assertThatThrownBy(() -> inquiryFaqService.create(
+                new InquiryFaqUpsertRequest(" ", "답변", 0, true)))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        exception -> assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+        assertThatThrownBy(() -> inquiryFaqService.create(
+                new InquiryFaqUpsertRequest("질문", " ", 0, true)))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        exception -> assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+        assertThatThrownBy(() -> inquiryFaqService.create(
+                new InquiryFaqUpsertRequest("질문", "답변", -1, true)))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        exception -> assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST));
+        verify(inquiryFaqRepository, never()).save(any());
+    }
+
+    @Test
+    void deleteRejectsUnknownFaq() {
+        when(inquiryFaqRepository.existsById(99L)).thenReturn(false);
+
+        assertThatThrownBy(() -> inquiryFaqService.delete(99L))
+                .isInstanceOfSatisfying(ResponseStatusException.class,
+                        exception -> assertThat(exception.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND));
+        verify(inquiryFaqRepository, never()).deleteById(any());
+    }
+}


### PR DESCRIPTION
## 변경 내용

- 관리자 문의 화면에서 Q&A를 추가, 수정, 삭제하고 공개 여부와 표시 순서를 관리할 수 있게 했습니다.
- 공개 API는 관리자가 공개한 Q&A만 순서대로 반환합니다.
- 신규 Q&A는 실수로 바로 노출되지 않도록 비공개 초안이 기본입니다.
- Q&A 저장용 Flyway 마이그레이션을 추가했으며 초기 Q&A 데이터는 넣지 않았습니다.
- 관리자 문의 화면의 접수·수정 시각을 한국시간으로 표시합니다.

## 안전성

- 관리자 CRUD는 기존 관리자 세션 검증과 CSRF 보호를 적용합니다.
- 관리자 API 감사 로그가 Q&A 변경도 자동 기록합니다.
- 공개 화면과 관리자 화면 모두 Q&A 문자열을 이스케이프하여 출력합니다.

## 검증

- 코드리뷰: APPROVE
- 아키텍처 리뷰: CLEAR
- `./gradlew clean test bootJar --no-daemon`
- 관리자 CRUD, 공개/비공개 분리, CSRF, 인증 회귀 테스트
