### PR TITLE
main 머지 전 필수 검증 워크플로 추가

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -1,0 +1,36 @@
+name: Pull Request Validation
+
+on:
+  pull_request:
+    branches: ["main"]
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pull-request-validation-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    name: PR validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SUBJECT_CACHE_PROVIDER: caffeine
+      REDIS_HEALTH_ENABLED: "false"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: "17"
+          distribution: temurin
+          cache: gradle
+
+      - name: Validate production configuration, test, and package
+        run: ./gradlew clean test bootJar --no-daemon


### PR DESCRIPTION
## 변경 사항
- main 대상 PR마다 운영 설정 검증, 전체 테스트, bootJar 생성을 실행합니다.
- 새 커밋이 올라오면 이전 검증을 취소하고 최신 상태만 검사합니다.
- merge queue에서도 동일한 검증을 수행합니다.

## 재발 방지
- 운영 application.yml 중복 키 검증 테스트가 PR 단계에서 실행됩니다.
- 이 PR의 검증 성공 후 main 보호 규칙에 `PR validation`을 필수 검사로 등록할 예정입니다.

## 검증
- actionlint 통과
- 로컬 전체 261개 테스트 및 bootJar 생성 통과