### PR TITLE
학점 제한 없는 시간표 조합 지원

### DIFF
--- a/src/main/java/inu/timetable/controller/TimetableCombinationController.java
+++ b/src/main/java/inu/timetable/controller/TimetableCombinationController.java
@@ -19,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 
 import static inu.timetable.util.ApiRequestValues.optionalStringList;
+import static inu.timetable.util.ApiRequestValues.optionalBoolean;
 import static inu.timetable.util.ApiRequestValues.requiredInteger;
 import static inu.timetable.util.ApiRequestValues.requiredLong;
 import static inu.timetable.util.ApiRequestValues.optionalString;
@@ -40,17 +41,22 @@ public class TimetableCombinationController {
     @Operation(
         summary = "시간표 조합 생성",
         description = "위시리스트 기반으로 목표 학점에 맞는 시간표 조합을 자동 생성합니다. " +
+                     "ignoreTargetCredits가 true이면 가능한 높은 학점의 조합을 자동으로 찾습니다. " +
                      "공강 요일을 설정하면 해당 요일에 수업이 없는 조합만 생성됩니다."
     )
     public ResponseEntity<?> generateTimetableCombinations(
-            @Parameter(description = "요청 파라미터: userId, semester, targetCredits, maxCombinations(선택), freeDays(선택)")
+            @Parameter(description = "요청 파라미터: userId, semester, targetCredits, ignoreTargetCredits(선택), maxCombinations(선택), freeDays(선택)")
             @RequestBody Map<String, Object> request,
             @AuthenticationPrincipal AuthenticatedUser authenticatedUser) {
         Long userId = requiredLong(request, "userId");
         userAccessGuard.requireMatchingUser(authenticatedUser, userId);
         String semester = optionalString(request, "semester");
-        int targetCredits = requiredInteger(request, "targetCredits");
-        validateTargetCredits(targetCredits);
+        boolean ignoreTargetCredits = optionalBoolean(request, "ignoreTargetCredits", false);
+        Integer targetCredits = null;
+        if (!ignoreTargetCredits) {
+            targetCredits = requiredInteger(request, "targetCredits");
+            validateTargetCredits(targetCredits);
+        }
         int maxCombinations = request.containsKey("maxCombinations")
                 ? requiredInteger(request, "maxCombinations")
                 : 20;
@@ -65,6 +71,7 @@ public class TimetableCombinationController {
         response.put("combinations", combinations);
         response.put("totalCount", combinations.size());
         response.put("targetCredits", targetCredits);
+        response.put("ignoreTargetCredits", ignoreTargetCredits);
         response.put("freeDays", freeDays);
 
         List<Map<String, Object>> combinationStats = combinations.stream()

--- a/src/main/java/inu/timetable/service/TimetableCombinationService.java
+++ b/src/main/java/inu/timetable/service/TimetableCombinationService.java
@@ -14,6 +14,7 @@ import java.util.stream.Collectors;
 public class TimetableCombinationService {
 
     private static final int CREDIT_TOLERANCE = 3;
+    private static final int MAX_TARGET_SEARCH_NODES = 50_000;
     private static final int SLOTS_PER_DAY = 128;
     private static final List<String> KNOWN_DAYS = List.of("월", "화", "수", "목", "금", "토", "일");
     
@@ -28,7 +29,8 @@ public class TimetableCombinationService {
         return generateTimetableCombinations(userId, semester, targetCredits, maxCombinations, new ArrayList<>());
     }
 
-    public List<List<Subject>> generateTimetableCombinations(Long userId, String semester, int targetCredits, int maxCombinations, List<String> freeDays) {
+    public List<List<Subject>> generateTimetableCombinations(Long userId, String semester, Integer targetCredits,
+                                                            int maxCombinations, List<String> freeDays) {
         // 위시리스트 가져오기
         List<WishlistItem> wishlist = wishlistRepository.findByUserIdAndSemesterWithSubjectAndSchedules(userId, semester);
 
@@ -85,11 +87,23 @@ public class TimetableCombinationService {
         }
 
         List<List<Subject>> combinations = new ArrayList<>();
+        int[] optionalSuffixCredits = suffixCredits(optionalOptions);
+        int effectiveTargetCredits = targetCredits != null
+                ? targetCredits
+                : findMaximumFeasibleCredits(
+                        optionalOptions,
+                        0,
+                        requiredCredits,
+                        requiredTimeMask,
+                        freeDaySet,
+                        optionalSuffixCredits,
+                        requiredCredits,
+                        new int[]{0});
 
         // 필수 과목을 먼저 포함한 상태로 조합 생성
         generateCombinationsWithRequired(optionalOptions, new ArrayList<>(requiredSubjects), 0,
-                requiredCredits, requiredTimeMask, targetCredits, combinations, maxCombinations,
-                freeDaySet, suffixCredits(optionalOptions));
+                requiredCredits, requiredTimeMask, effectiveTargetCredits, combinations, maxCombinations,
+                freeDaySet, optionalSuffixCredits);
 
         // 필수 과목 학점 합이 목표+tolerance 를 넘어 유효 조합이 하나도 없으면,
         // 필수 과목만으로 구성된 시간표를 최소 1개 보장한다(필수는 반드시 포함되어야 하므로).
@@ -103,8 +117,8 @@ public class TimetableCombinationService {
             int creditsA = a.stream().mapToInt(Subject::getCredits).sum();
             int creditsB = b.stream().mapToInt(Subject::getCredits).sum();
 
-            int diffA = Math.abs(creditsA - targetCredits);
-            int diffB = Math.abs(creditsB - targetCredits);
+            int diffA = Math.abs(creditsA - effectiveTargetCredits);
+            int diffB = Math.abs(creditsB - effectiveTargetCredits);
 
             return Integer.compare(diffA, diffB);
         });
@@ -160,6 +174,43 @@ public class TimetableCombinationService {
                 return;
             }
         }
+    }
+
+    private int findMaximumFeasibleCredits(List<SubjectOption> optionalSubjects, int startIndex,
+                                           int currentCredits, BitSet currentTimeMask,
+                                           Set<String> freeDays, int[] suffixCredits,
+                                           int bestCredits, int[] visitedNodes) {
+        if (++visitedNodes[0] > MAX_TARGET_SEARCH_NODES) {
+            return bestCredits;
+        }
+
+        int best = Math.max(bestCredits, currentCredits);
+        if (startIndex >= optionalSubjects.size()
+                || currentCredits + suffixCredits[startIndex] <= best) {
+            return best;
+        }
+
+        // 포함 가능한 과목부터 탐색해 제한된 탐색 예산 안에서도 높은 학점 조합을 먼저 찾는다.
+        for (int i = startIndex; i < optionalSubjects.size(); i++) {
+            SubjectOption option = optionalSubjects.get(i);
+            if (option.hasFreeDayConflict(freeDays)
+                    || option.hasTimeConflict(currentTimeMask)) {
+                continue;
+            }
+
+            BitSet nextTimeMask = (BitSet) currentTimeMask.clone();
+            nextTimeMask.or(option.timeMask());
+            best = findMaximumFeasibleCredits(
+                    optionalSubjects,
+                    i + 1,
+                    currentCredits + option.credits(),
+                    nextTimeMask,
+                    freeDays,
+                    suffixCredits,
+                    best,
+                    visitedNodes);
+        }
+        return best;
     }
 
     private int[] suffixCredits(List<SubjectOption> optionalSubjects) {

--- a/src/test/java/inu/timetable/controller/UserSecurityIntegrationTest.java
+++ b/src/test/java/inu/timetable/controller/UserSecurityIntegrationTest.java
@@ -23,6 +23,7 @@ import java.security.MessageDigest;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
@@ -283,6 +284,29 @@ class UserSecurityIntegrationTest {
                                 }
                                 """.formatted(registeredUser.userId())))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    void ignoreTargetCreditsAllowsGenerationWithoutNumericTarget() throws Exception {
+        RegisteredUser registeredUser = registerAndReturnSession();
+        CsrfProof csrfProof = fetchCsrfProof(registeredUser.session());
+
+        mockMvc.perform(post("/api/timetable-combination/generate")
+                        .session(registeredUser.session())
+                        .cookie(csrfProof.cookie())
+                        .header("X-XSRF-TOKEN", csrfProof.token())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "userId": %d,
+                                  "semester": "2026-1",
+                                  "targetCredits": 12,
+                                  "ignoreTargetCredits": true
+                                }
+                                """.formatted(registeredUser.userId())))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ignoreTargetCredits").value(true))
+                .andExpect(jsonPath("$.targetCredits").value(nullValue()));
     }
 
     @Test

