### PR TITLE
영문 과목 검색 대소문자 구분 제거

### DIFF
--- a/src/main/java/inu/timetable/repository/SubjectRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectRepository.java
@@ -86,9 +86,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "LEFT JOIN UserTimetable ut ON ut.subject = s " +
                         "WHERE s.active = true " +
                         "AND (:semester IS NULL OR s.semester = :semester OR s.semester IS NULL) " +
-                        "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
-                        "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
-					"AND (:courseCode IS NULL OR s.courseCode LIKE %:courseCode%) " +
+                        "AND (:subjectName IS NULL OR LOWER(s.subjectName) LIKE LOWER(CONCAT('%', :subjectName, '%'))) " +
+                        "AND (:professor IS NULL OR LOWER(s.professor) LIKE LOWER(CONCAT('%', :professor, '%'))) " +
+                        "AND (:courseCode IS NULL OR LOWER(s.courseCode) LIKE LOWER(CONCAT('%', :courseCode, '%'))) " +
                         "AND (:department IS NULL OR s.department = :department) " +
                         "AND (:departmentCount = 0 OR s.department IN :departments) " +
                         "AND (:subjectType IS NULL OR s.subjectType = :subjectType) " +
@@ -106,9 +106,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                                         +
                                         "WHERE s.active = true " +
                                         "AND (:semester IS NULL OR s.semester = :semester OR s.semester IS NULL) " +
-                                        "AND (:subjectName IS NULL OR s.subjectName LIKE %:subjectName%) " +
-                                        "AND (:professor IS NULL OR s.professor LIKE %:professor%) " +
-					"AND (:courseCode IS NULL OR s.courseCode LIKE %:courseCode%) " +
+                                        "AND (:subjectName IS NULL OR LOWER(s.subjectName) LIKE LOWER(CONCAT('%', :subjectName, '%'))) " +
+                                        "AND (:professor IS NULL OR LOWER(s.professor) LIKE LOWER(CONCAT('%', :professor, '%'))) " +
+                                        "AND (:courseCode IS NULL OR LOWER(s.courseCode) LIKE LOWER(CONCAT('%', :courseCode, '%'))) " +
                                         "AND (:department IS NULL OR s.department = :department) " +
                                         "AND (:departmentCount = 0 OR s.department IN :departments) " +
                                         "AND (:subjectType IS NULL OR s.subjectType = :subjectType) " +

--- a/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
+++ b/src/test/java/inu/timetable/repository/SubjectRepositoryIntegrationTest.java
@@ -179,6 +179,50 @@ class SubjectRepositoryIntegrationTest {
     }
 
     @Test
+    void findIdsWithFiltersMatchesSubjectNameIgnoringEnglishCase() {
+        Subject matched = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
+        matched.setSubjectName("AI Ethics");
+        persistSubject("AI01001002", "2026-1", true, "화", 1.0, 3.0)
+                .setSubjectName("Advanced AI Ethics");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> subjectIds = findIdsWithSearchFilters("ai ethics", null, null, 1);
+
+        assertThat(subjectIds.getContent()).containsExactly(matched.getId());
+        assertThat(subjectIds.getTotalElements()).isEqualTo(2);
+    }
+
+    @Test
+    void findIdsWithFiltersMatchesProfessorIgnoringEnglishCase() {
+        Subject matched = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
+        matched.setProfessor("Alice Kim");
+        persistSubject("AI01001002", "2026-1", true, "화", 1.0, 3.0)
+                .setProfessor("홍길동");
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> subjectIds = findIdsWithSearchFilters(null, "alice kim", null);
+
+        assertThat(subjectIds.getContent()).containsExactly(matched.getId());
+    }
+
+    @Test
+    void findIdsWithFiltersMatchesCourseCodeIgnoringEnglishCase() {
+        Subject matched = persistSubject("AIA6086001", "2026-1", true, "월", 4.0, 7.0);
+        persistSubject("XYZ0000001", "2026-1", true, "화", 1.0, 3.0);
+
+        entityManager.flush();
+        entityManager.clear();
+
+        Page<Long> subjectIds = findIdsWithSearchFilters(null, null, "aia6086");
+
+        assertThat(subjectIds.getContent()).containsExactly(matched.getId());
+    }
+
+    @Test
     void findIdsWithFiltersCanFilterByMultipleDepartments() {
         Subject computer = persistSubject("AI01001001", "2026-1", true, "월", 4.0, 7.0);
         computer.setDepartment("컴퓨터공학부");
@@ -318,6 +362,27 @@ class SubjectRepositoryIntegrationTest {
                 friStart, friEnd,
                 null, null,
                 PageRequest.of(0, 10));
+    }
+
+    private Page<Long> findIdsWithSearchFilters(
+            String subjectName,
+            String professor,
+            String courseCode) {
+        return findIdsWithSearchFilters(subjectName, professor, courseCode, 10);
+    }
+
+    private Page<Long> findIdsWithSearchFilters(
+            String subjectName,
+            String professor,
+            String courseCode,
+            int pageSize) {
+        return subjectRepository.findIdsWithFilters(
+                null, subjectName, professor, courseCode, null,
+                Collections.singletonList("__unused_department__"), 0, null,
+                null, null, null, null, null, null,
+                null, ClassMethod.ONLINE,
+                false, null, null, null, null, null, null, null, null, null, null, null, null,
+                PageRequest.of(0, pageSize));
     }
 
     @Test


### PR DESCRIPTION
## 변경 내용

- 과목명, 교수명, 과목코드 검색을 영문 대소문자와 관계없이 매칭하도록 변경했습니다.
- 목록 조회와 페이지 총개수 쿼리에 동일한 조건을 적용했습니다.
- 세 검색 필드와 페이지 집계를 검증하는 저장소 통합 테스트를 추가했습니다.

## 원인

PostgreSQL의 `LIKE` 비교가 영문 대소문자를 구분해 `AIA`는 조회되지만 `aia`는 조회되지 않았습니다.

## 사용자 영향

검색창에서 `AI`, `ai`, `Ai`처럼 어떤 대소문자로 입력해도 같은 과목을 찾을 수 있습니다. 교수명과 과목코드 검색도 동일합니다.

## 검증

- 수정 전 운영 API: `courseCode=AIA` 1건 / `courseCode=aia` 0건
- 회귀 테스트를 먼저 추가해 3건 실패 확인
- `SubjectRepositoryIntegrationTest` 통과
- `./gradlew clean test bootJar --no-daemon` 통과
