### PR TITLE
fix: 강의계획서 반영 시 잘못된 DB 변경 감지 수정

### DIFF
--- a/src/main/java/inu/timetable/service/SubjectImportReviewService.java
+++ b/src/main/java/inu/timetable/service/SubjectImportReviewService.java
@@ -886,6 +886,7 @@ public class SubjectImportReviewService {
                         schedule.startTime(),
                         schedule.endTime(),
                         schedule.rooms().stream().sorted(roomComparator).toList()))
+                .distinct()
                 .sorted(scheduleComparator)
                 .toList();
     }

--- a/src/test/java/inu/timetable/service/SubjectImportReviewServiceTest.java
+++ b/src/test/java/inu/timetable/service/SubjectImportReviewServiceTest.java
@@ -37,6 +37,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -281,6 +282,46 @@ class SubjectImportReviewServiceTest {
         assertThatThrownBy(() -> service.apply(preview.planId(), List.of("AI001")))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("다시 검토");
+    }
+
+    @Test
+    void applyIgnoresDuplicateScheduleRowsLoadedDuringImpactCalculation() throws Exception {
+        Subject original = subject(1L, "AI001", "기존과목", true, "월", 1.0, 3.0, "27-101");
+        OfficialSubjectImportService.OfficialSubjectRecord record = record(
+                "AI001", "변경과목", false, "월", 1.0, 3.0, "27-101");
+        MockMultipartFile file = new MockMultipartFile(
+                "file", "inu.json", "application/json", "{}".getBytes());
+        ArgumentCaptor<SubjectImportPlan> planCaptor = ArgumentCaptor.forClass(SubjectImportPlan.class);
+
+        when(officialSubjectImportService.parseOfficialFile(file, "2026-2"))
+                .thenReturn(new OfficialSubjectImportService.ParsedWorkbook(List.of(record), "SYLLABUS_JSON"));
+        when(subjectRepository.findImportCandidatesBySemester("2026-2"))
+                .thenReturn(List.of(original));
+        when(planRepository.save(planCaptor.capture()))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        doAnswer(invocation -> {
+            Subject subject = invocation.getArgument(0);
+            OfficialSubjectImportService.OfficialSubjectRecord applied = invocation.getArgument(1);
+            subject.setSubjectName(applied.subjectName());
+            return null;
+        }).when(officialSubjectImportService).applyRecord(any(), any());
+
+        SubjectImportPlanResponse preview = service.preview(file, "2026-2", false);
+        when(planRepository.findByIdForUpdate(preview.planId()))
+                .thenReturn(java.util.Optional.of(planCaptor.getValue()));
+        when(planRepository.findById(preview.planId()))
+                .thenReturn(java.util.Optional.of(planCaptor.getValue()));
+        when(subjectRepository.findFirstByCourseCodeAndSemesterOrderByIdAsc("AI001", "2026-2"))
+                .thenReturn(java.util.Optional.of(original));
+
+        // A fetch join over multiple user timetable rows can hydrate the same schedule
+        // more than once in the managed List even though the DB contains one schedule row.
+        original.getSchedules().add(original.getSchedules().get(0));
+
+        var response = service.apply(preview.planId(), List.of("AI001"));
+
+        assertThat(response.verified()).isTrue();
+        assertThat(planCaptor.getValue().getStatus()).isEqualTo("APPLIED");
     }
 
     @Test


### PR DESCRIPTION
## 변경 사항

- 시간표 스냅샷 정규화 과정에서 의미상 동일한 일정 중복을 제거합니다.
- 사용자 시간표 영향도 계산 중 fetch join으로 동일 일정이 중복 로딩되어도 DB 변경으로 오인하지 않습니다.
- 중복 일정이 존재하는 상태에서 선택 반영이 성공하는 회귀 테스트를 추가했습니다.

## 원인

사용자 시간표와 과목 일정을 함께 조회할 때 동일 Schedule이 List에 여러 번 적재될 수 있었습니다. 이후 미리보기 스냅샷과 현재 DB 상태를 비교하면서 이 중복을 실제 변경으로 판단해 409 다시 검토 응답을 반환했습니다.

## 사용자 영향

실제로 DB가 바뀌지 않았는데도 선택 후 DB 반영이 계속 차단되던 문제가 해결됩니다. 실제 필드 변경에 대한 충돌 검증은 그대로 유지됩니다.

## 검증

- ./gradlew test
- 268 tests, 0 failures, 0 errors