--- a/src/test/java/inu/timetable/service/TimetableCombinationServiceTest.java
+++ b/src/test/java/inu/timetable/service/TimetableCombinationServiceTest.java
@@ -54,6 +54,32 @@ class TimetableCombinationServiceTest {
         });
     }
 
+    @Test
+    void generatesHighestCreditCombinationsWhenTargetCreditsAreNotSpecified() {
+        TimetableCombinationService service = new TimetableCombinationService(wishlistRepository);
+        Subject mondayMorning = subject(1L, "월요일오전", "월", 1.0, 2.5);
+        Subject mondayConflict = subject(2L, "월요일충돌", "월", 1.5, 3.0);
+        Subject tuesday = subject(3L, "화요일", "화", 1.0, 2.5);
+        Subject wednesday = subject(4L, "수요일", "수", 1.0, 2.5);
+        when(wishlistRepository.findByUserIdAndSemesterWithSubjectAndSchedules(USER_ID, SEMESTER))
+                .thenReturn(List.of(
+                        wishlistItem(mondayMorning, false),
+                        wishlistItem(mondayConflict, false),
+                        wishlistItem(tuesday, false),
+                        wishlistItem(wednesday, false)));
+
+        List<List<Subject>> combinations = service.generateTimetableCombinations(
+                USER_ID, SEMESTER, null, 20, List.of());
+
+        assertThat(combinations).isNotEmpty();
+        assertThat(combinations.get(0))
+                .extracting(Subject::getSubjectName)
+                .contains("화요일", "수요일")
+                .satisfiesOnlyOnce(name -> assertThat(name).startsWith("월요일"));
+        assertThat(combinations.get(0)).hasSize(3);
+        assertThat(combinations).allSatisfy(combination -> assertThat(hasConflict(combination)).isFalse());
+    }
+
     @ParameterizedTest
     @ValueSource(ints = {6, 12, 18, 24, 30})
     void matchesReferenceCombinationsAcrossWishlistSizes(int wishlistSize) {


### PR DESCRIPTION
## 변경 내용

- 시간표 조합 요청에 `ignoreTargetCredits` 옵션을 추가했습니다.
- 목표 학점이 없는 경우 충돌과 공강 조건을 지키면서 가능한 높은 학점 조합을 우선 탐색합니다.
- 자동 목표 학점 탐색량을 제한해 공유 인스턴스의 과도한 CPU 사용을 방지합니다.
- 기존 숫자 목표 학점 요청과 유효성 검사는 그대로 유지합니다.

## 배경

수강 학점을 아직 정하지 못한 사용자는 기존처럼 정확한 목표 학점을 선택하지 않고도 위시리스트에서 가능한 시간표 조합을 확인할 수 있어야 합니다.

## 검증

- `./gradlew clean test bootJar --no-daemon`
- 목표 학점 미지정 서비스 테스트
- 인증·CSRF를 포함한 API 통합 테스트
