### PR TITLE
검색 대소문자 무시 PostgreSQL 타입 보완

### DIFF
--- a/src/main/java/inu/timetable/repository/SubjectRepository.java
+++ b/src/main/java/inu/timetable/repository/SubjectRepository.java
@@ -86,9 +86,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                         "LEFT JOIN UserTimetable ut ON ut.subject = s " +
                         "WHERE s.active = true " +
                         "AND (:semester IS NULL OR s.semester = :semester OR s.semester IS NULL) " +
-                        "AND (:subjectName IS NULL OR LOWER(s.subjectName) LIKE LOWER(CONCAT('%', :subjectName, '%'))) " +
-                        "AND (:professor IS NULL OR LOWER(s.professor) LIKE LOWER(CONCAT('%', :professor, '%'))) " +
-                        "AND (:courseCode IS NULL OR LOWER(s.courseCode) LIKE LOWER(CONCAT('%', :courseCode, '%'))) " +
+                        "AND (:subjectName IS NULL OR LOWER(s.subjectName) LIKE LOWER(CONCAT('%', CAST(:subjectName AS string), '%'))) " +
+                        "AND (:professor IS NULL OR LOWER(s.professor) LIKE LOWER(CONCAT('%', CAST(:professor AS string), '%'))) " +
+                        "AND (:courseCode IS NULL OR LOWER(s.courseCode) LIKE LOWER(CONCAT('%', CAST(:courseCode AS string), '%'))) " +
                         "AND (:department IS NULL OR s.department = :department) " +
                         "AND (:departmentCount = 0 OR s.department IN :departments) " +
                         "AND (:subjectType IS NULL OR s.subjectType = :subjectType) " +
@@ -106,9 +106,9 @@ public interface SubjectRepository extends JpaRepository<Subject, Long> {
                                         +
                                         "WHERE s.active = true " +
                                         "AND (:semester IS NULL OR s.semester = :semester OR s.semester IS NULL) " +
-                                        "AND (:subjectName IS NULL OR LOWER(s.subjectName) LIKE LOWER(CONCAT('%', :subjectName, '%'))) " +
-                                        "AND (:professor IS NULL OR LOWER(s.professor) LIKE LOWER(CONCAT('%', :professor, '%'))) " +
-                                        "AND (:courseCode IS NULL OR LOWER(s.courseCode) LIKE LOWER(CONCAT('%', :courseCode, '%'))) " +
+                                        "AND (:subjectName IS NULL OR LOWER(s.subjectName) LIKE LOWER(CONCAT('%', CAST(:subjectName AS string), '%'))) " +
+                                        "AND (:professor IS NULL OR LOWER(s.professor) LIKE LOWER(CONCAT('%', CAST(:professor AS string), '%'))) " +
+                                        "AND (:courseCode IS NULL OR LOWER(s.courseCode) LIKE LOWER(CONCAT('%', CAST(:courseCode AS string), '%'))) " +
                                         "AND (:department IS NULL OR s.department = :department) " +
                                         "AND (:departmentCount = 0 OR s.department IN :departments) " +
                                         "AND (:subjectType IS NULL OR s.subjectType = :subjectType) " +


### PR DESCRIPTION
## 변경 사항
- nullable 검색어를 HQL string으로 명시해 PostgreSQL에서 LOWER(bytea)로 해석되지 않게 했습니다.
- 과목명, 교수명, 학수번호의 대소문자 무시 검색을 유지합니다.

## 원인 및 안전장치
- 첫 후보 배포 검증에서 검색어가 없는 요청이 PostgreSQL 타입 추론 문제로 500을 반환했습니다.
- 후보 검증 실패로 운영 트래픽에는 승격되지 않았습니다.

## 검증
- `./gradlew test --tests inu.timetable.repository.SubjectRepositoryIntegrationTest --no-daemon`
- `./gradlew clean test bootJar --no-daemon`
- 생성 SQL이 검색어 파라미터를 `varchar`로 캐스팅하는 것을 확인했습니다.