### PR TITLE
fix: 과목 업데이트 기록 시간을 UTC로 정규화

### DIFF
--- a/src/main/java/inu/timetable/dto/SubjectUpdateLogResponse.java
+++ b/src/main/java/inu/timetable/dto/SubjectUpdateLogResponse.java
@@ -2,10 +2,10 @@ package inu.timetable.dto;
 
 import inu.timetable.entity.SubjectUpdateLog;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 public record SubjectUpdateLogResponse(
-        LocalDateTime appliedAt,
+        Instant appliedAt,
         String semester,
         String sourceFormat,
         int addedCount,

--- a/src/main/java/inu/timetable/entity/SubjectUpdateLog.java
+++ b/src/main/java/inu/timetable/entity/SubjectUpdateLog.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 /**
  * 공식 엑셀 반영 이력(공개 일지). apply 성공 시마다 1행 기록한다.
@@ -29,7 +29,7 @@ public class SubjectUpdateLog {
     private Long id;
 
     @Column(name = "applied_at", nullable = false)
-    private LocalDateTime appliedAt;
+    private Instant appliedAt;
 
     @Column(nullable = false, length = 20)
     private String semester;

--- a/src/main/java/inu/timetable/service/SubjectUpdateLogService.java
+++ b/src/main/java/inu/timetable/service/SubjectUpdateLogService.java
@@ -3,7 +3,6 @@ package inu.timetable.service;
 import inu.timetable.dto.SubjectUpdateLogResponse;
 import inu.timetable.entity.SubjectUpdateLog;
 import inu.timetable.repository.SubjectUpdateLogRepository;
-import inu.timetable.util.BusinessTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -25,7 +24,7 @@ public class SubjectUpdateLogService {
     public SubjectUpdateLog record(
             String semester, String sourceFormat, int addedCount, int modifiedCount, int removedCount) {
         return subjectUpdateLogRepository.save(SubjectUpdateLog.builder()
-                .appliedAt(BusinessTime.nowInKorea(clock))
+                .appliedAt(clock.instant())
                 .semester(semester)
                 .sourceFormat(sourceFormat)
                 .addedCount(addedCount)

--- a/src/main/resources/db/migration/V20260805_01__normalize_subject_update_log_timestamps.sql
+++ b/src/main/resources/db/migration/V20260805_01__normalize_subject_update_log_timestamps.sql
@@ -1,0 +1,18 @@
+-- subject_update_logs.applied_at was originally written as UTC to a timezone-less
+-- TIMESTAMP column. From the 2026-07-31 Korea-time rollout onward it was written
+-- as Asia/Seoul local time to the same column, so the historical values have two
+-- different meanings.
+--
+-- The Korea-time writer was merged at 2026-07-31 00:54:37 Asia/Seoul. Values
+-- below that local wall-clock boundary are the old UTC representation; values at
+-- or above it are the new Asia/Seoul representation. Normalize both groups to a
+-- real instant while converting the column to TIMESTAMP WITH TIME ZONE.
+ALTER TABLE subject_update_logs
+    ALTER COLUMN applied_at TYPE TIMESTAMP WITH TIME ZONE
+    USING (
+        CASE
+            WHEN applied_at >= TIMESTAMP '2026-07-31 00:54:37'
+                THEN applied_at AT TIME ZONE 'Asia/Seoul'
+            ELSE applied_at AT TIME ZONE 'UTC'
+        END
+    );

--- a/src/test/java/inu/timetable/controller/SubjectUpdateLogControllerTest.java
+++ b/src/test/java/inu/timetable/controller/SubjectUpdateLogControllerTest.java
@@ -11,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,13 +33,14 @@ class SubjectUpdateLogControllerTest {
     @Test
     @DisplayName("업데이트 일지는 인증 없이 최신순으로 조회된다")
     void getUpdateLogsIsPublicAndOrderedByAppliedAtDesc() throws Exception {
-        saveLog(LocalDateTime.of(2026, 7, 24, 10, 0), "2026-1", 5, 2, 1);
-        saveLog(LocalDateTime.of(2026, 7, 26, 10, 0), "2026-2", 10, 3, 0);
-        saveLog(LocalDateTime.of(2026, 7, 25, 10, 0), "2026-1", 7, 0, 2);
+        saveLog(Instant.parse("2026-07-24T01:00:00Z"), "2026-1", 5, 2, 1);
+        saveLog(Instant.parse("2026-07-26T01:00:00Z"), "2026-2", 10, 3, 0);
+        saveLog(Instant.parse("2026-07-25T01:00:00Z"), "2026-1", 7, 0, 2);
 
         mockMvc.perform(get("/api/subjects/update-logs"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$", hasSize(3)))
+                .andExpect(jsonPath("$[0].appliedAt").value("2026-07-26T01:00:00Z"))
                 .andExpect(jsonPath("$[0].semester").value("2026-2"))
                 .andExpect(jsonPath("$[0].sourceFormat").value("OFFICIAL_TIMETABLE"))
                 .andExpect(jsonPath("$[0].addedCount").value(10))
@@ -53,7 +54,7 @@ class SubjectUpdateLogControllerTest {
     @DisplayName("limit 파라미터를 적용하고 최대 50으로 클램프한다")
     void getUpdateLogsClampsLimit() throws Exception {
         for (int index = 0; index < 55; index++) {
-            saveLog(LocalDateTime.of(2026, 7, 1, 0, 0).plusMinutes(index), "2026-1", index, 0, 0);
+            saveLog(Instant.parse("2026-07-01T00:00:00Z").plusSeconds(index * 60L), "2026-1", index, 0, 0);
         }
 
         mockMvc.perform(get("/api/subjects/update-logs").param("limit", "2"))
@@ -66,7 +67,7 @@ class SubjectUpdateLogControllerTest {
     }
 
     private void saveLog(
-            LocalDateTime appliedAt, String semester, int addedCount, int modifiedCount, int removedCount) {
+            Instant appliedAt, String semester, int addedCount, int modifiedCount, int removedCount) {
         subjectUpdateLogRepository.save(SubjectUpdateLog.builder()
                 .appliedAt(appliedAt)
                 .semester(semester)

--- a/src/test/java/inu/timetable/service/SubjectUpdateLogServiceTest.java
+++ b/src/test/java/inu/timetable/service/SubjectUpdateLogServiceTest.java
@@ -9,7 +9,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.Clock;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -23,7 +22,7 @@ class SubjectUpdateLogServiceTest {
     private SubjectUpdateLogRepository subjectUpdateLogRepository;
 
     @Test
-    void recordsAppliedAtInKoreanTimeRegardlessOfServerTimezone() {
+    void recordsAppliedAtAsUtcInstantRegardlessOfServerTimezone() {
         Clock utcClock = Clock.fixed(
                 Instant.parse("2026-07-30T12:00:00Z"),
                 ZoneOffset.UTC);
@@ -36,6 +35,6 @@ class SubjectUpdateLogServiceTest {
                 service.record("2026-2", "SYLLABUS_JSON_REVIEW", 1, 2, 3);
 
         assertThat(saved.getAppliedAt())
-                .isEqualTo(LocalDateTime.parse("2026-07-30T21:00:00"));
+                .isEqualTo(Instant.parse("2026-07-30T12:00:00Z"));
     }
 }


### PR DESCRIPTION
## 변경 내용
- 과목 업데이트 기록 시각을 `LocalDateTime` 대신 UTC `Instant`로 저장합니다.
- API가 `appliedAt`을 `Z`가 포함된 ISO-8601 인스턴트로 반환하도록 계약을 명확히 했습니다.
- `subject_update_logs.applied_at`을 `TIMESTAMP WITH TIME ZONE`으로 변환하고, 기존 UTC/KST 혼재 데이터를 UTC 인스턴트로 정규화합니다.

## 원인
프론트는 시간대 없는 값을 UTC로 해석해 한국시간으로 변환했지만, 백엔드는 2026-07-31 이후 이미 한국시간을 시간대 없는 컬럼에 저장했습니다. 그 결과 최근 기록이 화면에서 9시간 미래로 표시됐습니다.

## DB 마이그레이션
- 기존 UTC 저장 구간은 UTC로 해석합니다.
- 한국시간 저장 전환 이후 구간은 `Asia/Seoul`로 해석합니다.
- 컬럼을 `TIMESTAMP WITH TIME ZONE`으로 변경해 이후에는 인스턴트 의미가 보존됩니다.

## 검증
- `./gradlew clean test bootJar`: 268개 통과, 실패 0, 기존 skip 2
- 운영 데이터 10행을 복사한 임시 테이블에서 마이그레이션 리허설 완료 후 롤백
- 프론트 `test:unit`, `lint`, `build` 통과
- API 응답의 `appliedAt`에 `Z`가 포함되는 통합 테스트 추가